### PR TITLE
Fix DSE string constant aliasing issue

### DIFF
--- a/client/src/main/java/org/evosuite/symbolic/vm/LocalsVM.java
+++ b/client/src/main/java/org/evosuite/symbolic/vm/LocalsVM.java
@@ -182,7 +182,7 @@ public final class LocalsVM extends AbstractVM {
             env.topFrame().operandStack.pushNullRef();
         } else {
             ReferenceConstant stringRef = (ReferenceConstant) env.heap
-                    .getReference(x);
+                    .getConstantReference(x);
 
             env.topFrame().operandStack.pushRef(stringRef);
         }


### PR DESCRIPTION
The `Issre13SystemTest` was failing because DSE could not solve a constraint involving a string comparison where the input variable shared the same interned string object as the constant in the code. This caused DSE to alias the constant to the variable, resulting in an unsatisfiable constraint (e.g., `concat(var0, 5) == var0`).

This change fixes the issue by ensuring that `LDC` instructions loading string constants always produce a `ReferenceExpression` that is distinct from any existing symbolic variable reference, even if they point to the same concrete string object. This allows `SymbolicHeap.getField` to correctly identify the constant and return its constant value instead of the variable's symbolic value.

Verified by running `Issre13SystemTest`.

---
*PR created automatically by Jules for task [6441304147582785975](https://jules.google.com/task/6441304147582785975) started by @gofraser*