### PR TITLE
Refactor org.evosuite.setup package

### DIFF
--- a/client/src/main/java/org/evosuite/setup/DependencyAnalysis.java
+++ b/client/src/main/java/org/evosuite/setup/DependencyAnalysis.java
@@ -211,25 +211,21 @@ public class DependencyAnalysis {
     // TODO implement something that takes parameters using properties -
     // generalize this method.
     public static boolean isTargetProject(String className) {
-        return (className.startsWith(Properties.PROJECT_PREFIX) || (!Properties.TARGET_CLASS_PREFIX
-                .isEmpty() && className.startsWith(Properties.TARGET_CLASS_PREFIX)))
-                && !className.startsWith("java.")
-                && !className.startsWith("sun.")
-                && !className.startsWith(PackageInfo.getEvoSuitePackage())
-                && !className.startsWith("org.exsyst")
-                && !className.startsWith("de.unisb.cs.st.evosuite")
-                && !className.startsWith("de.unisb.cs.st.specmate")
-                && !className.startsWith("javax.")
-                && !className.startsWith("org.xml")
-                && !className.startsWith("org.w3c")
-                && !className.startsWith("apple.")
-                && !className.startsWith("com.apple.")
-                && !className.startsWith("org.omg.")
-                && !className.startsWith("sunw.")
-                && !className.startsWith("org.jcp.")
-                && !className.startsWith("org.ietf.")
-                && !className.startsWith("daikon.")
-                && !className.startsWith("jdk.");
+        if (!className.startsWith(Properties.PROJECT_PREFIX) && (Properties.TARGET_CLASS_PREFIX.isEmpty() || !className.startsWith(Properties.TARGET_CLASS_PREFIX))) {
+            return false;
+        }
+
+        if (className.startsWith(PackageInfo.getEvoSuitePackage())) {
+            return false;
+        }
+
+        for (String forbidden : SetupConstants.FORBIDDEN_PACKAGES) {
+            if (className.startsWith(forbidden)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/client/src/main/java/org/evosuite/setup/InheritanceTree.java
+++ b/client/src/main/java/org/evosuite/setup/InheritanceTree.java
@@ -44,22 +44,28 @@ public class InheritanceTree {
     private Set<String> interfacesSet = new LinkedHashSet<>();
     private Set<String> abstractClassesSet = new LinkedHashSet<>();
 
-    private Map<String, Set<String>> analyzedMethods;
+    private Map<String, Set<String>> analyzedMethods = new LinkedHashMap<>();
 
     private DirectedMultigraph<String, DefaultEdge> inheritanceGraph = new DirectedMultigraph<>(
             DefaultEdge.class);
 
-    private void initialiseMap() {
-        if (analyzedMethods == null)
+    private Object readResolve() {
+        if (analyzedMethods == null) {
             analyzedMethods = new LinkedHashMap<>();
-        if (interfacesSet == null)
+        }
+        if (interfacesSet == null) {
             interfacesSet = new LinkedHashSet<>();
-        if (abstractClassesSet == null)
+        }
+        if (abstractClassesSet == null) {
             abstractClassesSet = new LinkedHashSet<>();
+        }
+        if (inheritanceGraph == null) {
+            inheritanceGraph = new DirectedMultigraph<>(DefaultEdge.class);
+        }
+        return this;
     }
 
     public boolean isClassDefined(String className) {
-        initialiseMap();
         return analyzedMethods.containsKey(className);
     }
 
@@ -72,32 +78,24 @@ public class InheritanceTree {
     }
 
     public void registerAbstractClass(String abstractClassName) {
-        initialiseMap();
         abstractClassesSet.add(ResourceList.getClassNameFromResourcePath(abstractClassName));
     }
 
     public void registerInterface(String interfaceName) {
-        initialiseMap();
         interfacesSet.add(ResourceList.getClassNameFromResourcePath(interfaceName));
     }
 
     public boolean isMethodDefined(String className, String methodNameWdescriptor) {
-        initialiseMap();
-
         if (analyzedMethods.get(className) == null) return false;
         return analyzedMethods.get(className).contains(methodNameWdescriptor);
     }
 
     public boolean isMethodDefined(String className, String methodName, String descriptor) {
-        initialiseMap();
-
         if (analyzedMethods.get(className) == null) return false;
         return analyzedMethods.get(className).contains(methodName + descriptor);
     }
 
-    //TODO the initialization in the clinit dosen't work, no idea why - mattia
     public void addAnalyzedMethod(String classname, String methodname, String descriptor) {
-        initialiseMap();
         classname = classname.replace(File.separator, ".");
         Set<String> tmp = analyzedMethods.get(classname);
         if (tmp == null)
@@ -109,11 +107,6 @@ public class InheritanceTree {
     public void addSuperclass(String className, String superName, int access) {
         String classNameWithDots = ResourceList.getClassNameFromResourcePath(className);
         String superNameWithDots = ResourceList.getClassNameFromResourcePath(superName);
-
-        if (inheritanceGraph == null) {
-            inheritanceGraph = new DirectedMultigraph<>(
-                    DefaultEdge.class);
-        }
 
         inheritanceGraph.addVertex(classNameWithDots);
         inheritanceGraph.addVertex(superNameWithDots);

--- a/client/src/main/java/org/evosuite/setup/SetupConstants.java
+++ b/client/src/main/java/org/evosuite/setup/SetupConstants.java
@@ -1,0 +1,50 @@
+package org.evosuite.setup;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Constants used in the setup package.
+ */
+public class SetupConstants {
+
+    public static final Set<String> PRIMITIVE_TYPES = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
+            "int", "short", "float", "double", "byte", "char", "boolean", "long"
+    )));
+
+    public static final Set<String> BLACKLIST_EVOSUITE_PRIMITIVES;
+
+    static {
+        Set<String> blacklist = new LinkedHashSet<>(PRIMITIVE_TYPES);
+        blacklist.add(java.lang.Enum.class.getName());
+        blacklist.add(java.lang.String.class.getName());
+        blacklist.add(java.lang.Class.class.getName());
+        blacklist.add(java.lang.ThreadGroup.class.getName()); // may lead to EvoSuite killing all threads
+        BLACKLIST_EVOSUITE_PRIMITIVES = Collections.unmodifiableSet(blacklist);
+    }
+
+    public static final Set<String> FORBIDDEN_PACKAGES = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
+            "java.",
+            "sun.",
+            "org.exsyst",
+            "de.unisb.cs.st.evosuite",
+            "de.unisb.cs.st.specmate",
+            "javax.",
+            "org.xml",
+            "org.w3c",
+            "apple.",
+            "com.apple.",
+            "org.omg.",
+            "sunw.",
+            "org.jcp.",
+            "org.ietf.",
+            "daikon.",
+            "jdk."
+    )));
+
+    private SetupConstants() {
+        // prevent instantiation
+    }
+}

--- a/client/src/main/java/org/evosuite/setup/TestCluster.java
+++ b/client/src/main/java/org/evosuite/setup/TestCluster.java
@@ -141,23 +141,8 @@ public class TestCluster {
                 recursiveRemoveGenerators(entry.getKey());
             }
 
-
             Set<GenericClass<?>> toRemove = new LinkedHashSet<>();
-
-            for (GenericAccessibleObject<?> gao : entry.getValue()) {
-                GenericClass<?> owner = gao.getOwnerClass();
-                if (removed.contains(owner)) {
-                    continue;
-                }
-                try {
-                    cacheGenerators(owner);
-                } catch (ConstructionFailedException e) {
-                    continue;
-                }
-                if (generatorCache.get(owner).isEmpty()) {
-                    toRemove.add(owner);
-                }
-            }
+            validateGenerators(entry.getValue(), removed, toRemove);
 
             for (GenericClass<?> tr : toRemove) {
                 recursiveRemoveGenerators(tr);
@@ -170,6 +155,23 @@ public class TestCluster {
         removeDirectCycle();
 
         generatorCache.clear();
+    }
+
+    private void validateGenerators(Set<GenericAccessibleObject<?>> generators, Set<GenericClass<?>> removed, Set<GenericClass<?>> toRemove) {
+        for (GenericAccessibleObject<?> gao : generators) {
+            GenericClass<?> owner = gao.getOwnerClass();
+            if (removed.contains(owner)) {
+                continue;
+            }
+            try {
+                cacheGenerators(owner);
+            } catch (ConstructionFailedException e) {
+                continue;
+            }
+            if (generatorCache.get(owner).isEmpty()) {
+                toRemove.add(owner);
+            }
+        }
     }
 
 
@@ -618,6 +620,7 @@ public class TestCluster {
 
     /**
      * @return the analyzedClasses
+     * @deprecated This field is deprecated and should not be used. It is maintained for backward compatibility.
      */
     @Deprecated
     public Set<Class<?>> getAnalyzedClasses() {

--- a/client/src/main/java/org/evosuite/setup/TestClusterGenerator.java
+++ b/client/src/main/java/org/evosuite/setup/TestClusterGenerator.java
@@ -109,8 +109,7 @@ public class TestClusterGenerator {
          * If we fail to load a class, we skip it, and avoid to try to load it
          * again (which would result in extra unnecessary logging)
          */
-        Set<String> blackList = new LinkedHashSet<>();
-        initBlackListWithEvoSuitePrimitives(blackList);
+        Set<String> blackList = new LinkedHashSet<>(SetupConstants.BLACKLIST_EVOSUITE_PRIMITIVES);
 
         logger.info("Handling cast classes");
         handleCastClasses();
@@ -137,8 +136,7 @@ public class TestClusterGenerator {
 
         Inputs.checkNull(rawTypes);
 
-        Set<String> blackList = new LinkedHashSet<>();
-        initBlackListWithEvoSuitePrimitives(blackList);
+        Set<String> blackList = new LinkedHashSet<>(SetupConstants.BLACKLIST_EVOSUITE_PRIMITIVES);
 
         rawTypes.stream().forEach(c -> dependencies.add(new DependencyPair(0, GenericClassFactory.get(c).getRawClass())));
 
@@ -189,8 +187,7 @@ public class TestClusterGenerator {
         // If we include type seeding, then we analyze classes to find types in
         // instanceof and cast instructions
         if (Properties.SEED_TYPES) {
-            Set<String> blackList = new LinkedHashSet<>();
-            initBlackListWithPrimitives(blackList);
+            Set<String> blackList = new LinkedHashSet<>(SetupConstants.PRIMITIVE_TYPES);
 
             Set<String> classNames = new LinkedHashSet<>();
             CastClassAnalyzer analyzer = new CastClassAnalyzer();
@@ -221,32 +218,6 @@ public class TestClusterGenerator {
                 TestCluster.getInstance().getGenerators().size());
         ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Modifiers,
                 TestCluster.getInstance().getModifiers().size());
-    }
-
-    private void initBlackListWithEvoSuitePrimitives(Set<String> blackList) throws NullPointerException {
-        blackList.add("int");
-        blackList.add("short");
-        blackList.add("float");
-        blackList.add("double");
-        blackList.add("byte");
-        blackList.add("char");
-        blackList.add("boolean");
-        blackList.add("long");
-        blackList.add(java.lang.Enum.class.getName());
-        blackList.add(java.lang.String.class.getName());
-        blackList.add(java.lang.Class.class.getName());
-        blackList.add(java.lang.ThreadGroup.class.getName()); // may lead to EvoSuite killing all threads
-    }
-
-    private void initBlackListWithPrimitives(Set<String> blackList) throws NullPointerException {
-        blackList.add("int");
-        blackList.add("short");
-        blackList.add("float");
-        blackList.add("double");
-        blackList.add("byte");
-        blackList.add("char");
-        blackList.add("boolean");
-        blackList.add("long");
     }
 
     private boolean addCastClassDependencyIfAccessible(String className, Set<String> blackList) {


### PR DESCRIPTION
This PR refactors the `org.evosuite.setup` package to address code quality and correctness issues.

1.  **Centralized Constants**: Introduced `SetupConstants` to hold blacklist definitions and forbidden package prefixes. This removes duplication and magic strings from `TestClusterGenerator` and `DependencyAnalysis`.
2.  **Initialization Safety**: Updated `InheritanceTree` to initialize fields inline and implement `readResolve()`. This ensures that fields are correctly initialized both during construction and deserialization, eliminating the need for repetitive `initialiseMap()` calls and potential null pointer exceptions if deserialization skipped initialization.
3.  **Code Simplification**:
    *   Extracted the nested loop logic in `TestCluster.removeUnusableGenerators` into a `validateGenerators` method to reduce cyclomatic complexity and improve readability.
    *   Simplified the boolean logic in `DependencyAnalysis.isTargetProject`.
4.  **Documentation**: Added Javadoc to the deprecated `getAnalyzedClasses` method in `TestCluster`.

Verified with existing tests: `DependencyAnalysisTest`, `TestClusterGeneratorTest`, `TestClusterUtilTest`, `InheritanceTreeGeneratorTest`, and `DependencyAnalysis_removeUnusableGeneratorsTest`.

---
*PR created automatically by Jules for task [649198461121238026](https://jules.google.com/task/649198461121238026) started by @gofraser*