### PR TITLE
Fix Checkstyle issues in org.evosuite.result package

### DIFF
--- a/client/src/main/java/org/evosuite/result/BranchInfo.java
+++ b/client/src/main/java/org/evosuite/result/BranchInfo.java
@@ -81,25 +81,33 @@ public class BranchInfo implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         BranchInfo other = (BranchInfo) obj;
         if (className == null) {
-            if (other.className != null)
+            if (other.className != null) {
                 return false;
-        } else if (!className.equals(other.className))
+            }
+        } else if (!className.equals(other.className)) {
             return false;
-        if (lineNo != other.lineNo)
+        }
+        if (lineNo != other.lineNo) {
             return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null)
+            if (other.methodName != null) {
                 return false;
-        } else if (!methodName.equals(other.methodName))
+            }
+        } else if (!methodName.equals(other.methodName)) {
             return false;
+        }
         return truthValue == other.truthValue;
     }
 

--- a/client/src/main/java/org/evosuite/result/MutationInfo.java
+++ b/client/src/main/java/org/evosuite/result/MutationInfo.java
@@ -82,28 +82,38 @@ public class MutationInfo implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         MutationInfo other = (MutationInfo) obj;
         if (className == null) {
-            if (other.className != null)
+            if (other.className != null) {
                 return false;
-        } else if (!className.equals(other.className))
+            }
+        } else if (!className.equals(other.className)) {
             return false;
-        if (lineNo != other.lineNo)
+        }
+        if (lineNo != other.lineNo) {
             return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null)
+            if (other.methodName != null) {
                 return false;
-        } else if (!methodName.equals(other.methodName))
+            }
+        } else if (!methodName.equals(other.methodName)) {
             return false;
+        }
         if (replacement == null) {
             return other.replacement == null;
-        } else return replacement.equals(other.replacement);
+        } else {
+            return replacement.equals(other.replacement);
+        }
     }
 
     @Override

