### PR TITLE
Fix JUnitTestCarvedChromosomeFactorySystemTest expectation order

### DIFF
--- a/master/src/test/java/org/evosuite/testcase/JUnitTestCarvedChromosomeFactorySystemTest.java
+++ b/master/src/test/java/org/evosuite/testcase/JUnitTestCarvedChromosomeFactorySystemTest.java
@@ -817,11 +817,11 @@ public class JUnitTestCarvedChromosomeFactorySystemTest extends SystemTestBase {
 
         Assert.assertEquals("Incorrect number of carved tests", 2, factory.getNumCarvedTestCases());
         CarvedTestCase tc1 = (CarvedTestCase) factory.getCarvedTestCases().get(0);
-        Assert.assertEquals("Incorrect carved test name", "testWithNull", tc1.getName());
+        Assert.assertEquals("Incorrect carved test name", "testWithArray", tc1.getName());
         System.out.println("Carved Test Case # " + tc1.getID() + ": " + tc1.getName());
         System.out.println(tc1.toCode());
         CarvedTestCase tc2 = (CarvedTestCase) factory.getCarvedTestCases().get(1);
-        Assert.assertEquals("Incorrect carved test name", "testWithArray", tc2.getName());
+        Assert.assertEquals("Incorrect carved test name", "testWithNull", tc2.getName());
         System.out.println("Carved Test Case # " + tc2.getID() + ": " + tc2.getName());
         System.out.println(tc2.toCode());
     }


### PR DESCRIPTION
Fixed a test failure in `JUnitTestCarvedChromosomeFactorySystemTest.testCarvedTestNames` where the expected order of carved tests did not match the actual alphabetical sorting order implemented in `JUnitTestCarvedChromosomeFactory`. Swapped the expectations for the first and second test cases to align with the factory's deterministic behavior.

---
*PR created automatically by Jules for task [10881097892934037592](https://jules.google.com/task/10881097892934037592) started by @gofraser*