### PR TITLE
Improve org.evosuite.ga.comparators correctness and quality

### DIFF
--- a/client/src/main/java/org/evosuite/ga/comparators/DominanceComparator.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/DominanceComparator.java
@@ -80,11 +80,12 @@ public class DominanceComparator<T extends Chromosome<T>> implements Comparator<
         boolean dominate1 = false;
         boolean dominate2 = false;
 
-        if (this.objectives == null) {
-            this.objectives = new LinkedHashSet<>(c1.getFitnessValues().keySet());
+        Set<FitnessFunction<T>> objectivesToUse = this.objectives;
+        if (objectivesToUse == null) {
+            objectivesToUse = c1.getFitnessValues().keySet();
         }
 
-        for (FitnessFunction<T> ff : this.objectives) {
+        for (FitnessFunction<T> ff : objectivesToUse) {
             int flag = Double.compare(c1.getFitness(ff), c2.getFitness(ff));
 
             if (flag < 0) {

--- a/client/src/main/java/org/evosuite/ga/comparators/OnlyCrowdingComparator.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/OnlyCrowdingComparator.java
@@ -63,6 +63,11 @@ public class OnlyCrowdingComparator<T extends Chromosome<T>> implements Comparat
      */
     @Override
     public int compare(T c1, T c2) {
+        if (c1 == null) {
+            return 1;
+        } else if (c2 == null) {
+            return -1;
+        }
         return Double.compare(c2.getDistance(), c1.getDistance());
     }
 }

--- a/client/src/main/java/org/evosuite/ga/comparators/PreferenceSortingComparator.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/PreferenceSortingComparator.java
@@ -84,13 +84,13 @@ public class PreferenceSortingComparator<T extends Chromosome<T>> implements Com
         double value1, value2;
         value1 = solution1.getFitness(this.objective);
         value2 = solution2.getFitness(this.objective);
-        if (value1 < value2) {
-            return -1;
-        } else if (value1 > value2) {
-            return +1;
-        } else {
-            return solution1.compareSecondaryObjective(solution2);
+
+        int comparison = Double.compare(value1, value2);
+        if (comparison != 0) {
+            return comparison;
         }
+
+        return solution1.compareSecondaryObjective(solution2);
     }
 }
 

--- a/client/src/main/java/org/evosuite/ga/comparators/RankAndCrowdingDistanceComparator.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/RankAndCrowdingDistanceComparator.java
@@ -35,12 +35,14 @@ public class RankAndCrowdingDistanceComparator<T extends Chromosome<T>> implemen
 
     private static final long serialVersionUID = -1663917547588039444L;
 
+    @Deprecated
     private boolean isToMaximize;
 
     public RankAndCrowdingDistanceComparator() {
         this.isToMaximize = false;
     }
 
+    @Deprecated
     public RankAndCrowdingDistanceComparator(boolean maximize) {
         this.isToMaximize = maximize;
     }
@@ -70,25 +72,16 @@ public class RankAndCrowdingDistanceComparator<T extends Chromosome<T>> implemen
             return 0;
         }
 
-        if (this.isToMaximize) {
-            if (c1.getRank() < c2.getRank()) {
-                return 1;
-            } else if (c1.getRank() > c2.getRank()) {
-                return -1;
-            } else if (c1.getRank() == c2.getRank()) {
-                return (c1.getDistance() > c2.getDistance()) ? -1 : 1;
-            }
-        } else {
-            if (c1.getRank() < c2.getRank()) {
-                return -1;
-            } else if (c1.getRank() > c2.getRank()) {
-                return 1;
-            } else if (c1.getRank() == c2.getRank()) {
-                return (c1.getDistance() > c2.getDistance()) ? -1 : 1;
-            }
+        // Rank 0 is always the best (non-dominated front), so we always minimize rank
+        if (c1.getRank() < c2.getRank()) {
+            return -1;
+        } else if (c1.getRank() > c2.getRank()) {
+            return 1;
         }
 
-        return 0;
+        // If ranks are equal, we check crowding distance
+        // Higher crowding distance is better (more diversity), so we sort descending
+        return Double.compare(c2.getDistance(), c1.getDistance());
     }
 
     /**
@@ -96,6 +89,7 @@ public class RankAndCrowdingDistanceComparator<T extends Chromosome<T>> implemen
      *
      * @param max a boolean.
      */
+    @Deprecated
     public void setMaximize(boolean max) {
         this.isToMaximize = max;
     }

--- a/client/src/main/java/org/evosuite/ga/comparators/SortByFitness.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/SortByFitness.java
@@ -54,11 +54,11 @@ public class SortByFitness<T extends Chromosome<T>> implements Comparator<T>, Se
         else if (c2 == null)
             return -1;
 
-        double objetive1 = c1.getFitness(this.ff);
-        double objetive2 = c2.getFitness(this.ff);
+        double objective1 = c1.getFitness(this.ff);
+        double objective2 = c2.getFitness(this.ff);
 
         return this.order
-                ? Double.compare(objetive2, objetive1)
-                : Double.compare(objetive1, objetive2);
+                ? Double.compare(objective2, objective1)
+                : Double.compare(objective1, objective2);
     }
 }

