### PR TITLE
Refactor CFGMethodAdapter clearing mechanism

### DIFF
--- a/client/src/main/java/org/evosuite/TestGenerationContext.java
+++ b/client/src/main/java/org/evosuite/TestGenerationContext.java
@@ -173,9 +173,7 @@ public class TestGenerationContext {
         GraphPool.clearAll();
         DefUsePool.clear();
 
-        // TODO: This is not nice
-        for (ClassLoader cl : CFGMethodAdapter.methods.keySet())
-            CFGMethodAdapter.methods.get(cl).clear();
+        CFGMethodAdapter.clear();
 
         // TODO: Clear only pool of current classloader?
         BytecodeInstructionPool.clearAll();

--- a/client/src/main/java/org/evosuite/graphs/cfg/CFGMethodAdapter.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/CFGMethodAdapter.java
@@ -66,7 +66,14 @@ public class CFGMethodAdapter extends MethodVisitor {
      * The set of all methods which can be used during test case generation This
      * excludes e.g. synthetic, initializers, private and deprecated methods
      */
-    public static Map<ClassLoader, Map<String, Set<String>>> methods = new HashMap<>();
+    private static Map<ClassLoader, Map<String, Set<String>>> methods = new HashMap<>();
+
+    public static void clear() {
+        for (ClassLoader cl : methods.keySet()) {
+            methods.get(cl).clear();
+        }
+        methods.clear();
+    }
 
     /**
      * This is the name + the description of the method. It is more like the

--- a/client/src/test/java/org/evosuite/graphs/cfg/CFGMethodAdapterTest.java
+++ b/client/src/test/java/org/evosuite/graphs/cfg/CFGMethodAdapterTest.java
@@ -1,0 +1,36 @@
+package org.evosuite.graphs.cfg;
+
+import org.junit.Test;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import static org.junit.Assert.*;
+
+public class CFGMethodAdapterTest {
+
+    @Test
+    public void testClear() throws Exception {
+        ClassLoader cl = new ClassLoader() {};
+
+        // Populate methods via reflection to be robust against visibility changes
+        Field methodsField = CFGMethodAdapter.class.getDeclaredField("methods");
+        methodsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<ClassLoader, Map<String, Set<String>>> methods = (Map<ClassLoader, Map<String, Set<String>>>) methodsField.get(null);
+
+        Map<String, Set<String>> classMap = new HashMap<>();
+        Set<String> methodSet = new HashSet<>();
+        methodSet.add("method1");
+        classMap.put("Class1", methodSet);
+        methods.put(cl, classMap);
+
+        assertTrue("Should have methods before clear", CFGMethodAdapter.getNumMethods(cl) > 0);
+
+        CFGMethodAdapter.clear();
+
+        assertEquals("Should have 0 methods after clear", 0, CFGMethodAdapter.getNumMethods(cl));
+        assertTrue("Map should be empty", methods.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR refactors how `CFGMethodAdapter.methods` is cleared in `TestGenerationContext`.
Instead of directly iterating over the map and clearing values, a static `clear()` method is introduced in `CFGMethodAdapter`.
The `methods` map is now private to enforce encapsulation.
A unit test `CFGMethodAdapterTest` is added to verify the `clear()` functionality.

---
*PR created automatically by Jules for task [13088038505953793110](https://jules.google.com/task/13088038505953793110) started by @gofraser*