### PR TITLE
Fix flaky POLIntTest by explicitly setting Randomness seed

### DIFF
--- a/master/src/test/java/org/evosuite/ga/problems/multiobjective/POLIntTest.java
+++ b/master/src/test/java/org/evosuite/ga/problems/multiobjective/POLIntTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.evosuite.Properties;
+import org.evosuite.utils.Randomness;
 import org.evosuite.ga.ChromosomeFactory;
 import org.evosuite.ga.FitnessFunction;
 import org.evosuite.ga.NSGAChromosome;
@@ -54,6 +55,7 @@ public class POLIntTest {
         Properties.SEARCH_BUDGET = 10_000;
         Properties.CROSSOVER_RATE = 0.9;
         Properties.RANDOM_SEED = 1L;
+        Randomness.setSeed(Properties.RANDOM_SEED);
     }
 
     @Test


### PR DESCRIPTION
The test `POLIntTest` was flaky because it set `Properties.RANDOM_SEED` but did not explicitly re-seed the `Randomness` singleton. If `Randomness` was already initialized (e.g., by a previous test), the new seed in `Properties` was ignored. This fix adds `Randomness.setSeed(Properties.RANDOM_SEED)` to the `setUp` method to ensure the test always runs with the specified seed (1L), making it deterministic.

---
*PR created automatically by Jules for task [3638939987577247872](https://jules.google.com/task/3638939987577247872) started by @gofraser*