### PR TITLE
Fix Checkstyle violations in ga.localsearch package

### DIFF
--- a/client/src/main/java/org/evosuite/ga/localsearch/DefaultLocalSearchObjective.java
+++ b/client/src/main/java/org/evosuite/ga/localsearch/DefaultLocalSearchObjective.java
@@ -91,7 +91,7 @@ public class DefaultLocalSearchObjective<T extends Chromosome<T>> implements Loc
     /**
      * {@inheritDoc}
      *
-     * @return
+     * @return the list of fitness functions.
      */
     @Override
     public List<FitnessFunction<T>> getFitnessFunctions() {

--- a/client/src/main/java/org/evosuite/ga/localsearch/LocalSearchBudget.java
+++ b/client/src/main/java/org/evosuite/ga/localsearch/LocalSearchBudget.java
@@ -42,7 +42,7 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
 
     private static final long serialVersionUID = 9152147170303160131L;
 
-    private final static Logger logger = LoggerFactory.getLogger(LocalSearchBudget.class);
+    private static final Logger logger = LoggerFactory.getLogger(LocalSearchBudget.class);
 
     // Singleton instance
     private static volatile LocalSearchBudget<?> instance = null;
@@ -77,7 +77,7 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
 
     /**
      * Resolve the singleton instance during deserialization.
-     * @return the singleton instance
+     * @return the singleton instance.
      * @throws ObjectStreamException if an error occurs
      */
     private Object readResolve() throws ObjectStreamException {
@@ -85,16 +85,15 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
     }
 
     /**
-     * <p>
-     * isFinished
-     * </p>
+     * Checks if the budget is exhausted.
      *
      * @return a boolean.
      */
     public boolean isFinished() {
         // If the global search is finished then we don't want local search either
-        if (ga != null && ga.isFinished())
+        if (ga != null && ga.isFinished()) {
             return true;
+        }
 
         switch (Properties.LOCAL_SEARCH_BUDGET_TYPE) {
             case FITNESS_EVALUATIONS:
@@ -110,7 +109,8 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
                 }
                 break;
             case STATEMENTS:
-                if (MaxStatementsStoppingCondition.getNumExecutedStatements() > executedStart + Properties.LOCAL_SEARCH_BUDGET) {
+                if (MaxStatementsStoppingCondition.getNumExecutedStatements()
+                        > executedStart + Properties.LOCAL_SEARCH_BUDGET) {
                     logger.info("Local search budget used up; type: " + Properties.LOCAL_SEARCH_BUDGET_TYPE);
                     return true;
                 }
@@ -135,7 +135,7 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
     }
 
     /**
-     * Reports that a fitness evaluation was consumed
+     * Reports that a fitness evaluation was consumed.
      */
     public void countFitnessEvaluation() {
         fitnessEvaluations++;
@@ -214,7 +214,6 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
 
     /**
      * {@inheritDoc}
-     *
      * Not used by LocalSearchBudget.
      */
     @Override
@@ -228,7 +227,6 @@ public class LocalSearchBudget<T extends Chromosome<T>> implements SearchListene
 
     /**
      * {@inheritDoc}
-     *
      * Not used by LocalSearchBudget.
      */
     @Override

--- a/client/src/main/java/org/evosuite/ga/localsearch/LocalSearchObjective.java
+++ b/client/src/main/java/org/evosuite/ga/localsearch/LocalSearchObjective.java
@@ -28,8 +28,8 @@ import java.util.List;
  * Represents a local search objective that will be used during local search to
  * assess the success (or failure) of a local search to a given chromosome
  * (it could be TestSuiteChromosome or TestChromosome).
- * <p>
- * The local search objective contains a list of fitness functions that are used
+ *
+ * <p>The local search objective contains a list of fitness functions that are used
  * to compute the fitness of an individual.
  *
  * @author Gordon Fraser
@@ -37,24 +37,24 @@ import java.util.List;
 public interface LocalSearchObjective<T extends Chromosome<T>> {
 
     /**
-     * true if the objective was achieved
+     * true if the objective was achieved.
      *
-     * @return
+     * @return true if the objective was achieved.
      */
     boolean isDone();
 
     /**
      * Returns true if all the fitness functions are maximising functions
      * (Observe that it is not possible to store simultaneously maximising and
-     * minimising fitness functions)
+     * minimising fitness functions).
      *
-     * @return
+     * @return true if all fitness functions are maximization functions.
      */
     boolean isMaximizationObjective();
 
     /**
      * Returns true if the individual has improved due to the applied local
-     * search
+     * search.
      *
      * @param chromosome a {@link org.evosuite.ga.Chromosome} object.
      * @return a boolean.
@@ -63,7 +63,7 @@ public interface LocalSearchObjective<T extends Chromosome<T>> {
 
     /**
      * Returns true if the individual has not worsened due to the applied local
-     * search
+     * search.
      *
      * @param chromosome a {@link org.evosuite.ga.Chromosome} object.
      * @return a boolean.
@@ -71,7 +71,7 @@ public interface LocalSearchObjective<T extends Chromosome<T>> {
     boolean hasNotWorsened(T chromosome);
 
     /**
-     * Checks if the individual has changed since local search started
+     * Checks if the individual has changed since local search started.
      *
      * @param chromosome a {@link org.evosuite.ga.Chromosome} object.
      * @return an integer indicating status: -1 if improved, 1 if worsened, 0 if unchanged.
@@ -82,7 +82,7 @@ public interface LocalSearchObjective<T extends Chromosome<T>> {
 
     /**
      * Returns a list with all the fitness functions stored in this local search
-     * objective
+     * objective.
      *
      * @return a {@link org.evosuite.ga.FitnessFunction} object.
      */


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.ga.localsearch` package in the `client` module to resolve all reported violations.

Changes include:
- `LocalSearchBudget.java`: Fixed modifier order (`private static final`), added braces to `if` statements, wrapped long lines, fixed operator wrapping, and corrected Javadoc.
- `DefaultLocalSearchObjective.java`: Added missing Javadoc descriptions.
- `LocalSearchObjective.java`: Fixed Javadoc paragraph structure and added missing periods/descriptions.

Verified by running `mvn checkstyle:check`, `mvn compile`, and `mvn test`.

---
*PR created automatically by Jules for task [4234945721172437381](https://jules.google.com/task/4234945721172437381) started by @gofraser*