### PR TITLE
Fix Checkstyle issues in org.evosuite.novelty package

### DIFF
--- a/client/src/main/java/org/evosuite/novelty/BranchNoveltyFunction.java
+++ b/client/src/main/java/org/evosuite/novelty/BranchNoveltyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -43,13 +43,16 @@ public class BranchNoveltyFunction extends NoveltyFunction<TestChromosome> {
     private final Set<String> branchlessMethods = new LinkedHashSet<>();
 
     public BranchNoveltyFunction() {
-        for (Branch branch : BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getAllBranches()) {
+        ClassLoader classLoader = TestGenerationContext.getInstance().getClassLoaderForSUT();
+        BranchPool branchPool = BranchPool.getInstance(classLoader);
+        for (Branch branch : branchPool.getAllBranches()) {
             if (!branch.isInstrumented()) {
                 branches.add(branch.getActualBranchId());
             }
         }
-        branchlessMethods.addAll(BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getBranchlessMethods());
-        logger.warn("Number of branches: " + branches.size() + " branches and " + branchlessMethods.size() + " branchless methods");
+        branchlessMethods.addAll(branchPool.getBranchlessMethods());
+        logger.warn("Number of branches: " + branches.size() + " branches and " + branchlessMethods.size()
+                + " branchless methods");
     }
 
     private ExecutionResult runTest(TestCase test) {

--- a/client/src/main/java/org/evosuite/novelty/SuiteFitnessEvaluationListener.java
+++ b/client/src/main/java/org/evosuite/novelty/SuiteFitnessEvaluationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>


### PR DESCRIPTION
This PR addresses Checkstyle violations in the `org.evosuite.novelty` package within the `client` module.

Changes:
1.  **BranchNoveltyFunction.java**:
    *   Updated license header to use block comment style.
    *   Refactored constructor to reduce line length by extracting `ClassLoader` and `BranchPool` to local variables.
    *   Split a long log message into two lines.
2.  **SuiteFitnessEvaluationListener.java**:
    *   Updated license header to use block comment style.

These changes resolve Javadoc parsing errors and LineLength violations reported by Checkstyle. Verification was performed using `mvn checkstyle:check` and running `NoveltySearchTest`.

---
*PR created automatically by Jules for task [11550670849644071172](https://jules.google.com/task/11550670849644071172) started by @gofraser*