### PR TITLE
Improve org.evosuite.ga.populationlimit package quality and correctness

### DIFF
--- a/client/src/main/java/org/evosuite/ga/populationlimit/IndividualPopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/IndividualPopulationLimit.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 /**
  * <p>IndividualPopulationLimit class.</p>
+ * <p>
+ * Limits the population size based on the number of individuals.
  *
  * @author Gordon Fraser
  */
@@ -34,7 +36,22 @@ public class IndividualPopulationLimit<T extends Chromosome<T>> implements Popul
 
     private static final long serialVersionUID = -3985726226793280031L;
 
+    private final int limit;
+
+    /**
+     * Constructor using the default population limit from Properties.
+     */
     public IndividualPopulationLimit() {
+        this(Properties.POPULATION);
+    }
+
+    /**
+     * Constructor using a specific population limit.
+     *
+     * @param limit the maximum number of individuals in the population.
+     */
+    public IndividualPopulationLimit(int limit) {
+        this.limit = limit;
     }
 
     /**
@@ -45,9 +62,10 @@ public class IndividualPopulationLimit<T extends Chromosome<T>> implements Popul
      * <p>
      * This constructor shall preserve the current state of the IndividualPopulationLimit (if existing).
      *
-     * @param other
+     * @param other the other limit to copy
      */
     public IndividualPopulationLimit(IndividualPopulationLimit<?> other) {
+        this.limit = other.limit;
     }
 
     /* (non-Javadoc)
@@ -59,7 +77,15 @@ public class IndividualPopulationLimit<T extends Chromosome<T>> implements Popul
      */
     @Override
     public boolean isPopulationFull(List<T> population) {
-        return population.size() >= Properties.POPULATION;
+        return population.size() >= limit;
     }
 
+    /**
+     * Returns the configured limit.
+     *
+     * @return the limit
+     */
+    public int getLimit() {
+        return limit;
+    }
 }

--- a/client/src/main/java/org/evosuite/ga/populationlimit/PopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/PopulationLimit.java
@@ -27,14 +27,17 @@ import java.util.List;
 /**
  * <p>PopulationLimit interface.</p>
  *
+ * Defines a strategy to determine if the population is full.
+ *
+ * @param <T> the type of chromosome
  * @author Gordon Fraser
  */
 public interface PopulationLimit<T extends Chromosome<T>> extends Serializable {
     /**
-     * <p>isPopulationFull</p>
+     * Checks if the population is full according to the implemented strategy.
      *
-     * @param population a {@link java.util.List} object.
-     * @return a boolean.
+     * @param population a {@link java.util.List} of chromosomes representing the current population.
+     * @return true if the population is considered full, false otherwise.
      */
     boolean isPopulationFull(List<T> population);
 }

--- a/client/src/main/java/org/evosuite/ga/populationlimit/SizePopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/SizePopulationLimit.java
@@ -27,6 +27,9 @@ import java.util.List;
 
 /**
  * <p>SizePopulationLimit class.</p>
+ * <p>
+ * Limits the population size based on the sum of the sizes of all individuals (chromosomes) in the population.
+ * The size of a chromosome is determined by {@link Chromosome#size()}.
  *
  * @author fraser
  */
@@ -34,7 +37,22 @@ public class SizePopulationLimit<T extends Chromosome<T>> implements PopulationL
 
     private static final long serialVersionUID = 7978512501601348014L;
 
+    private final int limit;
+
+    /**
+     * Constructor using the default population limit from Properties.
+     */
     public SizePopulationLimit() {
+        this(Properties.POPULATION);
+    }
+
+    /**
+     * Constructor using a specific limit.
+     *
+     * @param limit the maximum allowed sum of sizes of individuals.
+     */
+    public SizePopulationLimit(int limit) {
+        this.limit = limit;
     }
 
     /**
@@ -45,9 +63,10 @@ public class SizePopulationLimit<T extends Chromosome<T>> implements PopulationL
      * <p>
      * This constructor shall preserve the current state of the SizePopulationLimit (if existing).
      *
-     * @param other
+     * @param other the other limit to copy
      */
     public SizePopulationLimit(SizePopulationLimit<?> other) {
+        this.limit = other.limit;
     }
 
     /* (non-Javadoc)
@@ -60,7 +79,15 @@ public class SizePopulationLimit<T extends Chromosome<T>> implements PopulationL
     @Override
     public boolean isPopulationFull(List<T> population) {
         final int size = population.stream().mapToInt(Chromosome::size).sum();
-        return size >= Properties.POPULATION;
+        return size >= limit;
     }
 
+    /**
+     * Returns the configured limit.
+     *
+     * @return the limit
+     */
+    public int getLimit() {
+        return limit;
+    }
 }

