### PR TITLE
Refactor MaxSizeBloatControl for better testability and encapsulation

### DIFF
--- a/client/src/main/java/org/evosuite/ga/bloatcontrol/BloatControlFunction.java
+++ b/client/src/main/java/org/evosuite/ga/bloatcontrol/BloatControlFunction.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
  *
  * @author Gordon Fraser
  */
+@FunctionalInterface
 public interface BloatControlFunction<T extends Chromosome<T>> extends Serializable {
 
     /**

--- a/client/src/main/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControl.java
+++ b/client/src/main/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControl.java
@@ -31,12 +31,26 @@ public class MaxSizeBloatControl<T extends Chromosome<T>> implements BloatContro
 
     private static final long serialVersionUID = -8241127914702360972L;
 
+    private int maxSize;
+
     public MaxSizeBloatControl() {
-        // empty constructor
+        this.maxSize = Properties.MAX_SIZE;
+    }
+
+    public MaxSizeBloatControl(int maxSize) {
+        this.maxSize = maxSize;
     }
 
     public MaxSizeBloatControl(final MaxSizeBloatControl<?> that) {
-        // empty copy constructor
+        this.maxSize = that.maxSize;
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public void setMaxSize(int maxSize) {
+        this.maxSize = maxSize;
     }
 
     /**
@@ -46,7 +60,7 @@ public class MaxSizeBloatControl<T extends Chromosome<T>> implements BloatContro
      */
     @Override
     public boolean isTooLong(T chromosome) {
-        return chromosome.size() > Properties.MAX_SIZE;
+        return chromosome.size() > maxSize;
     }
 
 }

--- a/client/src/test/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControlTest.java
+++ b/client/src/test/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControlTest.java
@@ -1,0 +1,66 @@
+package org.evosuite.ga.bloatcontrol;
+
+import org.evosuite.Properties;
+import org.evosuite.ga.DummyChromosome;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MaxSizeBloatControlTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        int oldMaxSize = Properties.MAX_SIZE;
+        try {
+            Properties.MAX_SIZE = 50;
+            MaxSizeBloatControl<DummyChromosome> control = new MaxSizeBloatControl<>();
+            assertEquals(50, control.getMaxSize());
+
+            DummyChromosome c1 = new DummyChromosome(new int[50]);
+            assertFalse(control.isTooLong(c1));
+
+            DummyChromosome c2 = new DummyChromosome(new int[51]);
+            assertTrue(control.isTooLong(c2));
+        } finally {
+            Properties.MAX_SIZE = oldMaxSize;
+        }
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        MaxSizeBloatControl<DummyChromosome> control = new MaxSizeBloatControl<>(10);
+        assertEquals(10, control.getMaxSize());
+
+        DummyChromosome c1 = new DummyChromosome(new int[10]);
+        assertFalse(control.isTooLong(c1));
+
+        DummyChromosome c2 = new DummyChromosome(new int[11]);
+        assertTrue(control.isTooLong(c2));
+    }
+
+    @Test
+    public void testCopyConstructor() {
+        MaxSizeBloatControl<DummyChromosome> original = new MaxSizeBloatControl<>(20);
+        MaxSizeBloatControl<DummyChromosome> copy = new MaxSizeBloatControl<>(original);
+
+        assertEquals(20, copy.getMaxSize());
+
+        DummyChromosome c1 = new DummyChromosome(new int[20]);
+        assertFalse(copy.isTooLong(c1));
+
+        DummyChromosome c2 = new DummyChromosome(new int[21]);
+        assertTrue(copy.isTooLong(c2));
+    }
+
+    @Test
+    public void testSetMaxSize() {
+        MaxSizeBloatControl<DummyChromosome> control = new MaxSizeBloatControl<>(10);
+        control.setMaxSize(5);
+        assertEquals(5, control.getMaxSize());
+
+        DummyChromosome c1 = new DummyChromosome(new int[5]);
+        assertFalse(control.isTooLong(c1));
+
+        DummyChromosome c2 = new DummyChromosome(new int[6]);
+        assertTrue(control.isTooLong(c2));
+    }
+}


### PR DESCRIPTION
Refactored `MaxSizeBloatControl` to move away from direct static access of `Properties.MAX_SIZE` in the `isTooLong` method. The class now stores `maxSize` as an instance field, initialized by default to `Properties.MAX_SIZE` but configurable via constructor or setter. This improves testability and encapsulation. Also annotated `BloatControlFunction` with `@FunctionalInterface` and added comprehensive unit tests.

---
*PR created automatically by Jules for task [5896853275366281943](https://jules.google.com/task/5896853275366281943) started by @gofraser*