### PR TITLE
Refactor TestSuite factories for correctness and code quality

### DIFF
--- a/client/src/main/java/org/evosuite/testsuite/factories/FixedSizeTestSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/FixedSizeTestSuiteChromosomeFactory.java
@@ -49,7 +49,17 @@ public class FixedSizeTestSuiteChromosomeFactory implements
      * @param size a int.
      */
     public FixedSizeTestSuiteChromosomeFactory(int size) {
-        testChromosomeFactory = new RandomLengthTestFactory();
+        this(new RandomLengthTestFactory(), size);
+    }
+
+    /**
+     * <p>Constructor for FixedSizeTestSuiteChromosomeFactory.</p>
+     *
+     * @param factory a {@link org.evosuite.ga.ChromosomeFactory} object.
+     * @param size a int.
+     */
+    public FixedSizeTestSuiteChromosomeFactory(ChromosomeFactory<TestChromosome> factory, int size) {
+        this.testChromosomeFactory = factory;
         this.size = size;
     }
 
@@ -62,8 +72,7 @@ public class FixedSizeTestSuiteChromosomeFactory implements
      */
     @Override
     public TestSuiteChromosome getChromosome() {
-        TestSuiteChromosome chromosome = new TestSuiteChromosome(
-                new RandomLengthTestFactory());
+        TestSuiteChromosome chromosome = new TestSuiteChromosome(testChromosomeFactory);
         chromosome.clearTests();
 
         for (int i = 0; i < size; i++) {

--- a/client/src/main/java/org/evosuite/testsuite/factories/JUnitTestSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/JUnitTestSuiteChromosomeFactory.java
@@ -23,7 +23,6 @@ package org.evosuite.testsuite.factories;
 import org.evosuite.Properties;
 import org.evosuite.ga.ChromosomeFactory;
 import org.evosuite.testcase.TestChromosome;
-import org.evosuite.testcase.factories.RandomLengthTestFactory;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.evosuite.utils.Randomness;
 
@@ -59,23 +58,21 @@ public class JUnitTestSuiteChromosomeFactory implements
      */
     @Override
     public TestSuiteChromosome getChromosome() {
-		/*
-		double P_delta = 0.1d;
-		double P_clone = 0.1d;
-		int MAX_CHANGES = 10;
-		*/
-
-        TestSuiteChromosome chromosome = new TestSuiteChromosome(
-                new RandomLengthTestFactory());
+        TestSuiteChromosome chromosome = new TestSuiteChromosome(defaultFactory);
         chromosome.clearTests();
 
-        int numTests = Randomness.nextInt(Properties.MIN_INITIAL_TESTS,
-                Properties.MAX_INITIAL_TESTS + 1);
+        int min = Properties.MIN_INITIAL_TESTS;
+        int max = Properties.MAX_INITIAL_TESTS;
+
+        if (max < min) {
+            max = min;
+        }
+
+        int numTests = Randomness.nextInt(min, max + 1);
 
         for (int i = 0; i < numTests; i++) {
             TestChromosome test = defaultFactory.getChromosome();
             chromosome.addTest(test);
-            //chromosome.tests.add(test);
         }
 
         return chromosome;

--- a/client/src/main/java/org/evosuite/testsuite/factories/SerializationSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/SerializationSuiteChromosomeFactory.java
@@ -68,7 +68,7 @@ public class SerializationSuiteChromosomeFactory
         TestSuiteChromosome tsc = new TestSuiteChromosome(this.defaultFactory);
         tsc.clearTests();
 
-        if (Randomness.nextDouble() <= Properties.SEED_CLONE && this.previousSuite.size() > 0) {
+        if (Randomness.nextDouble() <= Properties.SEED_CLONE && !this.previousSuite.isEmpty()) {
             logger.debug("seeding previous test suite");
 
             for (TestChromosome tc : this.previousSuite) {
@@ -79,14 +79,20 @@ public class SerializationSuiteChromosomeFactory
         } else {
             logger.debug("creating a random testsuite");
 
-            int numTests = Randomness.nextInt(Properties.MIN_INITIAL_TESTS, Properties.MAX_INITIAL_TESTS + 1);
+            int min = Properties.MIN_INITIAL_TESTS;
+            int max = Properties.MAX_INITIAL_TESTS;
+
+            if (max < min) {
+                max = min;
+            }
+
+            int numTests = Randomness.nextInt(min, max + 1);
             for (int i = 0; i < numTests; i++) {
                 TestChromosome tc = this.defaultFactory.getChromosome();
                 tsc.addTest(tc);
             }
         }
 
-        assert (!tsc.getTestChromosomes().isEmpty());
         return tsc;
     }
 }

--- a/client/src/main/java/org/evosuite/testsuite/factories/TestSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/TestSuiteChromosomeFactory.java
@@ -59,10 +59,6 @@ public class TestSuiteChromosomeFactory implements ChromosomeFactory<TestSuiteCh
      */
     public TestSuiteChromosomeFactory(ChromosomeFactory<TestChromosome> testFactory) {
         testChromosomeFactory = testFactory;
-
-        // test_factory = new RandomLengthTestFactory();
-        // test_factory = new AllMethodsChromosomeFactory();
-        // test_factory = new OUMTestChromosomeFactory();
     }
 
     /**
@@ -83,18 +79,20 @@ public class TestSuiteChromosomeFactory implements ChromosomeFactory<TestSuiteCh
         TestSuiteChromosome chromosome = new TestSuiteChromosome(
                 testChromosomeFactory);
         chromosome.clearTests();
-        // ((AllMethodsChromosomeFactory)test_factory).clear();
 
-        int numTests = Randomness.nextInt(Properties.MIN_INITIAL_TESTS,
-                Properties.MAX_INITIAL_TESTS + 1);
+        int min = Properties.MIN_INITIAL_TESTS;
+        int max = Properties.MAX_INITIAL_TESTS;
+
+        if (max < min) {
+            max = min;
+        }
+
+        int numTests = Randomness.nextInt(min, max + 1);
 
         for (int i = 0; i < numTests; i++) {
             TestChromosome test = testChromosomeFactory.getChromosome();
             chromosome.addTest(test);
-            //chromosome.tests.add(test);
         }
-        // logger.info("Covered methods: "+((AllMethodsChromosomeFactory)test_factory).covered.size());
-        // logger.trace("Generated new test suite:"+chromosome);
         return chromosome;
     }
 }

--- a/client/src/test/java/org/evosuite/testsuite/factories/TestSuiteFactoryTest.java
+++ b/client/src/test/java/org/evosuite/testsuite/factories/TestSuiteFactoryTest.java
@@ -1,0 +1,94 @@
+package org.evosuite.testsuite.factories;
+
+import org.evosuite.Properties;
+import org.evosuite.ga.ChromosomeFactory;
+import org.evosuite.testcase.TestChromosome;
+import org.evosuite.testcase.factories.RandomLengthTestFactory;
+import org.evosuite.testsuite.TestSuiteChromosome;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class TestSuiteFactoryTest {
+
+    @Test
+    public void testFixedSizeTestSuiteChromosomeFactoryUsesCorrectFactoryInternal() {
+        // Arrange
+        int size = 5;
+        // Check default constructor
+        FixedSizeTestSuiteChromosomeFactory factory = new FixedSizeTestSuiteChromosomeFactory(size);
+        TestSuiteChromosome suite = factory.getChromosome();
+        assertTrue(suite.getTestChromosomeFactory() instanceof RandomLengthTestFactory);
+        assertEquals(size, suite.size());
+
+        // Check new constructor
+        ChromosomeFactory<TestChromosome> mockFactory = mock(ChromosomeFactory.class);
+        when(mockFactory.getChromosome()).thenReturn(new TestChromosome());
+        FixedSizeTestSuiteChromosomeFactory factory2 = new FixedSizeTestSuiteChromosomeFactory(mockFactory, size);
+        TestSuiteChromosome suite2 = factory2.getChromosome();
+        assertEquals(mockFactory, suite2.getTestChromosomeFactory());
+        assertEquals(size, suite2.size());
+    }
+
+    @Test
+    public void testTestSuiteChromosomeFactoryUsesCorrectFactory() {
+        // Arrange
+        ChromosomeFactory<TestChromosome> mockFactory = mock(ChromosomeFactory.class);
+        when(mockFactory.getChromosome()).thenReturn(new TestChromosome());
+
+        TestSuiteChromosomeFactory factory = new TestSuiteChromosomeFactory(mockFactory);
+
+        // Act
+        TestSuiteChromosome suite = factory.getChromosome();
+
+        // Assert
+        assertEquals(mockFactory, suite.getTestChromosomeFactory());
+        // Verify mock was called at least once (since MIN_INITIAL_TESTS defaults to 1)
+        verify(mockFactory, atLeastOnce()).getChromosome();
+    }
+
+    @Test
+    public void testJUnitTestSuiteChromosomeFactoryDefaults() {
+        // Arrange
+        ChromosomeFactory<TestChromosome> mockFactory = mock(ChromosomeFactory.class);
+        when(mockFactory.getChromosome()).thenReturn(new TestChromosome());
+
+        JUnitTestSuiteChromosomeFactory factory = new JUnitTestSuiteChromosomeFactory(mockFactory);
+
+        // Act
+        TestSuiteChromosome suite = factory.getChromosome();
+
+        // Assert
+        // Now it should use the mock factory
+        assertEquals(mockFactory, suite.getTestChromosomeFactory());
+    }
+
+    @Test
+    public void testPropertiesRangeCheck() {
+        // Save properties
+        int originalMin = Properties.MIN_INITIAL_TESTS;
+        int originalMax = Properties.MAX_INITIAL_TESTS;
+
+        try {
+            Properties.MIN_INITIAL_TESTS = 10;
+            Properties.MAX_INITIAL_TESTS = 5;
+
+            // Test FixedSize (doesn't use random count, so skipping)
+
+            // Test TestSuiteChromosomeFactory
+            TestSuiteChromosomeFactory factory = new TestSuiteChromosomeFactory();
+            TestSuiteChromosome suite = factory.getChromosome();
+            assertNotNull(suite);
+            // It should work without exception, using min as max
+
+            // Test JUnitTestSuiteChromosomeFactory
+            JUnitTestSuiteChromosomeFactory jUnitFactory = new JUnitTestSuiteChromosomeFactory(new RandomLengthTestFactory());
+            TestSuiteChromosome jSuite = jUnitFactory.getChromosome();
+            assertNotNull(jSuite);
+
+        } finally {
+            Properties.MIN_INITIAL_TESTS = originalMin;
+            Properties.MAX_INITIAL_TESTS = originalMax;
+        }
+    }
+}


### PR DESCRIPTION
Refactored `org.evosuite.testsuite.factories` to improve correctness and code quality.

Key changes:
1.  **Correctness**: Fixed a bug in `JUnitTestSuiteChromosomeFactory` and `FixedSizeTestSuiteChromosomeFactory` where the `TestSuiteChromosome` was initialized with a new `RandomLengthTestFactory` instead of the configured factory. This ensures that subsequent mutations on the test suite use the correct factory.
2.  **Robustness**: Added checks in all factories to ensure `Properties.MAX_INITIAL_TESTS >= Properties.MIN_INITIAL_TESTS` before calling `Randomness.nextInt`, preventing potential runtime exceptions if properties are misconfigured.
3.  **Flexibility**: `FixedSizeTestSuiteChromosomeFactory` now supports dependency injection of the `ChromosomeFactory<TestChromosome>`.
4.  **Cleanup**: Removed legacy commented-out code.
5.  **Testing**: Added `TestSuiteFactoryTest` to verify the fixes and ensure factories behave as expected.

---
*PR created automatically by Jules for task [1835137065491967211](https://jules.google.com/task/1835137065491967211) started by @gofraser*