### PR TITLE
Refactor method coverage package

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/method/AbstractMethodCoverageFactory.java
+++ b/client/src/main/java/org/evosuite/coverage/method/AbstractMethodCoverageFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.coverage.method;
+
+import org.evosuite.Properties;
+import org.evosuite.coverage.MethodNameMatcher;
+import org.evosuite.setup.TestUsageChecker;
+import org.evosuite.testsuite.AbstractFitnessFactory;
+import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract factory for method coverage goals.
+ *
+ * @param <T> the type of fitness function
+ */
+public abstract class AbstractMethodCoverageFactory<T extends AbstractMethodTestFitness> extends AbstractFitnessFactory<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractMethodCoverageFactory.class);
+    protected final MethodNameMatcher matcher = new MethodNameMatcher();
+
+    @Override
+    public List<T> getCoverageGoals() {
+        List<T> goals = new ArrayList<>();
+
+        long start = System.currentTimeMillis();
+
+        String className = Properties.TARGET_CLASS;
+        Class<?> clazz = Properties.getTargetClassAndDontInitialise();
+        if (clazz != null) {
+            goals.addAll(getCoverageGoals(clazz, className));
+            Class<?>[] innerClasses = clazz.getDeclaredClasses();
+            for (Class<?> innerClass : innerClasses) {
+                String innerClassName = innerClass.getCanonicalName();
+                goals.addAll(getCoverageGoals(innerClass, innerClassName));
+            }
+        }
+        goalComputationTime = System.currentTimeMillis() - start;
+        return goals;
+    }
+
+    protected List<T> getCoverageGoals(Class<?> clazz, String className) {
+        List<T> goals = new ArrayList<>();
+        Constructor<?>[] allConstructors = clazz.getDeclaredConstructors();
+        for (Constructor<?> c : allConstructors) {
+            if (TestUsageChecker.canUse(c)) {
+                String methodName = "<init>" + Type.getConstructorDescriptor(c);
+                logger.info("Adding goal for constructor " + className + "." + methodName);
+                goals.add(createGoal(className, methodName));
+            }
+        }
+        Method[] allMethods = clazz.getDeclaredMethods();
+        for (Method m : allMethods) {
+            if (TestUsageChecker.canUse(m)) {
+                if (clazz.isEnum()) {
+                    if (m.getName().equals("valueOf") || m.getName().equals("values")
+                            || m.getName().equals("ordinal")) {
+                        logger.debug("Excluding valueOf for Enum " + m);
+                        continue;
+                    }
+                }
+                if (clazz.isInterface() && Modifier.isAbstract(m.getModifiers())) {
+                    // Don't count interface declarations as targets
+                    continue;
+                }
+                String methodName = m.getName() + Type.getMethodDescriptor(m);
+                if (!matcher.methodMatches(methodName)) {
+                    logger.info("Method {} does not match criteria. ", methodName);
+                    continue;
+                }
+                logger.info("Adding goal for method " + className + "." + methodName);
+                goals.add(createGoal(className, methodName));
+            }
+        }
+        return goals;
+    }
+
+    protected abstract T createGoal(String className, String methodName);
+}

--- a/client/src/main/java/org/evosuite/coverage/method/AbstractMethodTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/method/AbstractMethodTestFitness.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.coverage.method;
+
+import org.evosuite.testcase.TestFitnessFunction;
+
+import java.util.Objects;
+
+/**
+ * Abstract base class for method coverage fitness functions.
+ *
+ * @author Gordon Fraser, Jose Miguel Rojas
+ */
+public abstract class AbstractMethodTestFitness extends TestFitnessFunction {
+
+    private static final long serialVersionUID = -5635347264626300451L;
+
+    /**
+     * Target method
+     */
+    protected final String className;
+    protected final String methodName;
+
+    public AbstractMethodTestFitness(String className, String methodName) {
+        this.className = Objects.requireNonNull(className, "className cannot be null");
+        this.methodName = Objects.requireNonNull(methodName, "methodName cannot be null");
+    }
+
+    /**
+     * <p>
+     * getClassName
+     * </p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * <p>
+     * getMethod
+     * </p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String getMethod() {
+        return methodName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return className + "." + methodName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int iConst = 13;
+        return 51 * iConst + className.hashCode() * iConst + methodName.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AbstractMethodTestFitness other = (AbstractMethodTestFitness) obj;
+        if (!className.equals(other.className)) {
+            return false;
+        } else return methodName.equals(other.methodName);
+    }
+
+    /* (non-Javadoc)
+     * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
+     */
+    @Override
+    public int compareTo(TestFitnessFunction other) {
+        if (this.getClass().equals(other.getClass())) {
+            AbstractMethodTestFitness otherMethodFitness = (AbstractMethodTestFitness) other;
+            if (className.equals(otherMethodFitness.getClassName()))
+                return methodName.compareTo(otherMethodFitness.getMethod());
+            else
+                return className.compareTo(otherMethodFitness.getClassName());
+        }
+        return compareClassName(other);
+    }
+
+    /* (non-Javadoc)
+     * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
+     */
+    @Override
+    public String getTargetClass() {
+        return getClassName();
+    }
+
+    /* (non-Javadoc)
+     * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
+     */
+    @Override
+    public String getTargetMethod() {
+        return getMethod();
+    }
+}