--- a/client/src/main/java/org/evosuite/strategy/PropertiesTestGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesTestGAFactory.java
@@ -30,6 +30,9 @@ import org.evosuite.ga.ChromosomeFactory;
 import org.evosuite.ga.FitnessReplacementFunction;
 import org.evosuite.ga.metaheuristics.*;
 import org.evosuite.ga.metaheuristics.mapelites.MAPElites;
+import org.evosuite.ga.populationlimit.IndividualPopulationLimit;
+import org.evosuite.ga.populationlimit.PopulationLimit;
+import org.evosuite.ga.populationlimit.SizePopulationLimit;
 import org.evosuite.ga.metaheuristics.mulambda.MuLambdaEA;
 import org.evosuite.ga.metaheuristics.mulambda.MuPlusLambdaEA;
 import org.evosuite.ga.metaheuristics.mulambda.OnePlusLambdaLambdaGA;
@@ -201,6 +204,19 @@ public class PropertiesTestGAFactory
             case PREFERENCE_SORTING:
             default:
                 return new RankBasedPreferenceSorting<>();
+        }
+    }
+
+    @Override
+    protected PopulationLimit<TestChromosome> getPopulationLimit() {
+        switch (Properties.POPULATION_LIMIT) {
+            case INDIVIDUALS:
+            case TESTS:
+                return new IndividualPopulationLimit<>();
+            case STATEMENTS:
+                return new SizePopulationLimit<>();
+            default:
+                throw new RuntimeException("Unsupported population limit");
         }
     }
 

--- a/client/src/test/java/org/evosuite/ga/populationlimit/PopulationLimitTest.java
+++ b/client/src/test/java/org/evosuite/ga/populationlimit/PopulationLimitTest.java
@@ -1,0 +1,88 @@
+package org.evosuite.ga.populationlimit;
+
+import org.evosuite.Properties;
+import org.evosuite.ga.DummyChromosome;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class PopulationLimitTest {
+
+    @Test
+    public void testIndividualPopulationLimit() {
+        int limit = 5;
+        IndividualPopulationLimit<DummyChromosome> popLimit = new IndividualPopulationLimit<>(limit);
+
+        List<DummyChromosome> population = new ArrayList<>();
+        assertFalse(popLimit.isPopulationFull(population));
+
+        for (int i = 0; i < limit; i++) {
+            population.add(new DummyChromosome(1));
+        }
+
+        assertTrue(popLimit.isPopulationFull(population));
+        assertEquals(limit, popLimit.getLimit());
+    }
+
+    @Test
+    public void testIndividualPopulationLimitDefault() {
+        // Set Properties.POPULATION to a known value
+        int originalPop = Properties.POPULATION;
+        try {
+            Properties.POPULATION = 10;
+            IndividualPopulationLimit<DummyChromosome> popLimit = new IndividualPopulationLimit<>();
+            assertEquals(10, popLimit.getLimit());
+        } finally {
+            Properties.POPULATION = originalPop;
+        }
+    }
+
+    @Test
+    public void testSizePopulationLimit() {
+        int limit = 10;
+        SizePopulationLimit<DummyChromosome> popLimit = new SizePopulationLimit<>(limit);
+
+        List<DummyChromosome> population = new ArrayList<>();
+        assertFalse(popLimit.isPopulationFull(population));
+
+        // Add chromosome of size 4
+        population.add(new DummyChromosome(1, 2, 3, 4));
+        assertFalse(popLimit.isPopulationFull(population));
+
+        // Add chromosome of size 5 (total 9)
+        population.add(new DummyChromosome(1, 2, 3, 4, 5));
+        assertFalse(popLimit.isPopulationFull(population));
+
+        // Add chromosome of size 2 (total 11)
+        population.add(new DummyChromosome(1, 2));
+        assertTrue(popLimit.isPopulationFull(population));
+
+        assertEquals(limit, popLimit.getLimit());
+    }
+
+    @Test
+    public void testSizePopulationLimitDefault() {
+        int originalPop = Properties.POPULATION;
+        try {
+            Properties.POPULATION = 20;
+            SizePopulationLimit<DummyChromosome> popLimit = new SizePopulationLimit<>();
+            assertEquals(20, popLimit.getLimit());
+        } finally {
+            Properties.POPULATION = originalPop;
+        }
+    }
+
+    @Test
+    public void testCopyConstructors() {
+        IndividualPopulationLimit<DummyChromosome> indLimit = new IndividualPopulationLimit<>(7);
+        IndividualPopulationLimit<DummyChromosome> copyInd = new IndividualPopulationLimit<>(indLimit);
+        assertEquals(7, copyInd.getLimit());
+
+        SizePopulationLimit<DummyChromosome> sizeLimit = new SizePopulationLimit<>(15);
+        SizePopulationLimit<DummyChromosome> copySize = new SizePopulationLimit<>(sizeLimit);
+        assertEquals(15, copySize.getLimit());
+    }
+}

