### PR TITLE
Refactor BasicBlock IDs and Cleanup CFG Package

### DIFF
--- a/client/src/main/java/org/evosuite/graphs/cfg/ActualControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ActualControlFlowGraph.java
@@ -205,25 +205,6 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
             if (!belongsToMethod(branch))
                 throw new IllegalArgumentException(
                         "branch does not belong to this CFGs method");
-            // if (!branch.isActualBranch()) // TODO this happens if your in a
-            // try-catch ... handle!
-            // throw new IllegalArgumentException(
-            // "unexpected branch byteCode instruction type: "
-            // + branch.getInstructionType());
-
-            // TODO the following doesn't work at this point
-            // because the BranchPool is not yet filled yet
-            // BUT one could fill the pool right now and drop further analysis
-            // later
-            // way cooler, because then filling of the BranchPool is unrelated
-            // to
-            // BranchInstrumentation - then again that instrumentation is needed
-            // anyways i guess
-
-            // if (!BranchPool.isKnownAsBranch(instruction))
-            // throw new IllegalStateException(
-            // "expect BranchPool to know all branching instructions: "
-            // + instruction.toString());
 
             this.branches.add(branch);
         }
@@ -261,9 +242,6 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
 
         computeNodes();
         computeEdges();
-
-        // TODO: Need to make that compatible with Testability Transformation
-        // checkSanity();
 
         addAuxiliaryBlocks();
     }
@@ -358,30 +336,6 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
         if (!addVertex(nodeBlock))
             throw new IllegalStateException(
                     "internal error while addind basic block to CFG");
