### PR TITLE
Fix Checkstyle violations in org.evosuite.ga.bloatcontrol

### DIFF
--- a/client/src/main/java/org/evosuite/ga/bloatcontrol/BloatControlFunction.java
+++ b/client/src/main/java/org/evosuite/ga/bloatcontrol/BloatControlFunction.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
 public interface BloatControlFunction<T extends Chromosome<T>> extends Serializable {
 
     /**
-     * <p>isTooLong</p>
+     * <p>isTooLong.</p>
      *
      * @param chromosome a {@link org.evosuite.ga.Chromosome} object.
      * @return a boolean.

--- a/client/src/main/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControl.java
+++ b/client/src/main/java/org/evosuite/ga/bloatcontrol/MaxSizeBloatControl.java
@@ -23,7 +23,7 @@ import org.evosuite.Properties;
 import org.evosuite.ga.Chromosome;
 
 /**
- * Reject individuals when they exceed a certain size
+ * Reject individuals when they exceed a certain size.
  *
  * @author Gordon Fraser
  */
@@ -55,8 +55,8 @@ public class MaxSizeBloatControl<T extends Chromosome<T>> implements BloatContro
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Check whether the chromosome is bigger than the max length constant
+     *
+     * <p>Check whether the chromosome is bigger than the max length constant.
      */
     @Override
     public boolean isTooLong(T chromosome) {


### PR DESCRIPTION
This PR applies checkstyle fixes to the `org.evosuite.ga.bloatcontrol` package in the `client` module. 

It addresses the following issues:
1. `SummaryJavadoc`: Added missing periods to the first sentence of Javadoc comments.
2. `JavadocParagraph`: Corrected the usage of `<p>` tags to ensure they are preceded by an empty line and placed immediately before the text.

Verified by running `mvn checkstyle:check` on the package and ensuring 0 violations.
Verified no regressions by running `MaxSizeBloatControlTest`.

---
*PR created automatically by Jules for task [9564912203527825394](https://jules.google.com/task/9564912203527825394) started by @gofraser*