### PR TITLE
Fix unit tests failures on Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
                         <exclude>${exclude.tests.concolic}</exclude>
                         <exclude>${exclude.tests.mimeType}</exclude>
                     </excludes>
-                    <argLine>-Djdk.attach.allowAttachSelf=true -Xms512m -Xmx4096m </argLine>
+                    <argLine>-Djdk.attach.allowAttachSelf=true -Xms512m -Xmx4096m --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED -Djava.security.manager=allow</argLine>
                 </configuration>
             </plugin>
             <!-- pluging to run tests after 'package' phase in 'integration-test' -->


### PR DESCRIPTION
This PR fixes unit test failures observed when running on Java 21.
The failures were primarily due to:
1. `com.thoughtworks.xstream.converters.ConversionException: No converter available` caused by module encapsulation preventing reflective access to `java.util` and `java.lang` internals.
2. `java.lang.reflect.InaccessibleObjectException: Unable to make java.net.NetworkInterface() accessible` caused by module encapsulation.
3. `UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release` when trying to set a Security Manager.

The fix involves updating the `maven-surefire-plugin` configuration in the root `pom.xml` to include the necessary `--add-opens` flags and `-Djava.security.manager=allow`.
All tests in the `client` module passed with these changes.

---
*PR created automatically by Jules for task [17573156070258556664](https://jules.google.com/task/17573156070258556664) started by @gofraser*