--- a/client/src/main/java/org/evosuite/ga/comparators/StrengthFitnessComparator.java
+++ b/client/src/main/java/org/evosuite/ga/comparators/StrengthFitnessComparator.java
@@ -25,7 +25,10 @@ import java.io.Serializable;
 import java.util.Comparator;
 
 /**
- * StrengthFitnessComparator class.
+ * Comparator based on the "strength" value of chromosomes.
+ * <p>
+ * This is primarily used in SPEA2. Note that the strength value (fitness + density)
+ * is stored in the {@link Chromosome#getDistance()} field.
  *
  * @author José Campos
  */
@@ -43,7 +46,8 @@ public class StrengthFitnessComparator implements Comparator<Chromosome<?>>, Ser
             return -1;
         }
 
-        double strengthC1 = c1.getDistance(); // TODO: should we change name of the function?
+        // Note: In SPEA2, the strength value is stored in the distance field of the chromosome.
+        double strengthC1 = c1.getDistance();
         double strengthC2 = c2.getDistance();
 
         return Double.compare(strengthC1, strengthC2);

--- a/client/src/test/java/org/evosuite/ga/comparators/RankAndCrowdingDistanceComparatorTest.java
+++ b/client/src/test/java/org/evosuite/ga/comparators/RankAndCrowdingDistanceComparatorTest.java
@@ -1,0 +1,45 @@
+package org.evosuite.ga.comparators;
+
+import org.evosuite.testcase.TestChromosome;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class RankAndCrowdingDistanceComparatorTest {
+
+    @Test
+    public void testMaximizeTruePreferLowerRank() {
+        TestChromosome c1 = new TestChromosome();
+        c1.setRank(0); // Better
+        c1.setDistance(0.0);
+
+        TestChromosome c2 = new TestChromosome();
+        c2.setRank(1); // Worse
+        c2.setDistance(0.0);
+
+        // maximize=true simulates usage in TournamentSelectionRankAndCrowdingDistanceComparator
+        RankAndCrowdingDistanceComparator<TestChromosome> comparator = new RankAndCrowdingDistanceComparator<>(true);
+
+        // We expect c1 to be better than c2.
+        // comparator.compare(c1, c2) should be < 0.
+        int result = comparator.compare(c1, c2);
+
+        // This assertion fails with current implementation
+        assertTrue("Rank 0 should be preferred over Rank 1 even when maximizing fitness. Result was: " + result, result < 0);
+    }
+
+    @Test
+    public void testMaximizeFalsePreferLowerRank() {
+        TestChromosome c1 = new TestChromosome();
+        c1.setRank(0); // Better
+        c1.setDistance(0.0);
+
+        TestChromosome c2 = new TestChromosome();
+        c2.setRank(1); // Worse
+        c2.setDistance(0.0);
+
+        RankAndCrowdingDistanceComparator<TestChromosome> comparator = new RankAndCrowdingDistanceComparator<>(false);
+
+        int result = comparator.compare(c1, c2);
+        assertTrue("Rank 0 should be preferred over Rank 1", result < 0);
+    }
+}

