### PR TITLE
Fix DSE string variable aliasing with constants

### DIFF
--- a/client/src/main/java/org/evosuite/symbolic/SymbolicObserver.java
+++ b/client/src/main/java/org/evosuite/symbolic/SymbolicObserver.java
@@ -1838,6 +1838,9 @@ public class SymbolicObserver extends ExecutionObserver {
         String string_instance;
         try {
             string_instance = (String) varRef.getObject(scope);
+            if (string_instance != null) {
+                string_instance = new String(string_instance);
+            }
             scope.setObject(varRef, string_instance);
         } catch (CodeUnderTestException e) {
             throw new EvosuiteError(e);


### PR DESCRIPTION
Fixes `EnvironmentDataSystemTest` failure where DSE could not solve string constraints due to aliasing between test variables and SUT constants.

Modified `SymbolicObserver` to explicitly create new `String` instances for variables tracked during symbolic execution, preventing them from being mapped to interned string constants in the symbolic heap. This ensures that constraints are generated correctly (variable vs constant) rather than incorrectly (variable vs variable).

---
*PR created automatically by Jules for task [5495191287145463886](https://jules.google.com/task/5495191287145463886) started by @gofraser*