### PR TITLE
Fix Checkstyle Javadoc violations in populationlimit package

### DIFF
--- a/client/src/main/java/org/evosuite/ga/populationlimit/IndividualPopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/IndividualPopulationLimit.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 /**
  * <p>IndividualPopulationLimit class.</p>
- * <p>
- * Limits the population size based on the number of individuals.
+ *
+ * <p>Limits the population size based on the number of individuals.</p>
  *
  * @author Gordon Fraser
  */
@@ -55,12 +55,12 @@ public class IndividualPopulationLimit<T extends Chromosome<T>> implements Popul
     }
 
     /**
-     * Copy Constructor
-     * <p>
-     * This constructor is used by {@link org.evosuite.ga.metaheuristics.TestSuiteAdapter} to adapt the generic type
-     * parameter.
-     * <p>
-     * This constructor shall preserve the current state of the IndividualPopulationLimit (if existing).
+     * Copy Constructor.
+     *
+     * <p>This constructor is used by {@link org.evosuite.ga.metaheuristics.TestSuiteAdapter} to adapt the generic type
+     * parameter.</p>
+     *
+     * <p>This constructor shall preserve the current state of the IndividualPopulationLimit (if existing).</p>
      *
      * @param other the other limit to copy
      */

--- a/client/src/main/java/org/evosuite/ga/populationlimit/PopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/PopulationLimit.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * <p>PopulationLimit interface.</p>
  *
- * Defines a strategy to determine if the population is full.
+ * <p>Defines a strategy to determine if the population is full.</p>
  *
  * @param <T> the type of chromosome
  * @author Gordon Fraser

--- a/client/src/main/java/org/evosuite/ga/populationlimit/SizePopulationLimit.java
+++ b/client/src/main/java/org/evosuite/ga/populationlimit/SizePopulationLimit.java
@@ -27,9 +27,9 @@ import java.util.List;
 
 /**
  * <p>SizePopulationLimit class.</p>
- * <p>
- * Limits the population size based on the sum of the sizes of all individuals (chromosomes) in the population.
- * The size of a chromosome is determined by {@link Chromosome#size()}.
+ *
+ * <p>Limits the population size based on the sum of the sizes of all individuals (chromosomes) in the population.
+ * The size of a chromosome is determined by {@link Chromosome#size()}.</p>
  *
  * @author fraser
  */
@@ -57,11 +57,11 @@ public class SizePopulationLimit<T extends Chromosome<T>> implements PopulationL
 
     /**
      * Copy constructor.
-     * <p>
-     * This constructor is used by {@link org.evosuite.ga.metaheuristics.TestSuiteAdapter} to adapt the generic type
-     * parameter.
-     * <p>
-     * This constructor shall preserve the current state of the SizePopulationLimit (if existing).
+     *
+     * <p>This constructor is used by {@link org.evosuite.ga.metaheuristics.TestSuiteAdapter} to adapt the generic type
+     * parameter.</p>
+     *
+     * <p>This constructor shall preserve the current state of the SizePopulationLimit (if existing).</p>
      *
      * @param other the other limit to copy
      */


### PR DESCRIPTION
This PR fixes Checkstyle violations in the `org.evosuite.ga.populationlimit` package.
The main issues addressed are:
- `JavadocParagraph`: `<p>` tags must be preceded by an empty line and immediately followed by text.
- `SummaryJavadoc`: First sentence of Javadoc must end with a period.

Changes applied to:
- `SizePopulationLimit.java`
- `IndividualPopulationLimit.java`
- `PopulationLimit.java`

Verified that `mvn checkstyle:check` passes for the package and `mvn test` passes for `PopulationLimitTest`.

---
*PR created automatically by Jules for task [7133130037682282949](https://jules.google.com/task/7133130037682282949) started by @gofraser*