### PR TITLE
Support Java 21 by updating ASM dependency to 9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,31 +349,31 @@
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.2</version>
+                <version>9.6</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.2</version>
+                <version>9.6</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.2</version>
+                <version>9.6</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-analysis</artifactId>
-                <version>9.2</version>
+                <version>9.6</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
-                <version>9.2</version>
+                <version>9.6</version>
             </dependency>
             <dependency>
                 <!-- Apache 2 -->


### PR DESCRIPTION
Updated ASM dependencies to version 9.6 to enable support for Java 21 bytecode.
Verified that:
1. The project builds successfully with Java 21.
2. ASM can successfully read Java 21 class files.
3. Existing tests pass on Java 21.

---
*PR created automatically by Jules for task [5096746747687818572](https://jules.google.com/task/5096746747687818572) started by @gofraser*