### PR TITLE
Update Maven plugins and enforce Maven 3.6.3

### DIFF
--- a/plugins/maven-test/projects/pom.xml
+++ b/plugins/maven-test/projects/pom.xml
@@ -16,13 +16,13 @@
     </modules>
 
     <properties>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <jmockit.version>1.23</jmockit.version>
         <junit.version>4.13.2</junit.version>
-        <surefire.version>2.21.0</surefire.version>
+        <surefire.version>3.5.4</surefire.version>
         <powermock.version>1.6.5</powermock.version>
         <cobertura.version>2.7</cobertura.version>
-        <pit.version>1.1.9</pit.version>
+        <pit.version>1.22.1</pit.version>
         <forkCount>1</forkCount>
         <evosuiteVersion>1.1.1-SNAPSHOT</evosuiteVersion>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -86,7 +86,7 @@
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <id>enforce-maven-3</id>
@@ -96,7 +96,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.1</version>
+                                    <version>3.6.3</version>
                                 </requireMavenVersion>
                             </rules>
                             <fail>true</fail>
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -12,7 +12,7 @@
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
-        <maven>3.1</maven>
+        <maven>3.6.3</maven>
     </prerequisites>
 
     <name>Maven Plugin for EvoSuite</name>
@@ -92,7 +92,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>3.15.1</version>
                     <configuration>
                         <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -157,19 +157,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.9.0</version>
+                <version>3.15.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.12.0</version>
                 <configuration>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.9.0</version>
                 <configuration>
                     <!-- essential, otherwise "site" will take forever and ever... -->
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
                 </configuration>
             </plugin>
 
-            <!-- we need at least Maven 3.1 due to special features in EvoSuite Maven Plugin -->
+            <!-- we need at least Maven 3.6.3 due to special features in EvoSuite Maven Plugin -->
             <plugin>
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -434,7 +434,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.1</version>
+                                    <version>3.6.3</version>
                                 </requireMavenVersion>
                             </rules>
                             <fail>true</fail>
@@ -533,7 +533,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>${compiler.source}</source>
                     <target>${compiler.target}</target>

--- a/standalone_runtime/pom.xml
+++ b/standalone_runtime/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.5.4</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.5.4</version>
                 <configuration>
                     <includes>
                         <include>**/*IntTest.java</include>


### PR DESCRIPTION
Updated the pom.xml (main and submodules) to require a minimum version of 3.6.3. Updated all other plugins to their latest versions, except maven-jxr-plugin and jaxb2-maven-plugin. Verified that the project still compiles.

---
*PR created automatically by Jules for task [299425206375132504](https://jules.google.com/task/299425206375132504) started by @gofraser*