### PR TITLE
Fix test pollution by clearing DependencyAnalysis static state

### DIFF
--- a/client/src/main/java/org/evosuite/TestGenerationContext.java
+++ b/client/src/main/java/org/evosuite/TestGenerationContext.java
@@ -180,6 +180,7 @@ public class TestGenerationContext {
 
         // TODO: After this, the test cluster is empty until
         // DependencyAnalysis.analyse is called
+        DependencyAnalysis.clear();
         TestCluster.reset();
         CastClassManager.getInstance().clear();
         ConcreteClassAnalyzer.getInstance().clear();

--- a/client/src/main/java/org/evosuite/setup/DependencyAnalysis.java
+++ b/client/src/main/java/org/evosuite/setup/DependencyAnalysis.java
@@ -63,6 +63,16 @@ public class DependencyAnalysis {
     private static Set<String> targetClasses = null;
 
     /**
+     * Clear all static state
+     */
+    public static void clear() {
+        classCache.clear();
+        callGraphs.clear();
+        inheritanceTree = null;
+        targetClasses = null;
+    }
+
+    /**
      * @return the inheritanceTree
      */
     public static InheritanceTree getInheritanceTree() {


### PR DESCRIPTION
The test `SimpleFM_SystemTest.testSimpleGenericNullString` was failing when run as part of the full test suite, likely due to pollution from shared state. 

Investigation revealed that `DependencyAnalysis` maintains static state (`classCache`, `callGraphs`, `inheritanceTree`, `targetClasses`) that was not being cleared during `TestGenerationContext.resetContext()`. This allowed state from previous tests to leak into subsequent tests, potentially influencing `CastClassManager` behavior (which relies on `DependencyAnalysis.getInheritanceTree()`).

This change adds a `clear()` method to `DependencyAnalysis` and ensures it is called within `TestGenerationContext.resetContext()`, enforcing proper isolation between test runs.

---
*PR created automatically by Jules for task [17170139609221802426](https://jules.google.com/task/17170139609221802426) started by @gofraser*