### PR TITLE
Fix checkstyle issues in org.evosuite.rmi package

### DIFF
--- a/client/src/main/java/org/evosuite/rmi/ClientServices.java
+++ b/client/src/main/java/org/evosuite/rmi/ClientServices.java
@@ -110,7 +110,7 @@ public class ClientServices<T extends Chromosome<T>> {
     }
 
     /**
-     * Shorthand for the commonly used trackOutputVariable method
+     * Shorthand for the commonly used trackOutputVariable method.
      *
      * @param outputVariable The runtime variable to track
      * @param value          The value of the runtime variable

--- a/client/src/main/java/org/evosuite/rmi/UtilsRMI.java
+++ b/client/src/main/java/org/evosuite/rmi/UtilsRMI.java
@@ -30,12 +30,12 @@ public class UtilsRMI {
     /**
      * This is a wrapper over UnicastRemoteObject.exportObject,
      * as it does not properly handle anonymous/ephemeral ports.
-     * <p>
-     * In particular, "exportObject(Remote obj)" returns a RemoteStub, and not a Remote reference.
      *
-     * @param obj
-     * @return
-     * @throws RemoteException
+     * <p>In particular, "exportObject(Remote obj)" returns a RemoteStub, and not a Remote reference.
+     *
+     * @param obj the object to export
+     * @return the remote object
+     * @throws RemoteException if export fails
      */
     public static Remote exportObject(Remote obj) throws RemoteException {
         int port = 2000;
@@ -47,6 +47,7 @@ public class UtilsRMI {
                 int candidatePort = port + i;
                 return UnicastRemoteObject.exportObject(obj, candidatePort);
             } catch (RemoteException e) {
+                // ignored
             }
         }
 
