### PR TITLE
Refactor org.evosuite.graphs for correctness and quality

### DIFF
--- a/client/src/test/java/org/evosuite/graphs/FloydWarshallTest.java
+++ b/client/src/test/java/org/evosuite/graphs/FloydWarshallTest.java
@@ -1,0 +1,59 @@
+package org.evosuite.graphs;
+
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class FloydWarshallTest {
+
+    @Test
+    public void testShortestPathAndDiameter() {
+        DefaultDirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addVertex("D");
+
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "D");
+        graph.addEdge("A", "D"); // shortcut
+
+        // In DefaultEdge, weights are 1.0 by default unless weighted graph is used.
+        // But DefaultDirectedGraph is not weighted by default?
+        // JGraphT's DefaultEdge does not support weights unless we use SimpleWeightedGraph or similar
+        // OR we use graph.setEdgeWeight. But DefaultDirectedGraph supports setEdgeWeight?
+        // Let's check JGraphT version... usually DefaultDirectedGraph implements WeightedGraph if specified?
+        // No, DefaultDirectedGraph implements DirectedGraph.
+        // However, JGraphT stores weights in a map inside the graph usually.
+
+        // Let's assume unweighted (weight 1.0).
+        // A->B (1), B->C (1), C->D (1). A->D (1).
+        // Path A->D should be 1.
+        // Path A->C should be 2.
+
+        FloydWarshall<String, DefaultEdge> fw = new FloydWarshall<>(graph);
+
+        assertEquals(1.0, fw.shortestDistance("A", "B"), 0.001);
+        assertEquals(2.0, fw.shortestDistance("A", "C"), 0.001);
+        assertEquals(1.0, fw.shortestDistance("A", "D"), 0.001);
+        assertEquals(0.0, fw.shortestDistance("A", "A"), 0.001);
+        assertEquals(Double.POSITIVE_INFINITY, fw.shortestDistance("B", "A"), 0.001); // Directed
+
+        // Diameter:
+        // Max shortest path.
+        // A->B=1, A->C=2, A->D=1
+        // B->C=1, B->D=2
+        // C->D=1
+        // Max is 2.
+        assertEquals(2.0, fw.getDiameter(), 0.001);
+    }
+
+    @Test
+    public void testEmptyGraph() {
+        DefaultDirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        FloydWarshall<String, DefaultEdge> fw = new FloydWarshall<>(graph);
+        assertEquals(0.0, fw.getDiameter(), 0.001);
+    }
+}

--- a/client/src/test/java/org/evosuite/graphs/GraphPoolTest.java
+++ b/client/src/test/java/org/evosuite/graphs/GraphPoolTest.java
@@ -1,0 +1,40 @@
+package org.evosuite.graphs;
+
+import org.evosuite.graphs.cfg.RawControlFlowGraph;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class GraphPoolTest {
+
+    @Test
+    public void testGetInstance() {
+        ClassLoader cl1 = new ClassLoader() {};
+        ClassLoader cl2 = new ClassLoader() {};
+
+        GraphPool pool1 = GraphPool.getInstance(cl1);
+        GraphPool pool2 = GraphPool.getInstance(cl1);
+        GraphPool pool3 = GraphPool.getInstance(cl2);
+
+        assertNotNull(pool1);
+        assertSame(pool1, pool2);
+        assertNotSame(pool1, pool3);
+    }
+
+    @Test
+    public void testRegisterAndRetrieve() {
+        ClassLoader cl = new ClassLoader() {};
+        GraphPool pool = GraphPool.getInstance(cl);
+
+        String className = "com.example.TestClass";
+        String methodName = "testMethod()V";
+
+        RawControlFlowGraph cfg = new RawControlFlowGraph(cl, className, methodName, 1);
+        pool.registerRawCFG(cfg);
+
+        RawControlFlowGraph retrieved = pool.getRawCFG(className, methodName);
+        assertSame(cfg, retrieved);
+
+        pool.clear(className);
+        assertNull(pool.getRawCFG(className, methodName));
+    }
+}


### PR DESCRIPTION
This PR addresses the review of `org.evosuite.graphs` package.
It improves thread safety in `GraphPool` by replacing `HashMap` with `ConcurrentHashMap`.
It fixes correctness issues in `FloydWarshall` (diameter calculation) and optimizes it.
It improves `EvoSuiteGraph` by using `ProcessBuilder` for external commands and better resource management.
Added `FloydWarshallTest` and `GraphPoolTest` for verification.

---
*PR created automatically by Jules for task [14626143724434628052](https://jules.google.com/task/14626143724434628052) started by @gofraser*