### PR TITLE
Refactor instrumentation coverage classes

### DIFF
--- a/client/src/main/java/org/evosuite/instrumentation/coverage/BranchInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/coverage/BranchInstrumentation.java
@@ -154,11 +154,7 @@ public class BranchInstrumentation implements MethodInstrumentation {
             case Opcodes.IFGT:
             case Opcodes.IFLE:
                 instrumentation.add(new InsnNode(Opcodes.DUP));
-                instrumentation.add(new LdcInsnNode(opcode));
-                instrumentation.add(new LdcInsnNode(branchId));
-                instrumentation.add(new LdcInsnNode(instructionId));
-                instrumentation.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-                        EXECUTION_TRACER, "passedBranch", "(IIII)V", false));
+                addPassedBranchCall(instrumentation, opcode, branchId, instructionId, "(IIII)V");
                 logger.debug("Adding passedBranch val=?, opcode=" + opcode + ", branch="
                         + branchId + ", bytecode_id=" + instructionId);
 
@@ -170,34 +166,29 @@ public class BranchInstrumentation implements MethodInstrumentation {
             case Opcodes.IF_ICMPGT:
             case Opcodes.IF_ICMPLE:
                 instrumentation.add(new InsnNode(Opcodes.DUP2));
-                instrumentation.add(new LdcInsnNode(opcode));
-                instrumentation.add(new LdcInsnNode(branchId));
-                instrumentation.add(new LdcInsnNode(instructionId));
-                instrumentation.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-                        EXECUTION_TRACER, "passedBranch", "(IIIII)V", false));
+                addPassedBranchCall(instrumentation, opcode, branchId, instructionId, "(IIIII)V");
                 break;
             case Opcodes.IF_ACMPEQ:
             case Opcodes.IF_ACMPNE:
                 instrumentation.add(new InsnNode(Opcodes.DUP2));
-                instrumentation.add(new LdcInsnNode(opcode));
-                instrumentation.add(new LdcInsnNode(branchId));
-                instrumentation.add(new LdcInsnNode(instructionId));
-                instrumentation.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-                        EXECUTION_TRACER, "passedBranch",
-                        "(Ljava/lang/Object;Ljava/lang/Object;III)V", false));
+                addPassedBranchCall(instrumentation, opcode, branchId, instructionId,
+                        "(Ljava/lang/Object;Ljava/lang/Object;III)V");
                 break;
             case Opcodes.IFNULL:
             case Opcodes.IFNONNULL:
                 instrumentation.add(new InsnNode(Opcodes.DUP));
-                instrumentation.add(new LdcInsnNode(opcode));
-                instrumentation.add(new LdcInsnNode(branchId));
-                instrumentation.add(new LdcInsnNode(instructionId));
-                instrumentation.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
-                        EXECUTION_TRACER, "passedBranch",
-                        "(Ljava/lang/Object;III)V", false));
+                addPassedBranchCall(instrumentation, opcode, branchId, instructionId,
+                        "(Ljava/lang/Object;III)V");
                 break;
         }
         return instrumentation;
+    }
+
+    private void addPassedBranchCall(InsnList instrumentation, int opcode, int branchId, int instructionId, String descriptor) {
+        instrumentation.add(new LdcInsnNode(opcode));
+        instrumentation.add(new LdcInsnNode(branchId));
+        instrumentation.add(new LdcInsnNode(instructionId));
+        instrumentation.add(new MethodInsnNode(Opcodes.INVOKESTATIC, EXECUTION_TRACER, "passedBranch", descriptor, false));
     }
 
     /**

--- a/client/src/main/java/org/evosuite/instrumentation/coverage/DefUseInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/coverage/DefUseInstrumentation.java
@@ -76,15 +76,16 @@ public class DefUseInstrumentation implements MethodInstrumentation {
             instructionMap.put(v.getASMNode(), v);
         }
 
+        boolean shouldInstrument = ArrayUtil.contains(Properties.CRITERION, Criterion.DEFUSE)
+                || ArrayUtil.contains(Properties.CRITERION, Criterion.ALLDEFS);
+
         Iterator<AbstractInsnNode> j = mn.instructions.iterator();
         while (j.hasNext()) {
             AbstractInsnNode in = j.next();
             BytecodeInstruction v = instructionMap.get(in);
 
             if (v != null) {
-                if ((ArrayUtil.contains(Properties.CRITERION, Criterion.DEFUSE)
-                        || ArrayUtil.contains(Properties.CRITERION, Criterion.ALLDEFS))
-                        && v.isDefUse()) {
+                if (shouldInstrument && v.isDefUse()) {
 
                     boolean isValidDU = false;
 

--- a/client/src/main/java/org/evosuite/instrumentation/coverage/MethodInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/coverage/MethodInstrumentation.java
@@ -35,14 +35,15 @@ public interface MethodInstrumentation {
      * analyze
      * </p>
      *
-     * @param mn         the ASM Node of the method
-     * @param className  the name of current class
-     * @param methodName the name of the current method. This name includes the
-     *                   description of the method and is therefore unique per class.
-     * @param access     the access of the current method (see
-     *                   org.objectweb.asm.ClassAdapter#visitMethod(int access, String
-     *                   name, String descriptor, String signature, String[]
-     *                   exceptions))
+     * @param classLoader the class loader used to resolve classes
+     * @param mn          the ASM Node of the method
+     * @param className   the name of current class
+     * @param methodName  the name of the current method. This name includes the
+     *                    description of the method and is therefore unique per class.
+     * @param access      the access of the current method (see
+     *                    org.objectweb.asm.ClassAdapter#visitMethod(int access, String
+     *                    name, String descriptor, String signature, String[]
+     *                    exceptions))
      */
     void analyze(ClassLoader classLoader, MethodNode mn, String className,
                  String methodName, int access);
