### PR TITLE
Fix flakiness in POLIntTest

### DIFF
--- a/master/src/test/java/org/evosuite/ga/problems/multiobjective/POLIntTest.java
+++ b/master/src/test/java/org/evosuite/ga/problems/multiobjective/POLIntTest.java
@@ -37,6 +37,7 @@ import org.evosuite.ga.problems.Problem;
 import org.evosuite.ga.problems.metrics.GenerationalDistance;
 import org.evosuite.ga.problems.metrics.Metrics;
 import org.evosuite.ga.problems.metrics.Spacing;
+import org.evosuite.utils.Randomness;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,6 +55,7 @@ public class POLIntTest {
         Properties.SEARCH_BUDGET = 10_000;
         Properties.CROSSOVER_RATE = 0.9;
         Properties.RANDOM_SEED = 1L;
+        Randomness.setSeed(Properties.RANDOM_SEED);
     }
 
     @Test


### PR DESCRIPTION
Fixes flaky failure in `POLIntTest` by ensuring `Randomness` is re-seeded with the value from `Properties.RANDOM_SEED` in the `setUp` method. This addresses issues where the test would fail due to non-determinism when run in a suite where `Randomness` was already initialized.

---
*PR created automatically by Jules for task [12680366105457728461](https://jules.google.com/task/12680366105457728461) started by @gofraser*