### PR TITLE
Exclude com.examples.with.different.packagename from test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -605,6 +605,7 @@
                         <exclude>${exclude.tests.mimeType}</exclude>
                         <exclude>**/MSecurityManagerTest.java</exclude>
                         <exclude>**/SandboxFromJUnitTest.java</exclude>
+                        <exclude>com/examples/with/different/packagename/**/*.java</exclude>
                     </excludes>
                     <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading -Xms512m -Xmx4096m --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.desktop/java.awt=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>


### PR DESCRIPTION
Excluded the package com.examples.with.different.packagename from maven-surefire-plugin configuration in pom.xml to prevent execution of test fixtures as tests.

---
*PR created automatically by Jules for task [13758373040067803995](https://jules.google.com/task/13758373040067803995) started by @gofraser*