### PR TITLE
Refactor testability transformation to use Map for Frames and safe iteration

### DIFF
--- a/client/src/main/java/org/evosuite/instrumentation/testability/ComparisonTransformation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/testability/ComparisonTransformation.java
@@ -66,7 +66,7 @@ public class ComparisonTransformation {
      */
     public void transformMethod(MethodNode mn) {
         AbstractInsnNode node = mn.instructions.getFirst();
-        while (node != mn.instructions.getLast()) {
+        while (node != null) {
             AbstractInsnNode next = node.getNext();
             if (node instanceof InsnNode) {
                 InsnNode in = (InsnNode) node;

--- a/client/src/main/java/org/evosuite/instrumentation/testability/ContainerTransformation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/testability/ContainerTransformation.java
@@ -78,9 +78,9 @@ public class ContainerTransformation {
     @SuppressWarnings("unchecked")
     public boolean transformMethod(MethodNode mn) {
         boolean changed = false;
-        ListIterator<AbstractInsnNode> iterator = mn.instructions.iterator();
-        while (iterator.hasNext()) {
-            AbstractInsnNode node = iterator.next();
+        AbstractInsnNode node = mn.instructions.getFirst();
+        while (node != null) {
+            AbstractInsnNode next = node.getNext();
 
             if (node instanceof MethodInsnNode) {
                 MethodInsnNode methodNode = (MethodInsnNode) node;
@@ -198,6 +198,7 @@ public class ContainerTransformation {
                     }
                 }
             }
+            node = next;
         }
         return changed;
     }

--- a/client/src/main/java/org/evosuite/instrumentation/testability/transformer/BooleanIfTransformer.java
+++ b/client/src/main/java/org/evosuite/instrumentation/testability/transformer/BooleanIfTransformer.java
@@ -57,10 +57,9 @@ public class BooleanIfTransformer extends MethodNodeTransformer {
                 jumpNode.setOpcode(Opcodes.IFGT);
             } else {
                 BooleanTestabilityTransformation.logger.info("Not changing IFNE");
-                int insnPosition = mn.instructions.indexOf(jumpNode);
-                Frame frame = this.booleanTestabilityTransformation.currentFrames[insnPosition];
-                AbstractInsnNode insn = mn.instructions.get(insnPosition - 1);
-                BooleanTestabilityTransformation.logger.info("Current node: " + mn.instructions.get(insnPosition));
+                Frame frame = this.booleanTestabilityTransformation.currentFrames.get(jumpNode);
+                AbstractInsnNode insn = jumpNode.getPrevious();
+                BooleanTestabilityTransformation.logger.info("Current node: " + jumpNode);
                 BooleanTestabilityTransformation.logger.info("Previous node: " + insn);
                 if (insn instanceof MethodInsnNode) {
                     MethodInsnNode mi = (MethodInsnNode) insn;
@@ -86,9 +85,8 @@ public class BooleanIfTransformer extends MethodNodeTransformer {
                 jumpNode.setOpcode(Opcodes.IFLE);
             } else {
                 BooleanTestabilityTransformation.logger.info("Not changing IFEQ");
-                int insnPosition = mn.instructions.indexOf(jumpNode);
-                Frame frame = this.booleanTestabilityTransformation.currentFrames[insnPosition];
-                AbstractInsnNode insn = mn.instructions.get(insnPosition - 1);
+                Frame frame = this.booleanTestabilityTransformation.currentFrames.get(jumpNode);
+                AbstractInsnNode insn = jumpNode.getPrevious();
                 BooleanTestabilityTransformation.logger.info("Previous node: " + insn);
                 if (insn instanceof MethodInsnNode) {
                     MethodInsnNode mi = (MethodInsnNode) insn;


### PR DESCRIPTION
This PR refactors the `org.evosuite.instrumentation.testability` package to address several issues related to bytecode transformation and analysis.

1.  **Instruction-to-Frame Mapping**: Previously, `BooleanTestabilityTransformation` and related transformers used `Frame[]` indexed by instruction position. Modifying the bytecode (inserting/removing instructions) invalidated these indices, leading to incorrect frame lookups (accessing the wrong frame or out-of-bounds). This has been replaced with `Map<AbstractInsnNode, Frame>`, using the instruction object identity as the key, which remains stable during transformation.

2.  **Safe Iteration**: `StringTransformation` and `ContainerTransformation` were iterating over instructions using `ListIterator` or indexed loops while simultaneously modifying the list (removing/inserting nodes). This leads to undefined behavior or skipped instructions. The loops have been refactored to use a safe pattern:
    ```java
    AbstractInsnNode node = list.getFirst();
    while (node != null) {
        AbstractInsnNode next = node.getNext();
        // modify node
        node = next;
    }
    ```

3.  **Edge Case Fixes**: `ComparisonTransformation`'s loop condition `node != list.getLast()` caused the last instruction to be skipped. This has been fixed to `node != null`. `StringTransformation`'s second pass loop now correctly handles dead code (null frames) by skipping instead of breaking, and ensures the last instruction is processed.

4.  **Performance**: Removed $O(N)$ `indexOf` calls inside transformation loops, improving performance for large methods.

Verification:
- `mvn compile -pl client` passed.
- Unit tests in `org.evosuite.instrumentation.testability` passed.

---
*PR created automatically by Jules for task [4148230476693565270](https://jules.google.com/task/4148230476693565270) started by @gofraser*