### PR TITLE
Fix FactoryTestSystemTest class loading issue

### DIFF
--- a/master/src/test/java/org/evosuite/testcase/FactoryTestSystemTest.java
+++ b/master/src/test/java/org/evosuite/testcase/FactoryTestSystemTest.java
@@ -92,12 +92,13 @@ public class FactoryTestSystemTest extends SystemTestBase {
 
     @Test
     public void testIntegerDependency() throws ConstructionFailedException,
-            NoSuchMethodException, SecurityException {
+            NoSuchMethodException, SecurityException, ClassNotFoundException {
         TestFactory testFactory = TestFactory.getInstance();
+        Class<?> sut = TestGenerationContext.getInstance().getClassLoaderForSUT().loadClass(FactoryExample.class.getCanonicalName());
 
         GenericMethod method = new GenericMethod(
-                FactoryExample.class.getMethod("testByte", byte.class, byte.class),
-                FactoryExample.class);
+                sut.getMethod("testByte", byte.class, byte.class),
+                sut);
         DefaultTestCase test = new DefaultTestCase();
         Properties.PRIMITIVE_REUSE_PROBABILITY = 0.0;
         testFactory.addMethod(test, method, 0, 0);


### PR DESCRIPTION
Updated `FactoryTestSystemTest.testIntegerDependency` to load the `FactoryExample` class using `TestGenerationContext.getInstance().getClassLoaderForSUT().loadClass(...)`.
This resolves a `ConstructionFailedException` caused by classloader mismatch (Statement 0 type vs assignment type) when using `TestFactory` with EvoSuite's instrumentation environment.
Verified that all tests in `FactoryTestSystemTest` pass.

---
*PR created automatically by Jules for task [12616157275616507468](https://jules.google.com/task/12616157275616507468) started by @gofraser*