--- a/client/src/test/java/org/evosuite/strategy/PropertiesTestGAFactoryTest.java
+++ b/client/src/test/java/org/evosuite/strategy/PropertiesTestGAFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.strategy;
+
+import org.evosuite.Properties;
+import org.evosuite.ga.populationlimit.IndividualPopulationLimit;
+import org.evosuite.ga.populationlimit.PopulationLimit;
+import org.evosuite.ga.populationlimit.SizePopulationLimit;
+import org.evosuite.testcase.TestChromosome;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PropertiesTestGAFactoryTest {
+
+    private static class TestFactory extends PropertiesTestGAFactory {
+        @Override
+        public PopulationLimit<TestChromosome> getPopulationLimit() {
+            return super.getPopulationLimit();
+        }
+    }
+
+    @Test
+    public void testGetPopulationLimit() {
+        TestFactory factory = new TestFactory();
+
+        Properties.POPULATION_LIMIT = Properties.PopulationLimit.INDIVIDUALS;
+        assertTrue(factory.getPopulationLimit() instanceof IndividualPopulationLimit);
+
+        Properties.POPULATION_LIMIT = Properties.PopulationLimit.TESTS;
+        assertTrue(factory.getPopulationLimit() instanceof IndividualPopulationLimit);
+
+        Properties.POPULATION_LIMIT = Properties.PopulationLimit.STATEMENTS;
+        assertTrue(factory.getPopulationLimit() instanceof SizePopulationLimit);
+    }
+}


### PR DESCRIPTION
This PR refactors the `org.evosuite.ga.populationlimit` package to improve code quality and correctness. 

Key changes:
1.  **Decoupling from Global State**: `IndividualPopulationLimit` and `SizePopulationLimit` now have constructors that accept an explicit limit. This allows them to be tested and used without relying on the global static `Properties.POPULATION` variable, although default constructors still use `Properties.POPULATION` for backward compatibility.
2.  **Correct Mapping in Factory**: `PropertiesTestGAFactory` was updated to correctly interpret `Properties.POPULATION_LIMIT` settings. Previously, it mapped `TESTS` to `SizePopulationLimit` (which checks total statements for TestChromosomes), which was confusing. Now `TESTS` maps to `IndividualPopulationLimit` (limiting the number of tests) and `STATEMENTS` maps to `SizePopulationLimit` (limiting the total size/statements).
3.  **Documentation**: Added Javadocs to the classes and interface.
4.  **Testing**: Added `PopulationLimitTest` and `PropertiesTestGAFactoryTest` to verify the behavior and factory logic.

---
*PR created automatically by Jules for task [2365028811074453080](https://jules.google.com/task/2365028811074453080) started by @gofraser*