--- a/master/src/main/java/org/evosuite/statistics/backend/HTMLStatisticsBackend.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/HTMLStatisticsBackend.java
@@ -300,7 +300,7 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
             int linecount = 1;
             String code = null;
             if (testChromosome.getLastExecutionResult() != null) {
-                code = test.toCode(testChromosome.getLastExecutionResult().exposeExceptionMapping());
+                code = test.toCode(testChromosome.getLastExecutionResult().getCopyOfExceptionMapping());
             } else
                 code = test.toCode();
 

--- a/master/src/test/java/org/evosuite/ga/comparators/TestCrowdingComparator.java
+++ b/master/src/test/java/org/evosuite/ga/comparators/TestCrowdingComparator.java
@@ -93,13 +93,13 @@ public class TestCrowdingComparator {
         population.sort(cc);
 
         // assert by Rank
-        Assert.assertEquals(1, population.get(0).getRank());
+        Assert.assertEquals(0, population.get(0).getRank());
         Assert.assertEquals(0, population.get(1).getRank());
-        Assert.assertEquals(0, population.get(2).getRank());
+        Assert.assertEquals(1, population.get(2).getRank());
 
         // assert by Distance
-        Assert.assertEquals(0.1, population.get(0).getDistance(), 0.0);
-        Assert.assertEquals(0.5, population.get(1).getDistance(), 0.0);
-        Assert.assertEquals(0.4, population.get(2).getDistance(), 0.0);
+        Assert.assertEquals(0.5, population.get(0).getDistance(), 0.0);
+        Assert.assertEquals(0.4, population.get(1).getDistance(), 0.0);
+        Assert.assertEquals(0.1, population.get(2).getDistance(), 0.0);
     }
 }

--- a/master/src/test/java/org/evosuite/ga/comparators/TestRankAndCrowdingDistanceComparator.java
+++ b/master/src/test/java/org/evosuite/ga/comparators/TestRankAndCrowdingDistanceComparator.java
@@ -126,7 +126,7 @@ public class TestRankAndCrowdingDistanceComparator {
         RankAndCrowdingDistanceComparator<TestChromosome> comparator =
                 new RankAndCrowdingDistanceComparator<>(true);
         double result = comparator.compare(tch1, tch2);
-        assertEquals(+1, result, 0.00001);
+        assertEquals(-1, result, 0.00001);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class TestRankAndCrowdingDistanceComparator {
         RankAndCrowdingDistanceComparator<TestChromosome> comparator =
                 new RankAndCrowdingDistanceComparator<>(true);
         double result = comparator.compare(tch1, tch2);
-        assertEquals(-1, result, 0.00001);
+        assertEquals(+1, result, 0.00001);
     }
 
     @Test


### PR DESCRIPTION
This PR addresses several issues in `org.evosuite.ga.comparators`:
1.  **Correctness Fix in `RankAndCrowdingDistanceComparator`**: Previously, when `maximize=true` was set (which is the default for `TournamentSelection`), the comparator inverted the rank comparison logic, preferring higher ranks (worse individuals). This has been fixed to always minimize Rank (Rank 0 is best) while maximizing Crowding Distance. The `isToMaximize` field and methods have been deprecated.
2.  **Null Safety**: Added null checks to `OnlyCrowdingComparator` to prevent NPEs.
3.  **Code Quality**: `DominanceComparator` no longer modifies its state lazily based on the first chromosome encountered, which improves thread safety and reusability. It now uses a local set of objectives if not initialized.
4.  **Readability**: Fixed typo in `SortByFitness` (`objetive` -> `objective`). Updated Javadoc in `StrengthFitnessComparator` to clarify `getDistance()` usage.
5.  **Build Fix**: Fixed a compilation error in `HTMLStatisticsBackend` in `master` module caused by a missing method in `ExecutionResult` (replaced with `getCopyOfExceptionMapping`).
6.  **Tests**: Updated `TestRankAndCrowdingDistanceComparator` and `TestCrowdingComparator` in `master` to reflect the correct sorting behavior. Added `RankAndCrowdingDistanceComparatorTest` in `client` to verify the fix.

---
*PR created automatically by Jules for task [13243082998812302647](https://jules.google.com/task/13243082998812302647) started by @gofraser*