### PR TITLE
Refactor TestCaseSecondaryObjective for correctness and better error handling

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/secondaryobjectives/MinimizeLengthSecondaryObjective.java
+++ b/client/src/main/java/org/evosuite/testcase/secondaryobjectives/MinimizeLengthSecondaryObjective.java
@@ -63,7 +63,7 @@ public class MinimizeLengthSecondaryObjective extends SecondaryObjective<TestChr
     @Override
     public int compareGenerations(TestChromosome parent1, TestChromosome parent2,
                                   TestChromosome child1, TestChromosome child2) {
-        logger.debug("Comparing sizes: " + parent1.size() + ", " + parent1.size()
+        logger.debug("Comparing sizes: " + parent1.size() + ", " + parent2.size()
                 + " vs " + child1.size() + ", " + child2.size());
         return Math.min(parent1.size(), parent2.size())
                 - Math.min(child1.size(), child2.size());

--- a/client/src/main/java/org/evosuite/testcase/secondaryobjectives/TestCaseSecondaryObjective.java
+++ b/client/src/main/java/org/evosuite/testcase/secondaryobjectives/TestCaseSecondaryObjective.java
@@ -22,29 +22,37 @@ package org.evosuite.testcase.secondaryobjectives;
 import org.evosuite.Properties;
 import org.evosuite.ga.SecondaryObjective;
 import org.evosuite.testcase.TestChromosome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestCaseSecondaryObjective {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestCaseSecondaryObjective.class);
+
     public static void setSecondaryObjectives() {
         for (Properties.SecondaryObjective secondaryObjective : Properties.SECONDARY_OBJECTIVE) {
-            try {
-                SecondaryObjective<TestChromosome> secondaryObjectiveInstance = null;
-                switch (secondaryObjective) {
-                    case AVG_LENGTH:
-                    case MAX_LENGTH:
-                    case TOTAL_LENGTH:
-                        secondaryObjectiveInstance = new MinimizeLengthSecondaryObjective();
-                        break;
-                    case EXCEPTIONS:
-                        secondaryObjectiveInstance = new MinimizeExceptionsSecondaryObjective();
-                        break;
-                    default:
-                        throw new RuntimeException("ERROR: asked for unknown secondary objective \""
-                                + secondaryObjective.name() + "\"");
-                }
+            SecondaryObjective<TestChromosome> secondaryObjectiveInstance = null;
+            switch (secondaryObjective) {
+                case AVG_LENGTH:
+                case MAX_LENGTH:
+                case TOTAL_LENGTH:
+                    secondaryObjectiveInstance = new MinimizeLengthSecondaryObjective();
+                    break;
+                case EXCEPTIONS:
+                    secondaryObjectiveInstance = new MinimizeExceptionsSecondaryObjective();
+                    break;
+                case SIZE:
+                case IBRANCH:
+                case RHO:
+                    // These objectives are not applicable to single test cases
+                    break;
+                default:
+                    logger.warn("ERROR: asked for unknown secondary objective \"{}\"", secondaryObjective.name());
+            }
+
+            if (secondaryObjectiveInstance != null) {
                 TestChromosome.addSecondaryObjective(secondaryObjectiveInstance);
-            } catch (Throwable t) {
-            } // Not all objectives make sense for tests
+            }
         }
     }
 }

--- a/client/src/test/java/org/evosuite/testcase/secondaryobjectives/TestCaseSecondaryObjectiveTest.java
+++ b/client/src/test/java/org/evosuite/testcase/secondaryobjectives/TestCaseSecondaryObjectiveTest.java
@@ -1,0 +1,60 @@
+package org.evosuite.testcase.secondaryobjectives;
+
+import org.evosuite.Properties;
+import org.evosuite.testcase.TestChromosome;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestCaseSecondaryObjectiveTest {
+
+    private Properties.SecondaryObjective[] originalObjectives;
+
+    @Before
+    public void setUp() {
+        originalObjectives = Properties.SECONDARY_OBJECTIVE;
+        TestChromosome.getSecondaryObjectives().clear();
+    }
+
+    @After
+    public void tearDown() {
+        Properties.SECONDARY_OBJECTIVE = originalObjectives;
+        TestChromosome.getSecondaryObjectives().clear();
+    }
+
+    @Test
+    public void testSetSecondaryObjectives_TotalLength() {
+        Properties.SECONDARY_OBJECTIVE = new Properties.SecondaryObjective[]{Properties.SecondaryObjective.TOTAL_LENGTH};
+        TestCaseSecondaryObjective.setSecondaryObjectives();
+        assertEquals(1, TestChromosome.getSecondaryObjectives().size());
+        assertTrue(TestChromosome.getSecondaryObjectives().get(0) instanceof MinimizeLengthSecondaryObjective);
+    }
+
+    @Test
+    public void testSetSecondaryObjectives_Exceptions() {
+        Properties.SECONDARY_OBJECTIVE = new Properties.SecondaryObjective[]{Properties.SecondaryObjective.EXCEPTIONS};
+        TestCaseSecondaryObjective.setSecondaryObjectives();
+        assertEquals(1, TestChromosome.getSecondaryObjectives().size());
+        assertTrue(TestChromosome.getSecondaryObjectives().get(0) instanceof MinimizeExceptionsSecondaryObjective);
+    }
+
+    @Test
+    public void testSetSecondaryObjectives_IBranch() {
+        Properties.SECONDARY_OBJECTIVE = new Properties.SecondaryObjective[]{Properties.SecondaryObjective.IBRANCH};
+        // This currently throws silently (caught), so nothing added.
+        // After refactoring, it should just ignore it (also nothing added).
+        TestCaseSecondaryObjective.setSecondaryObjectives();
+        assertEquals(0, TestChromosome.getSecondaryObjectives().size());
+    }
+
+    @Test
+    public void testSetSecondaryObjectives_Multiple() {
+        Properties.SECONDARY_OBJECTIVE = new Properties.SecondaryObjective[]{
+            Properties.SecondaryObjective.TOTAL_LENGTH,
+            Properties.SecondaryObjective.EXCEPTIONS
+        };
+        TestCaseSecondaryObjective.setSecondaryObjectives();
+        assertEquals(2, TestChromosome.getSecondaryObjectives().size());
+    }
+}


### PR DESCRIPTION
Refactored the `org.evosuite.testcase.secondaryobjectives` package to address code quality and correctness issues.

1.  **TestCaseSecondaryObjective.java**:
    -   Removed the `try-catch(Throwable t)` block that silently swallowed all exceptions, including potentially valid errors.
    -   Replaced exception-based flow control with explicit handling of inapplicable objectives (`SIZE`, `IBRANCH`, `RHO`) for `TestChromosome`.
    -   Added `SLF4J` logging to warn about unknown secondary objectives instead of throwing a `RuntimeException` that was previously ignored.

2.  **MinimizeLengthSecondaryObjective.java**:
    -   Fixed a copy-paste error in the debug log message of `compareGenerations` method where `parent1.size()` was printed twice instead of `parent1.size()` and `parent2.size()`.

3.  **Testing**:
    -   Added `TestCaseSecondaryObjectiveTest.java` to unit test `TestCaseSecondaryObjective.setSecondaryObjectives()`, ensuring correct objectives are added and inapplicable ones are ignored without errors.


---
*PR created automatically by Jules for task [6956387294980306936](https://jules.google.com/task/6956387294980306936) started by @gofraser*