@@ -51,7 +52,7 @@ public interface MethodInstrumentation {
      * If this method returns true, the analyze method is also called on public
      * static void main() methods
      *
-     * @return a boolean.
+     * @return true if this instrumentation should also be applied to public static void main() methods.
      */
     boolean executeOnMainMethod();
 
@@ -59,7 +60,7 @@ public interface MethodInstrumentation {
      * if this method returns true the analyze method is also called on methods
      * which are excluded in CFGMethodAdapter.EXCLUDE
      *
-     * @return a boolean.
+     * @return true if this instrumentation should also be applied to methods that are usually excluded.
      */
     boolean executeOnExcludedMethods();
 

--- a/client/src/main/java/org/evosuite/instrumentation/coverage/MutationInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/coverage/MutationInstrumentation.java
@@ -133,7 +133,7 @@ public class MutationInstrumentation implements MethodInstrumentation {
         int frameIndex = 0;
         int numMutants = 0;
         if (frames.length != mn.instructions.size()) {
-            logger.error("Number of frames does not match number number of bytecode instructions: "
+            logger.error("Number of frames does not match number of bytecode instructions: "
                     + frames.length + "/" + mn.instructions.size());
             logger.error("Skipping mutation of method " + className + "." + methodName);
             return;
@@ -180,7 +180,6 @@ public class MutationInstrumentation implements MethodInstrumentation {
 
             BytecodeInstruction v = instructionMap.get(in);
             if (v != null) {
-                logger.info(v.toString());
                 List<Mutation> mutations = new LinkedList<>();
 
                 // TODO: More than one mutation operator might apply to the same instruction
@@ -192,7 +191,7 @@ public class MutationInstrumentation implements MethodInstrumentation {
                     }
 
                     if (mutationOperator.isApplicable(v)) {
-                        logger.info("Applying mutation operator "
+                        logger.debug("Applying mutation operator "
                                 + mutationOperator.getClass().getSimpleName());
                         List<Mutation> applied = mutationOperator.apply(mn, className,
                                 methodName, v,
@@ -202,7 +201,7 @@ public class MutationInstrumentation implements MethodInstrumentation {
                     }
                 }
                 if (!mutations.isEmpty()) {
-                    logger.info("Adding instrumentation for mutation");
+                    logger.debug("Adding instrumentation for mutation");
                     addInstrumentation(mn, in, mutations);
                 }
             }
@@ -211,16 +210,7 @@ public class MutationInstrumentation implements MethodInstrumentation {
             }
         }
 
-        j = mn.instructions.iterator();
-
-        logger.info("Result of mutation: ");
-        while (j.hasNext()) {
-            AbstractInsnNode in = j.next();
-            logger.info(new BytecodeInstruction(classLoader, className, methodName, 0, 0,
-                    in).toString());
-        }
         logger.info("Done.");
-        // mn.maxStack += 3;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This PR improves the code quality and readability of the `org.evosuite.instrumentation.coverage` package.

Key changes:
1.  **`DefUseInstrumentation.java`**: Optimized the main loop by moving the `Properties.CRITERION` check outside.
2.  **`MutationInstrumentation.java`**: Removed dead code (commented out stack increment), fixed a typo in a log message, and reduced logging verbosity by changing `INFO` logs to `DEBUG` inside loops.
3.  **`BranchInstrumentation.java`**: Refactored the `getInstrumentation` method to use a helper method `addPassedBranchCall`, reducing duplicate code for `passedBranch` method calls.
4.  **`MethodInstrumentation.java`**: Updated Javadoc to be more precise and informative.

---
*PR created automatically by Jules for task [6096390513610616993](https://jules.google.com/task/6096390513610616993) started by @gofraser*