--- a/client/src/main/java/org/evosuite/result/TestGenerationResult.java
+++ b/client/src/main/java/org/evosuite/result/TestGenerationResult.java
@@ -30,65 +30,65 @@ import java.util.Set;
 
 public interface TestGenerationResult<T extends Chromosome<T>> extends Serializable {
 
-    enum Status {SUCCESS, TIMEOUT, ERROR}
+    enum Status { SUCCESS, TIMEOUT, ERROR }
 
     /**
-     * Did test generation succeed?
+     * Did test generation succeed.
      */
     Status getTestGenerationStatus();
 
     /**
-     * If there was an error, this contains the error message
+     * If there was an error, this contains the error message.
      */
     String getErrorMessage();
 
     /**
-     * The entire DSEA in its final state
+     * The entire DSEA in its final state.
      */
     ExplorationAlgorithmBase getDSEAlgorithm();
 
     /**
-     * The entire GA in its final state
+     * The entire GA in its final state.
      */
     GeneticAlgorithm<T> getGeneticAlgorithm();
 
     /**
-     * Map from test method to ContractViolation
+     * Map from test method to ContractViolation.
      */
     Set<Failure> getContractViolations(String name);
 
     /**
-     * Class that was tested
+     * Class that was tested.
      */
     String getClassUnderTest();
 
     /**
-     * Target coverage criterion used to create this test suite
+     * Target coverage criterion used to create this test suite.
      */
     String[] getTargetCriterion();
 
     /**
-     * Coverage level of the target criterion
+     * Coverage level of the target criterion.
      */
     double getTargetCoverage(FitnessFunction<?> function);
 
     /**
-     * Map from test method to EvoSuite test case
+     * Map from test method to EvoSuite test case.
      */
     TestCase getTestCase(String name);
 
     /**
-     * Map from test method to EvoSuite test case
+     * Map from test method to EvoSuite test case.
      */
     String getTestCode(String name);
 
     /**
-     * JUnit test suite source code
+     * JUnit test suite source code.
      */
     String getTestSuiteCode();
 
     /**
-     * Lines covered by test
+     * Lines covered by test.
      */
     Set<Integer> getCoveredLines(String name);
 
@@ -99,37 +99,37 @@ public interface TestGenerationResult<T extends Chromosome<T>> extends Serializa
     Set<MutationInfo> getExceptionMutants();
 
     /**
-     * Lines covered by final test suite
+     * Lines covered by final test suite.
      */
     Set<Integer> getCoveredLines();
 
     /**
-     * Branches covered by final test suite
+     * Branches covered by final test suite.
      */
     Set<BranchInfo> getCoveredBranches();
 
     /**
-     * Mutants detected by final test suite
+     * Mutants detected by final test suite.
      */
     Set<MutationInfo> getCoveredMutants();
 
     /**
-     * Lines not covered by final test suite
+     * Lines not covered by final test suite.
      */
     Set<Integer> getUncoveredLines();
 
     /**
-     * Branches not covered by final test suite
+     * Branches not covered by final test suite.
      */
     Set<BranchInfo> getUncoveredBranches();
 
     /**
-     * Mutants not detected by final test suite
+     * Mutants not detected by final test suite.
      */
     Set<MutationInfo> getUncoveredMutants();
 
     /**
-     * Comment for that test
+     * Comment for that test.
      */
     String getComment(String name);
 

--- a/client/src/main/java/org/evosuite/result/TestGenerationResultBuilder.java
+++ b/client/src/main/java/org/evosuite/result/TestGenerationResultBuilder.java
@@ -81,8 +81,9 @@ public class TestGenerationResultBuilder {
     }
 
     public static TestGenerationResultBuilder getInstance() {
-        if (instance == null)
+        if (instance == null) {
             instance = new TestGenerationResultBuilder();
+        }
 
         return instance;
     }
@@ -95,11 +96,13 @@ public class TestGenerationResultBuilder {
         testCases.clear();
         contractViolations.clear();
         uncoveredLines = LinePool.getAllLines();
-        for (Branch b : BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getAllBranches()) {
+        for (Branch b : BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                .getAllBranches()) {
             uncoveredBranches.add(new BranchInfo(b, true));
             uncoveredBranches.add(new BranchInfo(b, false));
         }
-        for (Mutation m : MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutants()) {
+        for (Mutation m : MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                .getMutants()) {
             uncoveredMutants.add(new MutationInfo(m));
         }
     }
@@ -107,15 +110,17 @@ public class TestGenerationResultBuilder {
     private void fillInformationFromConfiguration(TestGenerationResultImpl<?> result) {
         result.setClassUnderTest(Properties.TARGET_CLASS);
         String[] criteria = new String[Properties.CRITERION.length];
-        for (int i = 0; i < Properties.CRITERION.length; i++)
+        for (int i = 0; i < Properties.CRITERION.length; i++) {
             criteria[i] = Properties.CRITERION[i].name();
+        }
         result.setTargetCriterion(criteria);
     }
 
     private <T extends Chromosome<T>> void fillInformationFromTestData(TestGenerationResultImpl<T> result) {
 
         Set<MutationInfo> exceptionMutants = new LinkedHashSet<>();
-        for (Mutation m : MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutants()) {
+        for (Mutation m : MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                .getMutants()) {
             if (MutationTimeoutStoppingCondition.isDisabled(m)) {
                 MutationInfo info = new MutationInfo(m);
                 exceptionMutants.add(info);
@@ -194,21 +199,25 @@ public class TestGenerationResultBuilder {
 
         Set<BranchInfo> branchCoverage = new LinkedHashSet<>();
         for (int branchId : result.getTrace().getCoveredFalseBranches()) {
-            Branch branch = BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getBranch(branchId);
+            Branch branch = BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                    .getBranch(branchId);
             if (branch == null) {
                 LoggingUtils.getEvoLogger().warn("Branch is null: " + branchId);
                 continue;
             }
-            BranchInfo info = new BranchInfo(branch.getClassName(), branch.getMethodName(), branch.getInstruction().getLineNumber(), false);
+            BranchInfo info = new BranchInfo(branch.getClassName(), branch.getMethodName(),
+                    branch.getInstruction().getLineNumber(), false);
             branchCoverage.add(info);
         }
         for (int branchId : result.getTrace().getCoveredTrueBranches()) {
-            Branch branch = BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getBranch(branchId);
+            Branch branch = BranchPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                    .getBranch(branchId);
             if (branch == null) {
                 LoggingUtils.getEvoLogger().warn("Branch is null: " + branchId);
                 continue;
             }
-            BranchInfo info = new BranchInfo(branch.getClassName(), branch.getMethodName(), branch.getInstruction().getLineNumber(), true);
+            BranchInfo info = new BranchInfo(branch.getClassName(), branch.getMethodName(),
+                    branch.getInstruction().getLineNumber(), true);
             branchCoverage.add(info);
         }
         testBranchCoverage.put(name, branchCoverage);
@@ -240,7 +249,8 @@ public class TestGenerationResultBuilder {
 
     public void setDSEAlgorithm(ExplorationAlgorithmBase dse) {
         this.dse = dse;
-        for (Map.Entry<FitnessFunction<TestSuiteChromosome>, Double> e : dse.getGeneratedTestSuite().getCoverageValues().entrySet()) {
+        for (Map.Entry<FitnessFunction<TestSuiteChromosome>, Double> e : dse.getGeneratedTestSuite()
+                .getCoverageValues().entrySet()) {
             targetCoverages.put(e.getKey(), e.getValue());
         }
     }

--- a/client/src/main/java/org/evosuite/result/TestGenerationResultImpl.java
+++ b/client/src/main/java/org/evosuite/result/TestGenerationResultImpl.java
@@ -80,7 +80,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     private ExplorationAlgorithmBase dse = null;
 
     /**
-     * Did test generation succeed?
+     * Did test generation succeed.
      */
     public Status getTestGenerationStatus() {
         return status;
@@ -91,7 +91,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * If there was an error, this contains the error message
+     * If there was an error, this contains the error message.
      */
     public String getErrorMessage() {
         return errorMessage;
@@ -103,7 +103,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * The entire GA in its final state
+     * The entire GA in its final state.
      */
     public GeneticAlgorithm<T> getGeneticAlgorithm() {
         return ga;
@@ -114,7 +114,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * The entire DSEA in tirs final state
+     * The entire DSEA in its final state.
      */
     public ExplorationAlgorithmBase getDSEAlgorithm() {
         return dse;
@@ -125,7 +125,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * Map from test method to ContractViolation
+     * Map from test method to ContractViolation.
      */
     public Set<Failure> getContractViolations(String name) {
         return contractViolations.get(name);
@@ -162,7 +162,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * Map from test method to EvoSuite test case
+     * Map from test method to EvoSuite test case.
      */
     public TestCase getTestCase(String name) {
         return testCases.get(name);
@@ -173,7 +173,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * Map from test method to EvoSuite test case
+     * Map from test method to EvoSuite test case.
      */
     public String getTestCode(String name) {
         return testCode.get(name);
@@ -184,7 +184,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * JUnit test suite source code
+     * JUnit test suite source code.
      */
     public String getTestSuiteCode() {
         return testSuiteCode;
@@ -195,7 +195,7 @@ class TestGenerationResultImpl<T extends Chromosome<T>> implements TestGeneratio
     }
 
     /**
-     * Lines covered by final test suite
+     * Lines covered by final test suite.
      */
     public Set<Integer> getCoveredLines() {
         return coveredLines;


### PR DESCRIPTION
This PR fixes checkstyle violations in the `org.evosuite.result` package of the `client` module.

Changes include:
- Adding braces to `if`, `else`, and `for` statements.
- Fixing line lengths.
- Adding whitespace around braces.
- Ensuring Javadoc summaries end with a period.
- Fixing a typo in `TestGenerationResultImpl.java` ("tirs" -> "its").

Verified by running `mvn checkstyle:check` (0 violations) and relevant tests (`TestStandardGA`, `SPEA2Test`).

---
*PR created automatically by Jules for task [3122356722657479002](https://jules.google.com/task/3122356722657479002) started by @gofraser*