--- a/client/src/main/java/org/evosuite/coverage/method/MethodCoverageFactory.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodCoverageFactory.java
@@ -19,21 +19,7 @@
  */
 package org.evosuite.coverage.method;
 
-import org.evosuite.Properties;
-import org.evosuite.coverage.MethodNameMatcher;
 import org.evosuite.graphs.cfg.BytecodeInstruction;
-import org.evosuite.setup.TestUsageChecker;
-import org.evosuite.testsuite.AbstractFitnessFactory;
-import org.objectweb.asm.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
-
 
 /**
  * <p>
@@ -42,76 +28,11 @@ import java.util.List;
  *
  * @author Gordon Fraser, Andre Mis, Jose Miguel Rojas
  */
-public class MethodCoverageFactory extends
-        AbstractFitnessFactory<MethodCoverageTestFitness> {
+public class MethodCoverageFactory extends AbstractMethodCoverageFactory<MethodCoverageTestFitness> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MethodCoverageFactory.class);
-    private final MethodNameMatcher matcher = new MethodNameMatcher();
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.evosuite.coverage.TestCoverageFactory#getCoverageGoals()
-     */
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public List<MethodCoverageTestFitness> getCoverageGoals() {
-        List<MethodCoverageTestFitness> goals = new ArrayList<>();
-
-        long start = System.currentTimeMillis();
-
-        String className = Properties.TARGET_CLASS;
-        Class<?> clazz = Properties.getTargetClassAndDontInitialise();
-        if (clazz != null) {
-            goals.addAll(getCoverageGoals(clazz, className));
-            Class<?>[] innerClasses = clazz.getDeclaredClasses();
-            for (Class<?> innerClass : innerClasses) {
-                String innerClassName = innerClass.getCanonicalName();
-                goals.addAll(getCoverageGoals(innerClass, innerClassName));
-            }
-        }
-        goalComputationTime = System.currentTimeMillis() - start;
-        return goals;
-    }
-
-    private List<MethodCoverageTestFitness> getCoverageGoals(Class<?> clazz, String className) {
-        List<MethodCoverageTestFitness> goals = new ArrayList<>();
-        Constructor<?>[] allConstructors = clazz.getDeclaredConstructors();
-        for (Constructor<?> c : allConstructors) {
-            if (TestUsageChecker.canUse(c)) {
-                String methodName = "<init>" + Type.getConstructorDescriptor(c);
-                logger.info("Adding goal for constructor " + className + "." + methodName);
-                goals.add(new MethodCoverageTestFitness(className, methodName));
-            }
-        }
-        Method[] allMethods = clazz.getDeclaredMethods();
-        for (Method m : allMethods) {
-            if (TestUsageChecker.canUse(m)) {
-                if (clazz.isEnum()) {
-                    if (m.getName().equals("valueOf") || m.getName().equals("values")
-                            || m.getName().equals("ordinal")) {
-                        logger.debug("Excluding valueOf for Enum " + m);
-                        continue;
-                    }
-                }
-                if (clazz.isInterface() && Modifier.isAbstract(m.getModifiers())) {
-                    // Don't count interface declarations as targets
-                    continue;
-                }
-                String methodName = m.getName() + Type.getMethodDescriptor(m);
-                if (!matcher.methodMatches(methodName)) {
-                    logger.info("Method {} does not match criteria. ", methodName);
-                    continue;
-                }
-                logger.info("Adding goal for method " + className + "." + methodName);
-                goals.add(new MethodCoverageTestFitness(className, methodName));
-            }
-        }
-        return goals;
+    protected MethodCoverageTestFitness createGoal(String className, String methodName) {
+        return new MethodCoverageTestFitness(className, methodName);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/coverage/method/MethodCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodCoverageTestFitness.java
@@ -22,7 +22,6 @@ package org.evosuite.coverage.method;
 import org.evosuite.Properties;
 import org.evosuite.ga.archive.Archive;
 import org.evosuite.testcase.TestChromosome;
-import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testcase.execution.ExecutionResult;
 import org.evosuite.testcase.statements.ConstructorStatement;
 import org.evosuite.testcase.statements.EntityWithParametersStatement;
@@ -32,22 +31,15 @@ import org.evosuite.testcase.statements.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Fitness function for a single test on a single method (including calls that throw exceptions)
  *
  * @author Gordon Fraser, Jose Miguel Rojas
  */
-public class MethodCoverageTestFitness extends TestFitnessFunction {
+public class MethodCoverageTestFitness extends AbstractMethodTestFitness {
 
     private static final long serialVersionUID = 3624503060256855484L;
-
-    /**
-     * Target method
-     */
-    protected final String className;
-    protected final String methodName;
 
     /**
      * Constructor - fitness is specific to a method
@@ -56,30 +48,7 @@ public class MethodCoverageTestFitness extends TestFitnessFunction {
      * @param methodName the method name
      */
     public MethodCoverageTestFitness(String className, String methodName) {
-        this.className = Objects.requireNonNull(className, "className cannot be null");
-        this.methodName = Objects.requireNonNull(methodName, "methodName cannot be null");
-    }
-
-    /**
-     * <p>
-     * getClassName
-     * </p>
-     *
-     * @return a {@link String} object.
-     */
-    public String getClassName() {
-        return className;
-    }
-
-    /**
-     * <p>
-     * getMethod
-     * </p>
-     *
-     * @return a {@link String} object.
-     */
-    public String getMethod() {
-        return methodName;
+        super(className, methodName);
     }
 
     /**
@@ -147,63 +116,6 @@ public class MethodCoverageTestFitness extends TestFitnessFunction {
     @Override
     public String toString() {
         return "[METHOD] " + className + "." + methodName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        int iConst = 13;
-        return 51 * iConst + className.hashCode() * iConst + methodName.hashCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MethodCoverageTestFitness other = (MethodCoverageTestFitness) obj;
-        if (!className.equals(other.className)) {
-            return false;
-        } else return methodName.equals(other.methodName);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
-     */
-    @Override
-    public int compareTo(TestFitnessFunction other) {
-        if (other instanceof MethodCoverageTestFitness) {
-            MethodCoverageTestFitness otherMethodFitness = (MethodCoverageTestFitness) other;
-            if (className.equals(otherMethodFitness.getClassName()))
-                return methodName.compareTo(otherMethodFitness.getMethod());
-            else
-                return className.compareTo(otherMethodFitness.getClassName());
-        }
-        return compareClassName(other);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
-     */
-    @Override
-    public String getTargetClass() {
-        return getClassName();
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
-     */
-    @Override
-    public String getTargetMethod() {
-        return getMethod();
     }
 
 }

--- a/client/src/main/java/org/evosuite/coverage/method/MethodNoExceptionCoverageFactory.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodNoExceptionCoverageFactory.java
@@ -19,21 +19,7 @@
  */
 package org.evosuite.coverage.method;
 
-import org.evosuite.Properties;
-import org.evosuite.coverage.MethodNameMatcher;
 import org.evosuite.graphs.cfg.BytecodeInstruction;
-import org.evosuite.setup.TestUsageChecker;
-import org.evosuite.testsuite.AbstractFitnessFactory;
-import org.objectweb.asm.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
-
 
 /**
  * <p>
@@ -42,77 +28,11 @@ import java.util.List;
  *
  * @author Gordon Fraser, Andre Mis, Jose Miguel Rojas
  */
-public class MethodNoExceptionCoverageFactory extends
-        AbstractFitnessFactory<MethodNoExceptionCoverageTestFitness> {
+public class MethodNoExceptionCoverageFactory extends AbstractMethodCoverageFactory<MethodNoExceptionCoverageTestFitness> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MethodNoExceptionCoverageFactory.class);
-    private final MethodNameMatcher matcher = new MethodNameMatcher();
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.evosuite.coverage.TestCoverageFactory#getCoverageGoals()
-     */
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public List<MethodNoExceptionCoverageTestFitness> getCoverageGoals() {
-        List<MethodNoExceptionCoverageTestFitness> goals = new ArrayList<>();
-
-        long start = System.currentTimeMillis();
-
-        String className = Properties.TARGET_CLASS;
-        Class<?> clazz = Properties.getTargetClassAndDontInitialise();
-        if (clazz != null) {
-            goals.addAll(getCoverageGoals(clazz, className));
-            Class<?>[] innerClasses = clazz.getDeclaredClasses();
-            for (Class<?> innerClass : innerClasses) {
-                String innerClassName = innerClass.getCanonicalName();
-                goals.addAll(getCoverageGoals(innerClass, innerClassName));
-            }
-        }
-        goalComputationTime = System.currentTimeMillis() - start;
-        return goals;
-    }
-
-
-    private List<MethodNoExceptionCoverageTestFitness> getCoverageGoals(Class<?> clazz, String className) {
-        List<MethodNoExceptionCoverageTestFitness> goals = new ArrayList<>();
-        Constructor<?>[] allConstructors = clazz.getDeclaredConstructors();
-        for (Constructor<?> c : allConstructors) {
-            if (TestUsageChecker.canUse(c)) {
-                String methodName = "<init>" + Type.getConstructorDescriptor(c);
-                logger.info("Adding goal for constructor " + className + "." + methodName);
-                goals.add(new MethodNoExceptionCoverageTestFitness(className, methodName));
-            }
-        }
-        Method[] allMethods = clazz.getDeclaredMethods();
-        for (Method m : allMethods) {
-            if (TestUsageChecker.canUse(m)) {
-                if (clazz.isEnum()) {
-                    if (m.getName().equals("valueOf") || m.getName().equals("values")
-                            || m.getName().equals("ordinal")) {
-                        logger.debug("Excluding valueOf for Enum " + m);
-                        continue;
-                    }
-                }
-                if (clazz.isInterface() && Modifier.isAbstract(m.getModifiers())) {
-                    // Don't count interface declarations as targets
-                    continue;
-                }
-                String methodName = m.getName() + Type.getMethodDescriptor(m);
-                if (!matcher.methodMatches(methodName)) {
-                    logger.info("Method {} does not match criteria. ", methodName);
-                    continue;
-                }
-                logger.info("Adding goal for method " + className + "." + methodName);
-                goals.add(new MethodNoExceptionCoverageTestFitness(className, methodName));
-            }
-        }
-        return goals;
+    protected MethodNoExceptionCoverageTestFitness createGoal(String className, String methodName) {
+        return new MethodNoExceptionCoverageTestFitness(className, methodName);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/coverage/method/MethodNoExceptionCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodNoExceptionCoverageTestFitness.java
@@ -22,7 +22,6 @@ package org.evosuite.coverage.method;
 import org.evosuite.Properties;
 import org.evosuite.ga.archive.Archive;
 import org.evosuite.testcase.TestChromosome;
-import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testcase.execution.ExecutionResult;
 import org.evosuite.testcase.statements.ConstructorStatement;
 import org.evosuite.testcase.statements.EntityWithParametersStatement;
@@ -32,22 +31,15 @@ import org.evosuite.testcase.statements.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Fitness function for a single test on a single method (no exception)
  *
  * @author Gordon Fraser, Jose Miguel Rojas, Annibale Panichella
  */
-public class MethodNoExceptionCoverageTestFitness extends TestFitnessFunction {
+public class MethodNoExceptionCoverageTestFitness extends AbstractMethodTestFitness {
 
     private static final long serialVersionUID = 3624503060256855484L;
-
-    /**
-     * Target method
-     */
-    protected final String className;
-    protected final String methodName;
 
     /**
      * Constructor - fitness is specific to a method
@@ -56,30 +48,7 @@ public class MethodNoExceptionCoverageTestFitness extends TestFitnessFunction {
      * @param methodName the method name
      */
     public MethodNoExceptionCoverageTestFitness(String className, String methodName) {
-        this.className = Objects.requireNonNull(className, "className cannot be null");
-        this.methodName = Objects.requireNonNull(methodName, "methodName cannot be null");
-    }
-
-    /**
-     * <p>
-     * getClassName
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getClassName() {
-        return className;
-    }
-
-    /**
-     * <p>
-     * getMethod
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getMethod() {
-        return methodName;
+        super(className, methodName);
     }
 
     /**
@@ -145,63 +114,6 @@ public class MethodNoExceptionCoverageTestFitness extends TestFitnessFunction {
     @Override
     public String toString() {
         return "[METHODNOEX] " + className + "." + methodName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        int iConst = 13;
-        return 51 * iConst + className.hashCode() * iConst + methodName.hashCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MethodNoExceptionCoverageTestFitness other = (MethodNoExceptionCoverageTestFitness) obj;
-        if (!className.equals(other.className)) {
-            return false;
-        } else return methodName.equals(other.methodName);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
-     */
-    @Override
-    public int compareTo(TestFitnessFunction other) {
-        if (other instanceof MethodNoExceptionCoverageTestFitness) {
-            MethodNoExceptionCoverageTestFitness otherMethodFitness = (MethodNoExceptionCoverageTestFitness) other;
-            if (className.equals(otherMethodFitness.getClassName()))
-                return methodName.compareTo(otherMethodFitness.getMethod());
-            else
-                return className.compareTo(otherMethodFitness.getClassName());
-        }
-        return compareClassName(other);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
-     */
-    @Override
-    public String getTargetClass() {
-        return getClassName();
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
-     */
-    @Override
-    public String getTargetMethod() {
-        return getMethod();
     }
 
 }

--- a/client/src/main/java/org/evosuite/coverage/method/MethodTraceCoverageFactory.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodTraceCoverageFactory.java
@@ -19,20 +19,7 @@
  */
 package org.evosuite.coverage.method;
 
-import org.evosuite.Properties;
-import org.evosuite.coverage.MethodNameMatcher;
 import org.evosuite.graphs.cfg.BytecodeInstruction;
-import org.evosuite.setup.TestUsageChecker;
-import org.evosuite.testsuite.AbstractFitnessFactory;
-import org.objectweb.asm.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>
@@ -45,90 +32,11 @@ import java.util.List;
  *
  * @author Gordon Fraser, Andre Mis, Jose Miguel Rojas
  */
-public class MethodTraceCoverageFactory extends
-        AbstractFitnessFactory<MethodTraceCoverageTestFitness> {
+public class MethodTraceCoverageFactory extends AbstractMethodCoverageFactory<MethodTraceCoverageTestFitness> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MethodTraceCoverageFactory.class);
-    private final MethodNameMatcher matcher = new MethodNameMatcher();
-
-    protected static boolean isUsable(Method m) {
-        return !m.isSynthetic() &&
-                !m.isBridge() &&
-                !Modifier.isNative(m.getModifiers()) &&
-                !m.getName().contains("<clinit>");
-    }
-
-    protected static boolean isUsable(Constructor<?> c) {
-        return !c.isSynthetic() &&
-                !Modifier.isNative(c.getModifiers()) &&
-                !c.getName().contains("<clinit>");
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.evosuite.coverage.TestCoverageFactory#getCoverageGoals()
-     */
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public List<MethodTraceCoverageTestFitness> getCoverageGoals() {
-        List<MethodTraceCoverageTestFitness> goals = new ArrayList<>();
-
-        long start = System.currentTimeMillis();
-
-        String className = Properties.TARGET_CLASS;
-        Class<?> clazz = null;
-        try {
-            clazz = Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        }
-        if (clazz != null) {
-            goals.addAll(getCoverageGoals(clazz, className));
-            Class<?>[] innerClasses = clazz.getDeclaredClasses();
-            for (Class<?> innerClass : innerClasses) {
-                String innerClassName = innerClass.getCanonicalName();
-                goals.addAll(getCoverageGoals(innerClass, innerClassName));
-            }
-        }
-        goalComputationTime = System.currentTimeMillis() - start;
-        return goals;
-    }
-
-    private List<MethodTraceCoverageTestFitness> getCoverageGoals(Class<?> clazz, String className) {
-        List<MethodTraceCoverageTestFitness> goals = new ArrayList<>();
-        Constructor<?>[] allConstructors = clazz.getDeclaredConstructors();
-        for (Constructor<?> c : allConstructors) {
-            if (TestUsageChecker.canUse(c)) {
-                String methodName = "<init>" + Type.getConstructorDescriptor(c);
-                logger.info("Adding goal for constructor " + className + "." + methodName);
-                goals.add(new MethodTraceCoverageTestFitness(className, methodName));
-            }
-        }
-        Method[] allMethods = clazz.getDeclaredMethods();
-        for (Method m : allMethods) {
-            if (TestUsageChecker.canUse(m)) {
-                if (clazz.isEnum()) {
-                    if (m.getName().equals("valueOf") || m.getName().equals("values")
-                            || m.getName().equals("ordinal")) {
-                        logger.debug("Excluding valueOf for Enum " + m);
-                        continue;
-                    }
-                }
-                String methodName = m.getName() + Type.getMethodDescriptor(m);
-                if (!matcher.methodMatches(methodName)) {
-                    logger.info("Method {} does not match criteria. ", methodName);
-                    continue;
-                }
-                logger.info("Adding goal for method " + className + "." + methodName);
-                goals.add(new MethodTraceCoverageTestFitness(className, methodName));
-            }
-        }
-        return goals;
+    protected MethodTraceCoverageTestFitness createGoal(String className, String methodName) {
+        return new MethodTraceCoverageTestFitness(className, methodName);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/coverage/method/MethodTraceCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/method/MethodTraceCoverageTestFitness.java
@@ -22,25 +22,16 @@ package org.evosuite.coverage.method;
 import org.evosuite.Properties;
 import org.evosuite.ga.archive.Archive;
 import org.evosuite.testcase.TestChromosome;
-import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testcase.execution.ExecutionResult;
-
-import java.util.Objects;
 
 /**
  * Fitness function for a single test on a single method.
  *
  * @author Gordon Fraser, Jose Miguel Rojas
  */
-public class MethodTraceCoverageTestFitness extends TestFitnessFunction {
+public class MethodTraceCoverageTestFitness extends AbstractMethodTestFitness {
 
     private static final long serialVersionUID = -8880071948317243336L;
-
-    /**
-     * Target method
-     */
-    protected final String className;
-    protected final String methodName;
 
     /**
      * Constructor - fitness is specific to a method
@@ -49,30 +40,7 @@ public class MethodTraceCoverageTestFitness extends TestFitnessFunction {
      * @param methodName the method name
      */
     public MethodTraceCoverageTestFitness(String className, String methodName) throws IllegalArgumentException {
-        this.className = Objects.requireNonNull(className, "className cannot be null");
-        this.methodName = Objects.requireNonNull(methodName, "methodName cannot be null");
-    }
-
-    /**
-     * <p>
-     * getClassName
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getClassName() {
-        return className;
-    }
-
-    /**
-     * <p>
-     * getMethod
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getMethod() {
-        return methodName;
+        super(className, methodName);
     }
 
     /**
@@ -107,70 +75,5 @@ public class MethodTraceCoverageTestFitness extends TestFitnessFunction {
         }
 
         return fitness;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return className + "." + methodName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        int iConst = 13;
-        return 51 * iConst + className.hashCode() * iConst + methodName.hashCode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MethodTraceCoverageTestFitness other = (MethodTraceCoverageTestFitness) obj;
-        if (!className.equals(other.className)) {
-            return false;
-        } else return methodName.equals(other.methodName);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
-     */
-    @Override
-    public int compareTo(TestFitnessFunction other) {
-        if (other instanceof MethodTraceCoverageTestFitness) {
-            MethodTraceCoverageTestFitness otherMethodFitness = (MethodTraceCoverageTestFitness) other;
-            if (className.equals(otherMethodFitness.getClassName()))
-                return methodName.compareTo(otherMethodFitness.getMethod());
-            else
-                return className.compareTo(otherMethodFitness.getClassName());
-        }
-        return compareClassName(other);
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
-     */
-    @Override
-    public String getTargetClass() {
-        return getClassName();
-    }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
-     */
-    @Override
-    public String getTargetMethod() {
-        return getMethod();
     }
 }

--- a/client/src/test/java/org/evosuite/coverage/method/MethodCoverageFactoryTest.java
+++ b/client/src/test/java/org/evosuite/coverage/method/MethodCoverageFactoryTest.java
@@ -1,0 +1,70 @@
+package org.evosuite.coverage.method;
+
+import org.evosuite.Properties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MethodCoverageFactoryTest {
+
+    @Before
+    public void setUp() {
+        Properties.TARGET_CLASS = java.util.ArrayList.class.getName();
+    }
+
+    @Test
+    public void testMethodCoverageFactory() {
+        MethodCoverageFactory factory = new MethodCoverageFactory();
+        List<MethodCoverageTestFitness> goals = factory.getCoverageGoals();
+        Assert.assertFalse(goals.isEmpty());
+
+        boolean foundConstructor = false;
+        boolean foundAdd = false;
+
+        for (MethodCoverageTestFitness goal : goals) {
+            if (goal.getMethod().startsWith("<init>")) foundConstructor = true;
+            if (goal.getMethod().startsWith("add")) foundAdd = true;
+        }
+
+        Assert.assertTrue("Constructor not found", foundConstructor);
+        Assert.assertTrue("add not found", foundAdd);
+    }
+
+    @Test
+    public void testMethodNoExceptionCoverageFactory() {
+        MethodNoExceptionCoverageFactory factory = new MethodNoExceptionCoverageFactory();
+        List<MethodNoExceptionCoverageTestFitness> goals = factory.getCoverageGoals();
+        Assert.assertFalse(goals.isEmpty());
+
+        boolean foundConstructor = false;
+        boolean foundAdd = false;
+
+        for (MethodNoExceptionCoverageTestFitness goal : goals) {
+            if (goal.getMethod().startsWith("<init>")) foundConstructor = true;
+            if (goal.getMethod().startsWith("add")) foundAdd = true;
+        }
+
+        Assert.assertTrue("Constructor not found", foundConstructor);
+        Assert.assertTrue("add not found", foundAdd);
+    }
+
+    @Test
+    public void testMethodTraceCoverageFactory() {
+        MethodTraceCoverageFactory factory = new MethodTraceCoverageFactory();
+        List<MethodTraceCoverageTestFitness> goals = factory.getCoverageGoals();
+        Assert.assertFalse(goals.isEmpty());
+
+        boolean foundConstructor = false;
+        boolean foundAdd = false;
+
+        for (MethodTraceCoverageTestFitness goal : goals) {
+            if (goal.getMethod().startsWith("<init>")) foundConstructor = true;
+            if (goal.getMethod().startsWith("add")) foundAdd = true;
+        }
+
+        Assert.assertTrue("Constructor not found", foundConstructor);
+        Assert.assertTrue("add not found", foundAdd);
+    }
+}

--- a/client/src/test/java/org/evosuite/coverage/method/MethodCoverageFitnessTest.java
+++ b/client/src/test/java/org/evosuite/coverage/method/MethodCoverageFitnessTest.java
@@ -1,0 +1,186 @@
+package org.evosuite.coverage.method;
+
+import org.evosuite.Properties;
+import org.evosuite.testcase.DefaultTestCase;
+import org.evosuite.testcase.TestCase;
+import org.evosuite.testcase.TestChromosome;
+import org.evosuite.testcase.execution.ExecutionResult;
+import org.evosuite.testcase.execution.ExecutionTrace;
+import org.evosuite.testcase.execution.Scope;
+import org.evosuite.testcase.statements.EntityWithParametersStatement;
+import org.evosuite.testcase.statements.Statement;
+import org.evosuite.testcase.variable.VariableReference;
+import org.evosuite.utils.generic.GenericAccessibleObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintStream;
+import java.util.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.evosuite.testcase.statements.MethodStatement;
+
+public class MethodCoverageFitnessTest {
+
+    @Before
+    public void setUp() {
+        Properties.BREAK_ON_EXCEPTION = true;
+        Properties.TEST_ARCHIVE = false;
+    }
+
+    private MethodStatement createMockMethodStatement(TestCase tc, String className, String methodName, String descriptor, int position) {
+        MethodStatement ms = mock(MethodStatement.class);
+        when(ms.getDeclaringClassName()).thenReturn(className);
+        when(ms.getMethodName()).thenReturn(methodName);
+        when(ms.getDescriptor()).thenReturn(descriptor);
+        when(ms.getPosition()).thenReturn(position);
+        when(ms.getAssertions()).thenReturn(new HashSet<>());
+        VariableReference retval = mock(VariableReference.class);
+        when(ms.getReturnValue()).thenReturn(retval);
+        // DefaultTestCase.addStatement asserts isValid. We mock isValid to true
+        when(ms.isValid()).thenReturn(true);
+        return ms;
+    }
+
+    @Test
+    public void testMethodCoverageFitness() {
+        MethodCoverageTestFitness fitness = new MethodCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        MethodStatement statement = createMockMethodStatement(testCase, "com.example.Foo", "bar", "()V", 0);
+        testCase.addStatement(statement);
+
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(0.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodCoverageFitnessNotCovered() {
+        MethodCoverageTestFitness fitness = new MethodCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        MethodStatement statement = createMockMethodStatement(testCase, "com.example.Other", "baz", "()V", 0);
+        testCase.addStatement(statement);
+
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(1.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodCoverageFitnessWithExceptionBefore() {
+        MethodCoverageTestFitness fitness = new MethodCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        MethodStatement exceptionStmt = createMockMethodStatement(testCase, "com.example.Other", "baz", "()V", 0);
+        testCase.addStatement(exceptionStmt);
+
+        MethodStatement statement = createMockMethodStatement(testCase, "com.example.Foo", "bar", "()V", 1);
+        testCase.addStatement(statement);
+
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+        Map<Integer, Throwable> exceptions = new HashMap<>();
+        exceptions.put(0, new RuntimeException());
+        result.setThrownExceptions(exceptions);
+
+        Properties.BREAK_ON_EXCEPTION = true;
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(1.0, fit, 0.001);
+
+        Properties.BREAK_ON_EXCEPTION = false;
+        fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(0.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodNoExceptionCoverageFitness() {
+        MethodNoExceptionCoverageTestFitness fitness = new MethodNoExceptionCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        MethodStatement statement = createMockMethodStatement(testCase, "com.example.Foo", "bar", "()V", 0);
+        testCase.addStatement(statement);
+
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(0.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodNoExceptionCoverageFitnessWithException() {
+        MethodNoExceptionCoverageTestFitness fitness = new MethodNoExceptionCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        MethodStatement statement = createMockMethodStatement(testCase, "com.example.Foo", "bar", "()V", 0);
+        testCase.addStatement(statement);
+
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+        Map<Integer, Throwable> exceptions = new HashMap<>();
+        exceptions.put(0, new RuntimeException());
+        result.setThrownExceptions(exceptions);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(1.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodTraceCoverageFitness() {
+        MethodTraceCoverageTestFitness fitness = new MethodTraceCoverageTestFitness("com.example.Foo", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+        ExecutionTrace trace = mock(ExecutionTrace.class);
+        result.setTrace(trace);
+
+        Map<String, Integer> methodCount = new HashMap<>();
+        methodCount.put("com.example.Foo.bar()V", 1);
+        when(trace.getMethodExecutionCount()).thenReturn(methodCount);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(0.0, fit, 0.001);
+    }
+
+    @Test
+    public void testMethodTraceCoverageFitnessInnerClass() {
+        MethodTraceCoverageTestFitness fitness = new MethodTraceCoverageTestFitness("com.example.Foo.Inner", "bar()V");
+
+        TestCase testCase = new DefaultTestCase();
+        TestChromosome chromosome = new TestChromosome();
+        chromosome.setTestCase(testCase);
+
+        ExecutionResult result = new ExecutionResult(testCase);
+        ExecutionTrace trace = mock(ExecutionTrace.class);
+        result.setTrace(trace);
+
+        Map<String, Integer> methodCount = new HashMap<>();
+        methodCount.put("com.example.Foo$Inner.bar()V", 1);
+        when(trace.getMethodExecutionCount()).thenReturn(methodCount);
+
+        double fit = fitness.getFitness(chromosome, result);
+        Assert.assertEquals(0.0, fit, 0.001);
+    }
+}


### PR DESCRIPTION
This PR refactors the `org.evosuite.coverage.method` package to improve code quality, reduce duplication, and ensure correctness.

Key changes:
1.  **AbstractMethodTestFitness**: Created a base class for `MethodCoverageTestFitness`, `MethodNoExceptionCoverageTestFitness`, and `MethodTraceCoverageTestFitness` to hold common logic (fields, getters, identity methods).
2.  **AbstractMethodCoverageFactory**: Created a base class for factories to centralize the logic for iterating over class members and creating coverage goals. This removes significant code duplication and ensures consistent filtering logic.
3.  **Standardized Filtering**: `MethodTraceCoverageFactory` now uses `TestUsageChecker.canUse()` consistent with other factories, replacing ad-hoc logic.
4.  **Class Loading**: Factories now consistently use `Properties.getTargetClassAndDontInitialise()` to respect the SUT classloader.
5.  **Tests**: Added `MethodCoverageFitnessTest` and `MethodCoverageFactoryTest` to verify the behavior of the fitness functions and factories.

These changes make the code more maintainable and robust.

---
*PR created automatically by Jules for task [10751701914723135820](https://jules.google.com/task/10751701914723135820) started by @gofraser*