### PR TITLE
Fix elitism in StandardChemicalReaction overwriting superior solutions

### DIFF
--- a/client/src/main/java/org/evosuite/ga/metaheuristics/StandardChemicalReaction.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/StandardChemicalReaction.java
@@ -202,7 +202,7 @@ public class StandardChemicalReaction<T extends Chromosome<T>> extends GeneticAl
 
                     // If the molecule in the population is better than the elite one,
                     // we should not replace it.
-                    if (molecule.compareTo(best) < 0) {
+                    if (isBetterOrEqual(molecule, best)) {
                         continue;
                     }
 


### PR DESCRIPTION
Fixed a bug in `StandardChemicalReaction` where elitism could overwrite a superior solution found in the current iteration with an inferior elite solution from the previous iteration. Added a check to skip replacement if the current individual is better than the elite one. Verified by running `StandardChemicalReactionSystemTest`.

---
*PR created automatically by Jules for task [5085749724062486476](https://jules.google.com/task/5085749724062486476) started by @gofraser*