### PR TITLE
Refactor error instrumentation package

### DIFF
--- a/client/src/main/java/org/evosuite/instrumentation/error/CastErrorInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/error/CastErrorInstrumentation.java
@@ -33,22 +33,24 @@ public class CastErrorInstrumentation extends ErrorBranchInstrumenter {
 
         if (opcode == Opcodes.CHECKCAST) {
             Label origTarget = new Label();
-            // Label origTarget = new AnnotatedLabel();
-            // origTarget.info = Boolean.FALSE;
+
             mv.visitInsn(Opcodes.DUP);
-            mv.tagBranch();
+            tagBranchStart();
             mv.visitJumpInsn(Opcodes.IFNULL, origTarget);
+
             mv.visitInsn(Opcodes.DUP);
             mv.visitTypeInsn(Opcodes.INSTANCEOF, type);
-            mv.tagBranch();
+            tagBranchStart();
             mv.visitJumpInsn(Opcodes.IFNE, origTarget);
+
             mv.visitTypeInsn(Opcodes.NEW, "java/lang/ClassCastException");
             mv.visitInsn(Opcodes.DUP);
             mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/ClassCastException",
                     "<init>", "()V", false);
             mv.visitInsn(Opcodes.ATHROW);
+
             mv.visitLabel(origTarget);
-            mv.tagBranchExit();
+            tagBranchEnd();
         }
     }
 }

--- a/client/src/main/java/org/evosuite/instrumentation/error/VectorInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/error/VectorInstrumentation.java
@@ -51,11 +51,11 @@ public class VectorInstrumentation extends ErrorBranchInstrumenter {
                 // empty
                 Map<Integer, Integer> tempVariables = getMethodCallee(desc);
 
-                //tagBranchStart();
+                tagBranchStart();
                 mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, VECTORNAME,
                         "isEmpty", "()Z", false);
                 insertBranch(Opcodes.IFLE, "java/util/NoSuchElementException");
-                // tagBranchEnd();
+                tagBranchEnd();
                 restoreMethodParameters(tempVariables, desc);
 
             } else if (indexListMethods.contains(name)) {

--- a/client/src/test/java/org/evosuite/instrumentation/error/TestErrorInstrumentation.java
+++ b/client/src/test/java/org/evosuite/instrumentation/error/TestErrorInstrumentation.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.instrumentation.error;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import static org.mockito.Mockito.*;
+
+public class TestErrorInstrumentation {
+
+    private ErrorConditionMethodAdapter mv;
+    private NullPointerExceptionInstrumentation npeInstrumentation;
+
+    @Before
+    public void setUp() {
+        mv = mock(ErrorConditionMethodAdapter.class);
+        npeInstrumentation = new NullPointerExceptionInstrumentation(mv);
+        // Default behavior for newLocal to return some index
+        when(mv.newLocal(any(Type.class))).thenReturn(1);
+        when(mv.getMethodName()).thenReturn("testMethod");
+    }
+
+    @Test
+    public void testInvokeVirtualAddsNullCheck() {
+        String owner = "java/lang/String";
+        String name = "length";
+        String desc = "()I";
+
+        npeInstrumentation.visitMethodInsn(Opcodes.INVOKEVIRTUAL, owner, name, desc, false);
+
+        // Verify that we duplicated the callee (on stack)
+        // Since length() takes no args, getMethodCallee just duplicates.
+        verify(mv).dup();
+
+        // Verify branch insertion (IFNONNULL)
+        verify(mv).tagBranch();
+        verify(mv).visitJumpInsn(eq(Opcodes.IFNONNULL), any());
+    }
+
+    @Test
+    public void testInvokeSpecialAddsNullCheck() {
+        String owner = "java/util/ArrayList";
+        String name = "privateMethod";
+        String desc = "()V";
+
+        npeInstrumentation.visitMethodInsn(Opcodes.INVOKESPECIAL, owner, name, desc, false);
+
+        verify(mv).dup();
+        verify(mv).tagBranch();
+        verify(mv).visitJumpInsn(eq(Opcodes.IFNONNULL), any());
+    }
+
+    @Test
+    public void testInvokeSpecialInitDoesNotAddNullCheck() {
+        String owner = "java/util/ArrayList";
+        String name = "<init>";
+        String desc = "()V";
+
+        npeInstrumentation.visitMethodInsn(Opcodes.INVOKESPECIAL, owner, name, desc, false);
+
+        // Should not duplicate or tag branch
+        verify(mv, never()).dup();
+        verify(mv, never()).tagBranch();
+    }
+}


### PR DESCRIPTION
Refactored `org.evosuite.instrumentation.error` package to improve correctness, code quality, and readability.

Key changes:
1.  **NullPointerExceptionInstrumentation**: Refactored to use the helper method `getMethodCallee` for stack manipulation, reducing code duplication. Added support for `INVOKESPECIAL` (excluding constructors) to instrument private method calls and super calls. Added comments for `PUTFIELD` stack manipulation.
2.  **CastErrorInstrumentation**: Fixed inconsistent branch tagging where `tagBranch` was called twice for the same logical branch exit.
3.  **VectorInstrumentation**: Uncommented `tagBranchStart` and `tagBranchEnd` to ensure consistent branch instrumentation with other classes.
4.  **ErrorConditionChecker**: Fixed the logic for `overflowDistance` and `underflowDistance` for `long` multiplication. The previous logic was returning incorrect distance values (e.g., 1) for safe negative results due to incorrect usage of `scaleTo` with `HALFWAY`. Restored `double` overloads for distance methods that were accidentally omitted in previous edits.
5.  **TestErrorInstrumentation**: Added a new unit test class to verify that `NullPointerExceptionInstrumentation` correctly instruments method calls.

Verified by running all tests in `org.evosuite.instrumentation.error` package.

---
*PR created automatically by Jules for task [2326277118614712782](https://jules.google.com/task/2326277118614712782) started by @gofraser*