### PR TITLE
Fix LinkedListInstrumentation failure by enabling correct instrumentation

### DIFF
--- a/client/src/main/java/org/evosuite/instrumentation/error/ErrorConditionMethodAdapter.java
+++ b/client/src/main/java/org/evosuite/instrumentation/error/ErrorConditionMethodAdapter.java
@@ -82,10 +82,10 @@ public class ErrorConditionMethodAdapter extends GeneratorAdapter {
         instrumentation = new ArrayList<>();
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.ARRAY))
             instrumentation.add(new ArrayInstrumentation(this));
-        if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.LIST))
+        if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.LIST)) {
             instrumentation.add(new ListInstrumentation(this));
-		/*if(ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.ARRAYLIST))
-			instrumentation.add(new ArrayListInstrumentation(this));*/
+            instrumentation.add(new LinkedListInstrumentation(this));
+        }
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.CAST))
             instrumentation.add(new CastErrorInstrumentation(this));
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.DEQUE))
@@ -95,8 +95,6 @@ public class ErrorConditionMethodAdapter extends GeneratorAdapter {
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.LINKEDHASHSET))
             instrumentation.add(new LinkedHashSetInstrumentation(this));
         // instrumentation.add(new ListInstrumentation(this));
-		/*if(ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.LINKEDLIST))
-			instrumentation.add(new LinkedListInstrumentation(this));*/
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.NPE))
             instrumentation.add(new NullPointerExceptionInstrumentation(this));
         if (ArrayUtil.contains(Properties.ERROR_INSTRUMENTATION, Properties.ErrorInstrumentation.OVERFLOW))

--- a/client/src/main/java/org/evosuite/instrumentation/error/LinkedListInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/error/LinkedListInstrumentation.java
@@ -33,8 +33,6 @@ public class LinkedListInstrumentation extends ErrorBranchInstrumenter {
 
     private final List<String> emptyListMethods = Arrays.asList("getFirst", "getLast", "removeFirst", "removeLast", "element", "pop");
 
-    private final List<String> indexListMethods = Arrays.asList("get", "set", "add", "remove", "listIterator", "addAll");
-
     public LinkedListInstrumentation(ErrorConditionMethodAdapter mv) {
         super(mv);
     }
@@ -55,28 +53,6 @@ public class LinkedListInstrumentation extends ErrorBranchInstrumenter {
                 //tagBranchEnd();
                 restoreMethodParameters(tempVariables, desc);
 
-            } else if (indexListMethods.contains(name)) {
-                Type[] args = Type.getArgumentTypes(desc);
-                if (args.length == 0)
-                    return;
-                if (!args[0].equals(Type.INT_TYPE))
-                    return;
-
-                Map<Integer, Integer> tempVariables = getMethodCallee(desc);
-                tagBranchStart();
-                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, LISTNAME,
-                        "size", "()I", false);
-
-                // index >= size
-                mv.loadLocal(tempVariables.get(0));
-                insertBranch(Opcodes.IF_ICMPGT, "java/lang/IndexOutOfBoundsException");
-
-                // index < 0
-                mv.loadLocal(tempVariables.get(0));
-                insertBranch(Opcodes.IFGE, "java/lang/IndexOutOfBoundsException");
-                tagBranchEnd();
-
-                restoreMethodParameters(tempVariables, desc);
             }
         }
     }


### PR DESCRIPTION
Enables `LinkedListInstrumentation` when `Properties.ErrorInstrumentation.LIST` is active, ensuring `LinkedList` specific error branches (like `NoSuchElementException` for `getFirst()`) are instrumented.
To prevent duplicate instrumentation of index-based methods (which are covered by `ListInstrumentation` since it targets `LinkedList` as well), `LinkedListInstrumentation` was modified to only handle empty-list check methods.
Verified that `LinkedListInstrumentationSystemTest` passes, covering both `LinkedListAccess` (uses `getFirst`) and `LinkedListAccessIndex` (uses `get(index)`).

---
*PR created automatically by Jules for task [8282319520040316595](https://jules.google.com/task/8282319520040316595) started by @gofraser*