### PR TITLE
Refactor org.evosuite.seeding package

### DIFF
--- a/client/src/main/java/org/evosuite/seeding/PrimitivePoolMethodAdapter.java
+++ b/client/src/main/java/org/evosuite/seeding/PrimitivePoolMethodAdapter.java
@@ -33,8 +33,6 @@ import org.objectweb.asm.Opcodes;
  */
 public class PrimitivePoolMethodAdapter extends MethodVisitor {
 
-    // private final PrimitivePool constantPool = PrimitivePool.getInstance();
-
     private final ConstantPoolManager poolManager = ConstantPoolManager.getInstance();
 
     private final String className;
@@ -51,31 +49,12 @@ public class PrimitivePoolMethodAdapter extends MethodVisitor {
         this.className = className;
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This is a hack to avoid deadlocks because we are only testing single
-     * threaded stuff. This will be replaced with something nicer once Sebastian
-     * has found a solution
-     */
-	/*
-	@Override
-	public void visitInsn(int opcode) {
-		if (opcode != Opcodes.MONITORENTER && opcode != Opcodes.MONITOREXIT)
-			super.visitInsn(opcode);
-		else
-			super.visitInsn(Opcodes.POP);
-
-	}
-	*/
-
     /* (non-Javadoc)
      * @see org.objectweb.asm.MethodAdapter#visitLookupSwitchInsn(org.objectweb.asm.Label, int[], org.objectweb.asm.Label[])
      */
     @Override
     public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
         for (int key : keys) {
-            // constantPool.add(key);
             if (DependencyAnalysis.isTargetClassName(className)) {
                 poolManager.addSUTConstant(key);
             } else {
@@ -91,7 +70,6 @@ public class PrimitivePoolMethodAdapter extends MethodVisitor {
     @Override
     public void visitIntInsn(int opcode, int operand) {
         if (opcode == Opcodes.BIPUSH || opcode == Opcodes.SIPUSH) {
-            // constantPool.add(operand);
             if (DependencyAnalysis.isTargetClassName(className)) {
                 poolManager.addSUTConstant(operand);
             } else {
@@ -106,7 +84,6 @@ public class PrimitivePoolMethodAdapter extends MethodVisitor {
      */
     @Override
     public void visitLdcInsn(Object cst) {
-        // constantPool.add(cst);
         if (DependencyAnalysis.isTargetClassName(className)) {
             poolManager.addSUTConstant(cst);
         } else {

--- a/client/src/main/java/org/evosuite/seeding/StaticConstantPool.java
+++ b/client/src/main/java/org/evosuite/seeding/StaticConstantPool.java
@@ -21,9 +21,10 @@
 package org.evosuite.seeding;
 
 import org.evosuite.Properties;
-import org.evosuite.utils.LoggingUtils;
 import org.evosuite.utils.Randomness;
 import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -33,6 +34,10 @@ import java.util.Set;
  * @author Gordon Fraser
  */
 public class StaticConstantPool implements ConstantPool {
+
+    private static final Logger logger = LoggerFactory.getLogger(StaticConstantPool.class);
+
+    private static final int MAX_STRING_LITERAL_LENGTH = 65535;
 
     private final Set<String> stringPool = Collections.synchronizedSet(new LinkedHashSet<>());
 
@@ -102,8 +107,7 @@ public class StaticConstantPool implements ConstantPool {
      */
     @Override
     public int getRandomInt() {
-        int r = Randomness.choice(intPool);
-        return r;
+        return Randomness.choice(intPool);
     }
 
     /**
@@ -161,7 +165,7 @@ public class StaticConstantPool implements ConstantPool {
                 return;
             // String literals are constrained to 65535 bytes
             // as they are stored in the constant pool
-            if (string.length() > 65535)
+            if (string.length() > MAX_STRING_LITERAL_LENGTH)
                 return;
             stringPool.add(string);
         } else if (object instanceof Type) {
@@ -206,8 +210,7 @@ public class StaticConstantPool implements ConstantPool {
                 doublePool.add((Double) object);
             }
         } else {
-            LoggingUtils.getEvoLogger().info("Constant of unknown type: "
-                    + object.getClass());
+            logger.info("Constant of unknown type: {}", object.getClass());
         }
     }
 

--- a/client/src/main/java/org/evosuite/seeding/TestCaseRecycler.java
+++ b/client/src/main/java/org/evosuite/seeding/TestCaseRecycler.java
@@ -51,7 +51,9 @@ public final class TestCaseRecycler<T extends Chromosome<T>> implements SearchLi
 
     private static final long serialVersionUID = -2372656982678139994L;
 
-    private static TestCaseRecycler<?> instance;
+    private static class SingletonHolder {
+        private static final TestCaseRecycler<?> INSTANCE = new TestCaseRecycler<>();
+    }
 
     private final Set<TestCase> testPool;
 
@@ -64,9 +66,7 @@ public final class TestCaseRecycler<T extends Chromosome<T>> implements SearchLi
      */
     @SuppressWarnings("unchecked")
     public static <T extends Chromosome<T>> TestCaseRecycler<T> getInstance() {
-        if (instance == null)
-            instance = new TestCaseRecycler<>();
-        return (TestCaseRecycler<T>) instance;
+        return (TestCaseRecycler<T>) SingletonHolder.INSTANCE;
     }
 
     private TestCaseRecycler() {
@@ -76,14 +76,12 @@ public final class TestCaseRecycler<T extends Chromosome<T>> implements SearchLi
 
     @Override
     public void searchStarted(GeneticAlgorithm<T> algorithm) {
-        // TODO Auto-generated method stub
-
+        // Empty implementation
     }
 
     @Override
     public void iteration(GeneticAlgorithm<T> algorithm) {
-        // TODO Auto-generated method stub
-
+        // Empty implementation
     }
 
     @Override
@@ -100,13 +98,11 @@ public final class TestCaseRecycler<T extends Chromosome<T>> implements SearchLi
 
     @Override
     public void fitnessEvaluation(T individual) {
-        // TODO Auto-generated method stub
-
+        // Empty implementation
     }
 
     @Override
     public void modification(T individual) {
-        // TODO Auto-generated method stub
-
+        // Empty implementation
     }
 }

--- a/client/src/test/java/org/evosuite/seeding/ConstantPoolManagerTest.java
+++ b/client/src/test/java/org/evosuite/seeding/ConstantPoolManagerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.seeding;
+
+import org.evosuite.Properties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConstantPoolManagerTest {
+
+    @Test
+    public void testSingleton() {
+        ConstantPoolManager instance1 = ConstantPoolManager.getInstance();
+        ConstantPoolManager instance2 = ConstantPoolManager.getInstance();
+        assertNotNull(instance1);
+        assertTrue(instance1 == instance2);
+    }
+
+    @Test
+    public void testGetConstantPool() {
+        ConstantPoolManager manager = ConstantPoolManager.getInstance();
+        manager.reset();
+        ConstantPool pool = manager.getConstantPool();
+        assertNotNull(pool);
+    }
+
+    @Test
+    public void testAddConstants() {
+        ConstantPoolManager manager = ConstantPoolManager.getInstance();
+        manager.reset();
+
+        manager.addSUTConstant(10);
+        manager.addNonSUTConstant(20);
+        manager.addDynamicConstant(30);
+
+        // We can't easily verify they were added without inspecting the pools,
+        // but we can ensure no exceptions are thrown.
+        // Also the selection logic relies on randomness, so it is hard to deterministically test which pool we got.
+    }
+}

--- a/client/src/test/java/org/evosuite/seeding/ObjectPoolTest.java
+++ b/client/src/test/java/org/evosuite/seeding/ObjectPoolTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.seeding;
+
+import org.evosuite.testcase.DefaultTestCase;
+import org.evosuite.testcase.TestCase;
+import org.evosuite.utils.generic.GenericClass;
+import org.evosuite.utils.generic.GenericClassFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ObjectPoolTest {
+
+    @Test
+    public void testAddAndGetSequence() {
+        ObjectPool pool = new ObjectPool();
+        GenericClass<?> clazz = GenericClassFactory.get(String.class);
+        TestCase testCase = new DefaultTestCase(); // minimal test case
+
+        pool.addSequence(clazz, testCase);
+
+        assertTrue(pool.hasSequence(clazz));
+        assertEquals(1, pool.getNumberOfClasses());
+        assertEquals(1, pool.getNumberOfSequences());
+
+        TestCase retrieved = pool.getRandomSequence(clazz);
+        assertNotNull(retrieved);
+        // Equality might not be implemented for TestCase, so we check if it is the same object or we rely on logic
+        // getRandomSequence returns one of the added sequences.
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        ObjectPool pool = new ObjectPool();
+        GenericClass<?> clazz = GenericClassFactory.get(String.class);
+        TestCase testCase = new DefaultTestCase();
+        pool.addSequence(clazz, testCase);
+
+        File tempFile = File.createTempFile("objectpool", ".ser");
+        tempFile.deleteOnExit();
+        String path = tempFile.getAbsolutePath();
+
+        pool.writePool(path);
+
+        ObjectPool loadedPool = ObjectPool.getPoolFromFile(path);
+        assertNotNull(loadedPool);
+        assertTrue(loadedPool.hasSequence(clazz));
+        assertEquals(1, loadedPool.getNumberOfSequences());
+    }
+}


### PR DESCRIPTION
Refactored classes in `org.evosuite.seeding` to improve thread safety, resource management, and code readability. 
- `ConstantPoolManager` and `TestCaseRecycler` now use the initialization-on-demand holder idiom. 
- `ObjectPoolManager` uses synchronized lazy initialization to support its `reset()` method.
- `ObjectPool` now uses standard `ObjectOutputStream` to avoid access control issues on newer Java versions and employs try-with-resources.
- Added named constants and improved logging throughout the package.
- Added `ObjectPoolTest` and `ConstantPoolManagerTest` to verify functionality.

---
*PR created automatically by Jules for task [5752696585114540131](https://jules.google.com/task/5752696585114540131) started by @gofraser*