### PR TITLE
Fix VNET_SystemTest failure by increasing timeout

### DIFF
--- a/master/src/test/java/org/evosuite/papers/VNET_SystemTest.java
+++ b/master/src/test/java/org/evosuite/papers/VNET_SystemTest.java
@@ -30,6 +30,7 @@ public class VNET_SystemTest extends SystemTestBase {
     @Test
     public void testTCP() {
         Properties.SEARCH_BUDGET = 1_000_000;
+        Properties.GLOBAL_TIMEOUT = 300;
         do100percentLineTest(Example_UDP_TCP.class);
     }
 


### PR DESCRIPTION
The `VNET_SystemTest` (specifically `testTCP` using `Example_UDP_TCP`) was failing with non-optimal coverage due to a timeout. The test requires finding a specific sequence of Virtual Network calls (sending a UDP packet, setting up a TCP response listener, then receiving the TCP connection) which is computationally expensive for the search algorithm in the restricted environment.

This change increases `Properties.GLOBAL_TIMEOUT` to 300 seconds for this specific test case, giving EvoSuite enough time to find the solution and achieve 100% line coverage.

The failure was not directly caused by the removal of the Security Manager in newer Java versions, although the new environment might have introduced some overhead contributing to the timeout. The fix ensures robustness by relaxing the time constraint.

---
*PR created automatically by Jules for task [6370448944447137330](https://jules.google.com/task/6370448944447137330) started by @gofraser*