### PR TITLE
Refactor instrumentation package for code quality and correctness

### DIFF
--- a/client/src/main/java/org/evosuite/instrumentation/testability/ComparisonTransformation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/testability/ComparisonTransformation.java
@@ -25,8 +25,6 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
-import java.util.List;
-
 /**
  * <p>ComparisonTransformation class.</p>
  *
@@ -50,10 +48,8 @@ public class ComparisonTransformation {
      *
      * @return a {@link org.objectweb.asm.tree.ClassNode} object.
      */
-    @SuppressWarnings("unchecked")
     public ClassNode transform() {
-        List<MethodNode> methodNodes = cn.methods;
-        for (MethodNode mn : methodNodes) {
+        for (MethodNode mn : cn.methods) {
             transformMethod(mn);
         }
         return cn;

--- a/client/src/main/java/org/evosuite/instrumentation/testability/transformer/BooleanIfTransformer.java
+++ b/client/src/main/java/org/evosuite/instrumentation/testability/transformer/BooleanIfTransformer.java
@@ -57,7 +57,7 @@ public class BooleanIfTransformer extends MethodNodeTransformer {
                 jumpNode.setOpcode(Opcodes.IFGT);
             } else {
                 BooleanTestabilityTransformation.logger.info("Not changing IFNE");
-                Frame frame = this.booleanTestabilityTransformation.currentFrames.get(jumpNode);
+                Frame frame = this.booleanTestabilityTransformation.getFrame(jumpNode);
                 AbstractInsnNode insn = jumpNode.getPrevious();
                 BooleanTestabilityTransformation.logger.info("Current node: " + jumpNode);
                 BooleanTestabilityTransformation.logger.info("Previous node: " + insn);
@@ -85,7 +85,7 @@ public class BooleanIfTransformer extends MethodNodeTransformer {
                 jumpNode.setOpcode(Opcodes.IFLE);
             } else {
                 BooleanTestabilityTransformation.logger.info("Not changing IFEQ");
-                Frame frame = this.booleanTestabilityTransformation.currentFrames.get(jumpNode);
+                Frame frame = this.booleanTestabilityTransformation.getFrame(jumpNode);
                 AbstractInsnNode insn = jumpNode.getPrevious();
                 BooleanTestabilityTransformation.logger.info("Previous node: " + insn);
                 if (insn instanceof MethodInsnNode) {


### PR DESCRIPTION
This PR refactors classes in `org.evosuite.instrumentation.testability` to address code quality and correctness issues.

Key changes:
1.  **Refactoring of `BooleanTestabilityTransformation`**:
    *   Made `currentFrames` private and added a `getFrame()` accessor.
    *   Refactored the complex `isBooleanAssignment` method into smaller, more readable helper methods (`checkFieldAssignment`, `checkVariableAssignment`, etc.).
    *   Removed commented-out dead code.
    *   Improved exception logging to include stack traces.
    *   Addressed raw type usage by leveraging ASM 9 generics.

2.  **Update `BooleanIfTransformer`**:
    *   Updated to use the new public `getFrame()` method instead of accessing the now private `currentFrames` field.

3.  **Refactoring of `ComparisonTransformation`**:
    *   Removed unnecessary `@SuppressWarnings("unchecked")` annotations.
    *   Simplified method iteration using enhanced for-loop on `cn.methods`.

4.  **Refactoring of `StringTransformation`**:
    *   Introduced constants for repeated string literals (e.g., "java/lang/String").
    *   Improved exception handling to properly log stack traces.
    *   Removed `@SuppressWarnings("unchecked")`.
    *   Added null check in `isStringMethod`.

Verification:
*   Ran `TestTestabilityTransformation`, `TestDoubleFloatComparison`, `TestLongComparison`, and `StringHelperTest`. All tests passed.

---
*PR created automatically by Jules for task [17419980337269003874](https://jules.google.com/task/17419980337269003874) started by @gofraser*