### PR TITLE
Refactor org.evosuite.setup.callgraph for correctness and quality

### DIFF
--- a/client/src/main/java/org/evosuite/setup/callgraph/Graph.java
+++ b/client/src/main/java/org/evosuite/setup/callgraph/Graph.java
@@ -38,6 +38,20 @@ public abstract class Graph<E> {
     }
 
     public synchronized void removeVertex(E vertex) {
+        if (edges.containsKey(vertex)) {
+            for (E neighbor : edges.get(vertex)) {
+                if (reverseEdges.containsKey(neighbor)) {
+                    reverseEdges.get(neighbor).remove(vertex);
+                }
+            }
+        }
+        if (reverseEdges.containsKey(vertex)) {
+            for (E neighbor : reverseEdges.get(vertex)) {
+                if (edges.containsKey(neighbor)) {
+                    edges.get(neighbor).remove(vertex);
+                }
+            }
+        }
         edges.remove(vertex);
         reverseEdges.remove(vertex);
         vertexSet.remove(vertex);

--- a/client/src/main/java/org/evosuite/setup/callgraph/PathFinder.java
+++ b/client/src/main/java/org/evosuite/setup/callgraph/PathFinder.java
@@ -39,22 +39,22 @@ public class PathFinder {
      * @param startingVertex
      * @return
      */
-    public static <E> Set<List<E>> getPahts(Graph<E> g, E startingVertex) {
+    public static <E> Set<List<E>> getPaths(Graph<E> g, E startingVertex) {
         if (!g.containsVertex(startingVertex)) {
             return new HashSet<>();
         }
-        PathFinderDFSIterator<E> dfs = new PathFinderDFSIterator<>(g, startingVertex);
+        PathFinderDFSIterator<E> dfs = new PathFinderDFSIterator<>(g, startingVertex, false, true);
         while (dfs.hasNext()) {
             dfs.next();
         }
         return dfs.getPaths();
     }
 
-    public static <E> Set<List<E>> getReversePahts(Graph<E> g, E startingVertex) {
+    public static <E> Set<List<E>> getReversePaths(Graph<E> g, E startingVertex) {
         if (!g.containsVertex(startingVertex)) {
             return new HashSet<>();
         }
-        PathFinderDFSIterator<E> dfs = new PathFinderDFSIterator<>(g, startingVertex, true);
+        PathFinderDFSIterator<E> dfs = new PathFinderDFSIterator<>(g, startingVertex, true, true);
         while (dfs.hasNext()) {
             dfs.next();
         }

--- a/client/src/main/java/org/evosuite/setup/callgraph/PathFinderDFSIterator.java
+++ b/client/src/main/java/org/evosuite/setup/callgraph/PathFinderDFSIterator.java
@@ -32,12 +32,17 @@ public class PathFinderDFSIterator<E> implements Iterator<E> {
     private final Set<List<E>> paths = new HashSet<>();
     private List<E> currentPath = new ArrayList<>();
     private boolean reversed = false;
+    private final boolean visitAllPaths;
 
     public PathFinderDFSIterator(Graph<E> g, E startingVertex) {
-        this(g, startingVertex, false);
+        this(g, startingVertex, false, false);
     }
 
     public PathFinderDFSIterator(Graph<E> g, E startingVertex, boolean reversed) {
+        this(g, startingVertex, reversed, false);
+    }
+
+    public PathFinderDFSIterator(Graph<E> g, E startingVertex, boolean reversed, boolean visitAllPaths) {
         if (!reversed) {
             this.stack.push(g.getNeighbors(startingVertex).iterator());
         } else {
@@ -47,6 +52,7 @@ public class PathFinderDFSIterator<E> implements Iterator<E> {
         this.next = startingVertex;
         paths.add(currentPath);
         this.reversed = reversed;
+        this.visitAllPaths = visitAllPaths;
     }
 
     public Set<List<E>> getPaths() {
@@ -95,6 +101,12 @@ public class PathFinderDFSIterator<E> implements Iterator<E> {
             }
 
             if (update) {
+                if (visitAllPaths) {
+                    for (int i = 0; i < levelback; i++) {
+                        E e = currentPath.get(currentPath.size() - 1 - i);
+                        visited.remove(e);
+                    }
+                }
                 List<E> newPath = new ArrayList<>(currentPath.subList(0,
                         currentPath.size() - levelback));
                 currentPath = newPath;

--- a/client/src/test/java/org/evosuite/setup/callgraph/GraphTest.java
+++ b/client/src/test/java/org/evosuite/setup/callgraph/GraphTest.java
@@ -1,0 +1,33 @@
+package org.evosuite.setup.callgraph;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.Iterator;
+
+public class GraphTest {
+
+    @Test
+    public void testRemoveVertex() {
+        Graph<String> graph = new Graph<String>() {};
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+
+        assertTrue(graph.containsVertex("B"));
+        assertTrue(graph.containsEdge("A", "B"));
+        assertTrue(graph.containsEdge("B", "C"));
+
+        graph.removeVertex("B");
+
+        assertFalse(graph.containsVertex("B"));
+        assertFalse(graph.containsEdge("A", "B"));
+        assertFalse(graph.containsEdge("B", "C"));
+
+        // Check dangling edges in A
+        Iterator<String> neighborsA = graph.getNeighbors("A").iterator();
+        assertFalse("A should not have neighbors after B is removed", neighborsA.hasNext());
+
+        // Check dangling reverse edges in C
+        Iterator<String> reverseNeighborsC = graph.getReverseNeighbors("C").iterator();
+        assertFalse("C should not have reverse neighbors after B is removed", reverseNeighborsC.hasNext());
+    }
+}

--- a/client/src/test/java/org/evosuite/setup/callgraph/PathFinderTest.java
+++ b/client/src/test/java/org/evosuite/setup/callgraph/PathFinderTest.java
@@ -1,0 +1,46 @@
+package org.evosuite.setup.callgraph;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+public class PathFinderTest {
+
+    @Test
+    public void testDiamondGraph() {
+        // Diamond graph: A -> B, A -> C, B -> D, C -> D
+        // In reverse graph (if used for contexts): D -> B, D -> C, B -> A, C -> A
+        // Let's just use Graph directly.
+        // D -> B -> A
+        // D -> C -> A
+
+        Graph<String> graph = new Graph<String>() {};
+
+        graph.addEdge("D", "B");
+        graph.addEdge("D", "C");
+        graph.addEdge("B", "A");
+        graph.addEdge("C", "A");
+
+        Set<List<String>> paths = PathFinder.getPaths(graph, "D");
+
+        System.out.println("Paths found: " + paths);
+
+        // We expect paths ending in A.
+        // [D, B, A]
+        // [D, C, A]
+        // And prefixes [D, B], [D, C], [D]
+
+        boolean foundDBA = false;
+        boolean foundDCA = false;
+
+        for (List<String> path : paths) {
+            if (path.toString().equals("[D, B, A]")) foundDBA = true;
+            if (path.toString().equals("[D, C, A]")) foundDCA = true;
+        }
+
+        assertTrue("Should find path [D, B, A]", foundDBA);
+        assertTrue("Should find path [D, C, A]", foundDCA);
+    }
+}


### PR DESCRIPTION
This PR improves the correctness and code quality of the `org.evosuite.setup.callgraph` package.

Key changes:
1.  **Correctness Fix in `Graph.removeVertex`**: The previous implementation failed to remove the vertex from the adjacency lists of its neighbors, leaving dangling edges. The new implementation correctly cleans up both `edges` and `reverseEdges`.
2.  **`PathFinder` improvements**:
    -   `PathFinderDFSIterator` was updated to support a `visitAllPaths` mode. In this mode, nodes are removed from the `visited` set upon backtracking, allowing the discovery of all paths in DAGs (fixing the diamond problem where valid paths were skipped).
    -   `PathFinder.getPaths` (formerly `getPahts`) now uses this mode to ensure all call contexts are returned.
    -   Default behavior of `PathFinderDFSIterator` remains unchanged (single visit) to preserve performance for reachability checks (e.g., in `CallGraph.computeInterestingClasses`).
3.  **Code Cleanup**:
    -   Fixed typos (`getPahts` -> `getPaths`).
    -   Removed unused code and fields in `CallGraph` (`cutNodes`, unused logger, old legacy methods).
4.  **Tests**:
    -   Added `GraphTest` to verify `removeVertex`.
    -   Added `PathFinderTest` to verify path finding in diamond graphs.

---
*PR created automatically by Jules for task [10110115501738267675](https://jules.google.com/task/10110115501738267675) started by @gofraser*