### PR TITLE
Fix LineCoverageFitnessFunctionSystemTest timeout

### DIFF
--- a/master/src/test/java/org/evosuite/coverage/line/LineCoverageFitnessFunctionSystemTest.java
+++ b/master/src/test/java/org/evosuite/coverage/line/LineCoverageFitnessFunctionSystemTest.java
@@ -228,6 +228,7 @@ public class LineCoverageFitnessFunctionSystemTest extends SystemTestBase {
         // seeding, but need to increase the budget
         Properties.PRIMITIVE_POOL = 0.0;
         Properties.SEARCH_BUDGET = 150_000;
+        Properties.GLOBAL_TIMEOUT = 300;
 
         String[] command = new String[]{"-generateSuite", "-class", targetClass};
         Object result = evosuite.parseCommandLine(command);
@@ -256,6 +257,7 @@ public class LineCoverageFitnessFunctionSystemTest extends SystemTestBase {
         // seeding, but need to increase the budget
         Properties.PRIMITIVE_POOL = 0.0;
         Properties.SEARCH_BUDGET = 150000;
+        Properties.GLOBAL_TIMEOUT = 300;
 
         String[] command = new String[]{"-generateSuite", "-class", targetClass};
         Object result = evosuite.parseCommandLine(command);
@@ -312,6 +314,7 @@ public class LineCoverageFitnessFunctionSystemTest extends SystemTestBase {
         // seeding, but need to increase the budget
         Properties.PRIMITIVE_POOL = 0.0;
         Properties.SEARCH_BUDGET = 150000;
+        Properties.GLOBAL_TIMEOUT = 300;
 
         String[] command = new String[]{"-generateSuite", "-class", targetClass};
         Object result = evosuite.parseCommandLine(command);


### PR DESCRIPTION
The system test `LineCoverageFitnessFunctionSystemTest` was failing with a timeout when running the full suite. This was traced to `testLineCoverageFitnessBranchGuidanceWithArchive`, `testOnlyLineCoverageFitnessBranchGuidanceWithArchive`, and `testLineCoverageFitnessBranchGuidance2WithArchive` having a large `SEARCH_BUDGET` (150,000 statements) but relying on the default `GLOBAL_TIMEOUT` (120s), which proved insufficient in the CI environment. The fix aligns these tests with their "WithoutArchive" counterparts by explicitly increasing the timeout to 300 seconds.

---
*PR created automatically by Jules for task [8514281107478598177](https://jules.google.com/task/8514281107478598177) started by @gofraser*