-
-        // for (BasicBlock test : graph.vertexSet()) {
-        // logger.debug("experimental self-equals on " + test.getName());
-        // if (nodeBlock.equals(test))
-        // logger.debug("true");
-        // else
-        // logger.debug("false");
-        // if (!containsBlock(test))
-        // throw new IllegalStateException("wtf");
-        //
-        // logger.debug("experimental equals on " + test.getName() + " with "
-        // + nodeBlock.getName());
-        // if (test.equals(nodeBlock))
-        // logger.debug("true");
-        // else
-        // logger.debug("false");
-        //
-        // logger.debug("experimental dual-equal");
-        // if (nodeBlock.equals(test))
-        // logger.debug("true");
-        // else
-        // logger.debug("false");
-        //
-        // }
 
         if (!containsVertex(nodeBlock))
             throw new IllegalStateException(

--- a/client/src/main/java/org/evosuite/graphs/cfg/EntryBlock.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/EntryBlock.java
@@ -30,7 +30,7 @@ public class EntryBlock extends BasicBlock {
      * @param methodName a {@link java.lang.String} object.
      */
     public EntryBlock(String className, String methodName) {
-        super(className, methodName);
+        super(className, methodName, -1);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/cfg/ExitBlock.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ExitBlock.java
@@ -30,7 +30,7 @@ public class ExitBlock extends BasicBlock {
      * @param methodName a {@link java.lang.String} object.
      */
     public ExitBlock(String className, String methodName) {
-        super(className, methodName);
+        super(className, methodName, -2);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/cfg/RawControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/RawControlFlowGraph.java
@@ -162,19 +162,9 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                     + target);
             return internalAddEdge(src, target, new ControlFlowEdge(isExceptionEdge));
         }
-        // throw new IllegalStateException(
-        // "expect BranchPool to contain a Branch for each switch-case-label"+src.toString()+" to "+target.toString());
-
-        // TODO there is an inconsistency when it comes to switches with
-        // empty case: blocks. they do not have their own label, so there
-        // can be multiple ControlFlowEdges from the SWITCH instruction to
-        // one LabelNode.
-        // But currently our RawCFG does not permit multiple edges between
-        // two nodes
 
         for (Branch switchCaseBranch : switchCaseBranches) {
 
-            // TODO n^2
             Set<ControlFlowEdge> soFar = incomingEdgesOf(target);
             boolean handled = false;
             for (ControlFlowEdge old : soFar)
@@ -183,22 +173,6 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
             if (handled)
                 continue;
-            /*
-             * previous try to add fake intermediate nodes for each empty case
-             * block to help the CDG - unsuccessful:
-             * if(switchCaseBranches.size()>1) { // // e = new
-             * ControlFlowEdge(isExceptionEdge); //
-             * e.setBranchInstruction(switchCaseBranch); //
-             * e.setBranchExpressionValue(true); // BytecodeInstruction
-             * fakeInstruction =
-             * BytecodeInstructionPool.createFakeInstruction(className
-             * ,methodName); // addVertex(fakeInstruction); //
-             * internalAddEdge(src,fakeInstruction,e); // // e = new
-             * ControlFlowEdge(isExceptionEdge); //
-             * e.setBranchInstruction(switchCaseBranch); //
-             * e.setBranchExpressionValue(true); // // e =
-             * internalAddEdge(fakeInstruction,target,e); // } else {
-             */
 
             ControlDependency cd = new ControlDependency(switchCaseBranch, true);
             ControlFlowEdge e = new ControlFlowEdge(cd, isExceptionEdge);
@@ -214,7 +188,6 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                                             BytecodeInstruction target, ControlFlowEdge e) {
 
         if (!super.addEdge(src, target, e)) {
-            // TODO find out why this still happens
             logger.debug("unable to add edge from " + src.toString() + " to "
                     + target.toString() + " into the rawCFG of " + getMethodName());
             e = super.getEdge(src, target);
@@ -249,8 +222,6 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
     public BasicBlock determineBasicBlockFor(BytecodeInstruction instruction) {
         if (instruction == null)
             throw new IllegalArgumentException("null given");
-
-        // TODO clean this up
 
         logger.debug("creating basic block for " + instruction);
 
@@ -768,9 +739,6 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                 if (GraphPool.getInstance(classLoader).getRawCFG(className,
                         ins.getCalledMethod()) != null)
                     calls.add(ins);
-                // TODO logger.warn or logger.debug
-                // else
-                // System.out.println("false positive call to own classes method: "+ins.toString());
             }
 
         return calls;

--- a/client/src/test/java/org/evosuite/graphs/cfg/BasicBlockTest.java
+++ b/client/src/test/java/org/evosuite/graphs/cfg/BasicBlockTest.java
@@ -1,0 +1,51 @@
+package org.evosuite.graphs.cfg;
+
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.InsnNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class BasicBlockTest {
+
+    @Test
+    public void testIdDeterminism() {
+        String className = "TestClass";
+        String methodName = "testMethod";
+        ClassLoader cl = getClass().getClassLoader();
+
+        BytecodeInstruction i1 = new BytecodeInstruction(cl, className, methodName, 10, 0, new InsnNode(Opcodes.NOP));
+        List<BytecodeInstruction> instructions1 = new ArrayList<>();
+        instructions1.add(i1);
+
+        // Create first block
+        BasicBlock b1 = new BasicBlock(cl, className, methodName, instructions1);
+
+        // Create second block with same content
+        BytecodeInstruction i2 = new BytecodeInstruction(cl, className, methodName, 10, 0, new InsnNode(Opcodes.NOP));
+        List<BytecodeInstruction> instructions2 = new ArrayList<>();
+        instructions2.add(i2);
+        BasicBlock b2 = new BasicBlock(cl, className, methodName, instructions2);
+
+        // Now they should be equal because they have the same ID (10) derived from instruction ID.
+        // Note: BasicBlock.equals() compares ID, className, methodName, and instructions list.
+        // The instructions list contains BytecodeInstruction objects.
+        // BytecodeInstruction.equals() compares className, methodName, instructionId.
+        // So instructions lists should be equal.
+        assertEquals(b1, b2);
+        assertEquals(b1.hashCode(), b2.hashCode());
+    }
+
+    @Test
+    public void testEntryExitBlock() {
+        EntryBlock entry = new EntryBlock("C", "m");
+        ExitBlock exit = new ExitBlock("C", "m");
+
+        // They have different IDs (-1 vs -2) and different isEntry/ExitBlock flags.
+        assertNotEquals(entry, exit);
+    }
+}


### PR DESCRIPTION
Improved the `org.evosuite.graphs.cfg` package by:
1.  **Refactoring `BasicBlock` ID Generation**: Replaced the static `blockCount` with deterministic ID generation based on the first instruction's ID. `EntryBlock` and `ExitBlock` now have fixed IDs (-1 and -2). This resolves non-determinism issues in graph construction and equality checks.
2.  **Fixing Typos**: Renamed `constainsInstruction` to `containsInstruction` in `BasicBlock`.
3.  **Code Cleanup**: Removed extensive dead code, commented-out blocks, and obsolete TODOs in `BasicBlock`, `BytecodeInstruction`, `RawControlFlowGraph`, and `ActualControlFlowGraph`.
4.  **Logging**: Replaced `System.out.println` usage with SLF4J `Logger` in `BytecodeInstruction` and `RawControlFlowGraph`.
5.  **Testing**: Added `BasicBlockTest` to verify deterministic ID generation and equality behavior. Verified existing `CFGMethodAdapterTest` passes.

---
*PR created automatically by Jules for task [2379984850941349380](https://jules.google.com/task/2379984850941349380) started by @gofraser*