### PR TITLE
Update pom.xml files to fix plugin versions and dependency scopes

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -141,7 +141,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -55,11 +55,13 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.8.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.8.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -114,12 +116,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                        <encoding>${project.build.sourceEncoding}</encoding>
-                    </configuration>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,6 @@
         <module>shaded</module>
     </modules>
 
-    <prerequisites>
-        <maven>3.1</maven>
-    </prerequisites>
-
     <developers>
         <developer>
             <id>fraser</id>


### PR DESCRIPTION
This PR updates the `pom.xml` files to resolve issues with plugin versions and dependency scopes. 

Key changes:
1.  **Root pom.xml**: Removed the deprecated and invalid `<prerequisites>` section. The existing `maven-enforcer-plugin` handles the Maven version enforcement.
2.  **plugins/maven/pom.xml**:
    *   Added `<scope>provided</scope>` to `maven-core` and `maven-plugin-api` dependencies to fix build errors related to wrong scopes.
    *   Removed explicit version and configuration for `maven-compiler-plugin` to correctly inherit settings from the parent pom.
3.  **client/pom.xml**:
    *   Removed explicit version for `maven-jar-plugin` to inherit the version managed by the parent pom.

These changes ensure better consistency across modules and fix the reported build errors.

---
*PR created automatically by Jules for task [16442654369314187754](https://jules.google.com/task/16442654369314187754) started by @gofraser*