@@ -59,14 +60,12 @@ public class UtilsRMI {
      * address 127.0.0.1. But, if there are network interfaces, depending
      * on the operating system the "localhost" can bind to them.
      *
-     * <p>
-     * So, if we start EvoSuite with a connection on (eg WiFi), losing such connection
+     * <p>So, if we start EvoSuite with a connection on (eg WiFi), losing such connection
      * would mess up EvoSuite. Even worse, if EvoSuite is started from Eclipse, Eclipse
      * will always use the binding it used at it start! In that case, Eclipse would need
      * to be restarted each time connection change.
      *
-     * <p>
-     * For these reasons, here we try to force to always bind to 127.0.0.1
+     * <p>For these reasons, here we try to force to always bind to 127.0.0.1
      */
     public static void ensureRegistryOnLoopbackAddress() {
         /*

--- a/client/src/main/java/org/evosuite/rmi/service/ClientNodeImpl.java
+++ b/client/src/main/java/org/evosuite/rmi/service/ClientNodeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.evosuite.rmi.service;
 
-import org.evosuite.Properties;
 import org.evosuite.*;
+import org.evosuite.Properties;
 import org.evosuite.Properties.NoSuchParameterException;
 import org.evosuite.classpath.ClassPathHandler;
 import org.evosuite.coverage.ClassStatisticsPrinter;
@@ -53,27 +53,27 @@ public class ClientNodeImpl<T extends Chromosome<T>>
     private static final long serialVersionUID = 485858845631346580L;
 
     /**
-     * The current state/phase in which this client process is (eg, search or assertion generation)
+     * The current state/phase in which this client process is (eg, search or assertion generation).
      */
     private volatile ClientState state;
 
     /**
-     * RMI reference used to communicate with the master node
+     * RMI reference used to communicate with the master node.
      */
     private MasterNodeRemote masterNode;
 
     /**
-     * A unique identifier for this client process (needed if running several clients in parallel)
+     * A unique identifier for this client process (needed if running several clients in parallel).
      */
     private String clientRmiIdentifier;
 
     /**
-     * A latch used to wait till the test generation is done
+     * A latch used to wait till the test generation is done.
      */
     protected volatile CountDownLatch doneLatch;
 
     /**
-     * A latch used to wait for this process to be fully finished
+     * A latch used to wait for this process to be fully finished.
      */
     protected volatile CountDownLatch finishedLatch;
 
@@ -190,26 +190,31 @@ public class ClientNodeImpl<T extends Chromosome<T>>
         try {
             doneLatch.await();
         } catch (InterruptedException ignored) {
+            // ignored
         }
     }
 
     @Override
     public void emigrate(Set<T> immigrants) {
         try {
-            logger.debug(ClientProcess.getPrettyPrintIdentifier() + "Sending " + immigrants.size() + " immigrants");
+            logger.debug(ClientProcess.getPrettyPrintIdentifier() + "Sending "
+                    + immigrants.size() + " immigrants");
             masterNode.evosuite_migrate(clientRmiIdentifier, immigrants);
         } catch (RemoteException e) {
-            logger.error(ClientProcess.getPrettyPrintIdentifier() + "Cannot send immigrating individuals to master", e);
+            logger.error(ClientProcess.getPrettyPrintIdentifier()
+                    + "Cannot send immigrating individuals to master", e);
         }
     }
 
     @Override
     public void sendBestSolution(Set<T> solutions) {
         try {
-            logger.debug(ClientProcess.getPrettyPrintIdentifier() + "sending best solutions to " + ClientProcess.DEFAULT_CLIENT_NAME);
+            logger.debug(ClientProcess.getPrettyPrintIdentifier() + "sending best solutions to "
+                    + ClientProcess.DEFAULT_CLIENT_NAME);
             masterNode.evosuite_collectBestSolutions(clientRmiIdentifier, solutions);
         } catch (RemoteException e) {
-            logger.error(ClientProcess.getPrettyPrintIdentifier() + "Cannot send best solution to master", e);
+            logger.error(ClientProcess.getPrettyPrintIdentifier()
+                    + "Cannot send best solution to master", e);
         }
     }
 
@@ -221,7 +226,8 @@ public class ClientNodeImpl<T extends Chromosome<T>>
     @Override
     public void changeState(ClientState state, ClientStateInformation information) {
         if (this.state != state) {
-            logger.info(ClientProcess.getPrettyPrintIdentifier() + "Client changing state from " + this.state + " to " + state);
+            logger.info(ClientProcess.getPrettyPrintIdentifier() + "Client changing state from "
+                    + this.state + " to " + state);
         }
 
         this.state = state;

--- a/client/src/main/java/org/evosuite/rmi/service/ClientNodeRemote.java
+++ b/client/src/main/java/org/evosuite/rmi/service/ClientNodeRemote.java
@@ -38,10 +38,12 @@ public interface ClientNodeRemote<T extends Chromosome<T>> extends Remote {
     void cancelCurrentSearch() throws RemoteException;
 
     /**
+     * Waits until the client finishes its task or timeout occurs.
+     *
      * @param timeoutInMs maximum amount of time we can wait for the client to finish
      * @return <code>true</code> if client is finished
-     * @throws RemoteException
-     * @throws InterruptedException
+     * @throws RemoteException if communication fails
+     * @throws InterruptedException if interrupted while waiting
      */
     boolean waitUntilFinished(long timeoutInMs) throws RemoteException,
             InterruptedException;

--- a/client/src/main/java/org/evosuite/rmi/service/ClientState.java
+++ b/client/src/main/java/org/evosuite/rmi/service/ClientState.java
@@ -22,7 +22,7 @@ package org.evosuite.rmi.service;
 import org.evosuite.Properties;
 
 /**
- * FIXME: sync with ProgressMonitor, and finish set it in all client code
+ * FIXME: sync with ProgressMonitor, and finish set it in all client code.
  *
  * @author arcuri
  */
@@ -39,7 +39,8 @@ public enum ClientState {
     MINIMIZING_VALUES("Minimizing values", "Minimizing primitive values in the tests", 6),
     MINIMIZATION("Minimizing", "Minimizing size/length of test cases", 7),
     //TODO, question: why is it before ASSERTION?
-    COVERAGE_ANALYSIS("Coverage Analysis", "Compute and the different coverage criteria of the generated test suite", 8),
+    COVERAGE_ANALYSIS("Coverage Analysis",
+            "Compute and the different coverage criteria of the generated test suite", 8),
     ASSERTION_GENERATION("Generating assertions", "Adding assertions to the test cases", 9),
     JUNIT_CHECK("Check JUnit", "Validate and fix the generated tests", 10),
     WRITING_TESTS("JUnit", "Writing JUnit tests to disk", 11),
@@ -88,8 +89,9 @@ public enum ClientState {
 
     public int getPhaseProgress() {
         int divisor = maxProgress - startProgress;
-        if (divisor == 0)
+        if (divisor == 0) {
             return 0;
+        }
         return (progress - startProgress) / divisor;
     }
 

--- a/client/src/main/java/org/evosuite/rmi/service/ClientStateInformation.java
+++ b/client/src/main/java/org/evosuite/rmi/service/ClientStateInformation.java
@@ -28,12 +28,12 @@ public class ClientStateInformation implements Serializable {
     private ClientState state;
 
     /**
-     * Progress 0-100
+     * Progress 0-100.
      */
     private int progress = 0;
 
     /**
-     * Achieved coverage 0-100
+     * Achieved coverage 0-100.
      */
     private int coverage = 0;
 

--- a/client/src/main/java/org/evosuite/rmi/service/MasterNodeRemote.java
+++ b/client/src/main/java/org/evosuite/rmi/service/MasterNodeRemote.java
@@ -45,19 +45,25 @@ public interface MasterNodeRemote extends Remote {
 
     void evosuite_registerClientNode(String clientRmiIdentifier) throws RemoteException;
 
-    void evosuite_informChangeOfStateInClient(String clientRmiIdentifier, ClientState state, ClientStateInformation information) throws RemoteException;
+    void evosuite_informChangeOfStateInClient(String clientRmiIdentifier, ClientState state,
+                                              ClientStateInformation information) throws RemoteException;
 
     void evosuite_collectStatistics(String clientRmiIdentifier, Chromosome<?> individual) throws RemoteException;
 
-    void evosuite_collectStatistics(String clientRmiIdentifier, RuntimeVariable variable, Object value) throws RemoteException;
+    void evosuite_collectStatistics(String clientRmiIdentifier, RuntimeVariable variable,
+                                    Object value) throws RemoteException;
 
-    void evosuite_collectTestGenerationResult(String clientRmiIdentifier, List<TestGenerationResult> results) throws RemoteException;
+    void evosuite_collectTestGenerationResult(String clientRmiIdentifier,
+                                              List<TestGenerationResult> results) throws RemoteException;
 
     void evosuite_flushStatisticsForClassChange(String clientRmiIdentifier) throws RemoteException;
 
-    void evosuite_updateProperty(String clientRmiIdentifier, String propertyName, Object value) throws RemoteException, IllegalArgumentException, IllegalAccessException, NoSuchParameterException;
+    void evosuite_updateProperty(String clientRmiIdentifier, String propertyName, Object value)
+            throws RemoteException, IllegalArgumentException, IllegalAccessException,
+            NoSuchParameterException;
 
     void evosuite_migrate(String clientRmiIdentifier, Set<? extends Chromosome<?>> migrants) throws RemoteException;
 
-    void evosuite_collectBestSolutions(String clientRmiIdentifier, Set<? extends Chromosome<?>> solutions) throws RemoteException;
+    void evosuite_collectBestSolutions(String clientRmiIdentifier,
+                                       Set<? extends Chromosome<?>> solutions) throws RemoteException;
 }


### PR DESCRIPTION
This PR fixes checkstyle issues in the `org.evosuite.rmi` package in the `client` module.
It addresses violations such as Javadoc formatting, line length, empty catch blocks, and import order.
Verified by running `mvn checkstyle:check` on the package and running `OpenRegistryTest` to ensure no regressions.

---
*PR created automatically by Jules for task [17317999843508746952](https://jules.google.com/task/17317999843508746952) started by @gofraser*