### PR TITLE
Fix NullPointerException when getClientsOnceAllConnected returns null

### DIFF
--- a/master/src/main/java/org/evosuite/executionmode/MeasureCoverage.java
+++ b/master/src/main/java/org/evosuite/executionmode/MeasureCoverage.java
@@ -174,8 +174,11 @@ public class MeasureCoverage {
         if (handler.startProcess(newArgs)) {
             Set<ClientNodeRemote> clients = null;
             try {
-                clients = new CopyOnWriteArraySet<>(MasterServices.getInstance().getMasterNode()
-                        .getClientsOnceAllConnected(10000).values());
+                java.util.Map<String, ClientNodeRemote> connectedClients = MasterServices.getInstance().getMasterNode()
+                        .getClientsOnceAllConnected(10000);
+                if (connectedClients != null) {
+                    clients = new CopyOnWriteArraySet<>(connectedClients.values());
+                }
             } catch (InterruptedException e) {
             }
             if (clients == null) {

--- a/master/src/main/java/org/evosuite/executionmode/PrintStats.java
+++ b/master/src/main/java/org/evosuite/executionmode/PrintStats.java
@@ -141,8 +141,11 @@ public class PrintStats {
         if (handler.startProcess(newArgs)) {
             Set<ClientNodeRemote> clients = null;
             try {
-                clients = new CopyOnWriteArraySet<>(MasterServices.getInstance().getMasterNode()
-                        .getClientsOnceAllConnected(10000).values());
+                java.util.Map<String, ClientNodeRemote> connectedClients = MasterServices.getInstance().getMasterNode()
+                        .getClientsOnceAllConnected(10000);
+                if (connectedClients != null) {
+                    clients = new CopyOnWriteArraySet<>(connectedClients.values());
+                }
             } catch (InterruptedException e) {
             }
             if (clients == null) {

--- a/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
+++ b/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
@@ -509,8 +509,11 @@ public class TestGeneration {
             Set<ClientNodeRemote> clients = null;
             try {
                 //FIXME: timeout here should be handled by TimeController
-                clients = new CopyOnWriteArraySet<>(MasterServices.getInstance().getMasterNode()
-                        .getClientsOnceAllConnected(60000).values());
+                java.util.Map<String, ClientNodeRemote> connectedClients = MasterServices.getInstance().getMasterNode()
+                        .getClientsOnceAllConnected(60000);
+                if (connectedClients != null) {
+                    clients = new CopyOnWriteArraySet<>(connectedClients.values());
+                }
             } catch (InterruptedException e) {
             }
             if (clients == null) {

--- a/master/src/main/java/org/evosuite/executionmode/WriteDependencies.java
+++ b/master/src/main/java/org/evosuite/executionmode/WriteDependencies.java
@@ -150,8 +150,11 @@ public class WriteDependencies {
         if (handler.startProcess(newArgs)) {
             Set<ClientNodeRemote> clients = null;
             try {
-                clients = new CopyOnWriteArraySet<>(MasterServices.getInstance().getMasterNode()
-                        .getClientsOnceAllConnected(10000).values());
+                java.util.Map<String, ClientNodeRemote> connectedClients = MasterServices.getInstance().getMasterNode()
+                        .getClientsOnceAllConnected(10000);
+                if (connectedClients != null) {
+                    clients = new CopyOnWriteArraySet<>(connectedClients.values());
+                }
             } catch (InterruptedException e) {
             }
             if (clients == null) {


### PR DESCRIPTION
Fixed NullPointerException in `PrintStats`, `MeasureCoverage`, `WriteDependencies`, and `TestGeneration` by checking if the return value of `getClientsOnceAllConnected` is null before accessing its values. This prevents crashes when the client connection times out.

---
*PR created automatically by Jules for task [18388012650553978730](https://jules.google.com/task/18388012650553978730) started by @gofraser*