### PR TITLE
Apply Checkstyle fixes to org.evosuite.ga.operators package

### DIFF
--- a/client/src/main/java/org/evosuite/ga/operators/crossover/CoverageCrossOver.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/CoverageCrossOver.java
@@ -48,8 +48,8 @@ public class CoverageCrossOver extends CrossOverFunction<TestSuiteChromosome> {
     /**
      * {@inheritDoc}
      *
-     * @param parent1
-     * @param parent2
+     * @param parent1 a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @param parent2 a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
     @Override
     public void crossOver(TestSuiteChromosome parent1, TestSuiteChromosome parent2)
@@ -105,18 +105,19 @@ public class CoverageCrossOver extends CrossOverFunction<TestSuiteChromosome> {
     }
 
     /**
-     * Create a map from coverage goal to tests that cover this goal
+     * Create a map from coverage goal to tests that cover this goal.
      *
-     * @param goalMap
-     * @param suite
+     * @param goalMap a {@link java.util.Map} object.
+     * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
     private void populateCoverageMap(
             Map<TestFitnessFunction, Set<TestChromosome>> goalMap,
             TestSuiteChromosome suite) {
         for (TestChromosome test : suite.getTestChromosomes()) {
             for (TestFitnessFunction goal : test.getTestCase().getCoveredGoals()) {
-                if (!goalMap.containsKey(goal))
+                if (!goalMap.containsKey(goal)) {
                     goalMap.put(goal, new HashSet<>());
+                }
                 goalMap.get(goal).add(test);
             }
 

--- a/client/src/main/java/org/evosuite/ga/operators/crossover/CrossOverFunction.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/CrossOverFunction.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 
 /**
- * Cross over two individuals
+ * Cross over two individuals.
  *
  * @author Gordon Fraser
  */
@@ -36,12 +36,12 @@ public abstract class CrossOverFunction<T extends Chromosome<T>> implements Seri
     private static final long serialVersionUID = -4765602400132319324L;
 
     /**
-     * Constant <code>logger</code>
+     * Constant <code>logger</code>.
      */
     protected static final Logger logger = LoggerFactory.getLogger(CrossOverFunction.class);
 
     /**
-     * Replace parents with crossed over individuals
+     * Replace parents with crossed over individuals.
      *
      * @param parent1 a {@link Chromosome} object.
      * @param parent2 a {@link Chromosome} object.

--- a/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointCrossOver.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointCrossOver.java
@@ -24,7 +24,7 @@ import org.evosuite.ga.ConstructionFailedException;
 import org.evosuite.utils.Randomness;
 
 /**
- * Select one random point in each individual and cross over (TPX)
+ * Select one random point in each individual and cross over (TPX).
  *
  * @author Gordon Fraser
  */
@@ -34,11 +34,11 @@ public class SinglePointCrossOver<T extends Chromosome<T>> extends CrossOverFunc
 
     /**
      * {@inheritDoc}
-     * <p>
-     * A different splitting point is selected for each individual
      *
-     * @param parent1
-     * @param parent2
+     * <p>A different splitting point is selected for each individual
+     *
+     * @param parent1 a T object.
+     * @param parent2 a T object.
      */
     @Override
     public void crossOver(T parent1, T parent2)

--- a/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointFixedCrossOver.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointFixedCrossOver.java
@@ -24,7 +24,7 @@ import org.evosuite.ga.ConstructionFailedException;
 import org.evosuite.utils.Randomness;
 
 /**
- * Cross individuals at identical point
+ * Cross individuals at identical point.
  *
  * @author Gordon Fraser
  */
@@ -34,12 +34,12 @@ public class SinglePointFixedCrossOver<T extends Chromosome<T>> extends CrossOve
 
     /**
      * {@inheritDoc}
-     * <p>
-     * The splitting point for to individuals p1, p2 is selected within
+     *
+     * <p>The splitting point for to individuals p1, p2 is selected within
      * min(length(p1),length(p2))
      *
-     * @param parent1
-     * @param parent2
+     * @param parent1 a T object.
+     * @param parent2 a T object.
      */
     @Override
     public void crossOver(T parent1, T parent2)

--- a/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointRelativeCrossOver.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/SinglePointRelativeCrossOver.java
@@ -24,7 +24,7 @@ import org.evosuite.ga.ConstructionFailedException;
 import org.evosuite.utils.Randomness;
 
 /**
- * Cross over individuals at relative position
+ * Cross over individuals at relative position.
  *
  * @author Gordon Fraser
  */
@@ -34,14 +34,14 @@ public class SinglePointRelativeCrossOver<T extends Chromosome<T>> extends Cross
 
     /**
      * {@inheritDoc}
-     * <p>
-     * The splitting point is not an absolute value but a relative value (eg, at
+     *
+     * <p>The splitting point is not an absolute value but a relative value (eg, at
      * position 70% of n). For example, if n1=10 and n2=20 and splitting point
      * is 70%, we would have position 7 in the first and 14 in the second.
-     * Therefore, the offspring d have n<=max(n1,n2)
+     * Therefore, the offspring d have n&lt;=max(n1,n2)
      *
-     * @param parent1
-     * @param parent2
+     * @param parent1 a T object.
+     * @param parent2 a T object.
      */
     @Override
     public void crossOver(T parent1, T parent2)

--- a/client/src/main/java/org/evosuite/ga/operators/crossover/UniformCrossOver.java
+++ b/client/src/main/java/org/evosuite/ga/operators/crossover/UniformCrossOver.java
@@ -38,8 +38,8 @@ public class UniformCrossOver<T extends Chromosome<T>> extends CrossOverFunction
     /**
      * {@inheritDoc}
      *
-     * @param parent1
-     * @param parent2
+     * @param parent1 a T object.
+     * @param parent2 a T object.
      */
     @Override
     public void crossOver(T parent1, T parent2)

--- a/client/src/main/java/org/evosuite/ga/operators/mutation/BinomialMutation.java
+++ b/client/src/main/java/org/evosuite/ga/operators/mutation/BinomialMutation.java
@@ -51,8 +51,8 @@ public class BinomialMutation extends MutationDistribution {
      * Number of bits to be mutated (in our context, number of test cases to be mutated) according to
      * a binomial distribution.
      *
-     * @param numTrials
-     * @param probability
+     * @param numTrials   a int.
+     * @param probability a double.
      * @return number of test cases to be mutated
      */
     private int howManyBits(int numTrials, double probability) {

--- a/client/src/main/java/org/evosuite/ga/operators/mutation/MutationDistribution.java
+++ b/client/src/main/java/org/evosuite/ga/operators/mutation/MutationDistribution.java
@@ -30,26 +30,26 @@ public abstract class MutationDistribution implements Serializable {
     private static final long serialVersionUID = -5800252656232641574L;
 
     /**
-     * Constant <code>logger</code>
+     * Constant <code>logger</code>.
      */
     protected static final Logger logger = LoggerFactory.getLogger(MutationDistribution.class);
 
     protected int sizeOfDistribution;
 
     /**
-     * Check whether a particular chromosome is allowed to be mutated
+     * Check whether a particular chromosome is allowed to be mutated.
      *
-     * @param index
+     * @param index a int.
      * @return true if mutation is allowed, false otherwise
      */
     public abstract boolean toMutate(int index);
 
     /**
      * Get mutation distribution defined in
-     * {@link org.evosuite.Properties.MutationProbabilityDistribution}
+     * {@link org.evosuite.Properties.MutationProbabilityDistribution}.
      *
-     * @param sizeOfDistribution
-     * @return
+     * @param sizeOfDistribution a int.
+     * @return a {@link org.evosuite.ga.operators.mutation.MutationDistribution} object.
      */
     public static MutationDistribution getMutationDistribution(int sizeOfDistribution) {
         switch (Properties.MUTATION_PROBABILITY_DISTRIBUTION) {

--- a/client/src/main/java/org/evosuite/ga/operators/ranking/CrowdingDistance.java
+++ b/client/src/main/java/org/evosuite/ga/operators/ranking/CrowdingDistance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * This class implements different variants of Crowding Distance for many-objective problems
+ * This class implements different variants of Crowding Distance for many-objective problems.
  *
  * @author Annibale Panichella
  */
@@ -46,8 +46,9 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
     public void crowdingDistanceAssignment(List<T> front, List<? extends FitnessFunction<T>> set) {
         int size = front.size();
 
-        if (size == 0)
+        if (size == 0) {
             return;
+        }
         if (size == 1) {
             front.get(0).setDistance(Double.POSITIVE_INFINITY);
             return;
@@ -92,9 +93,9 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
     /**
      * This method implements a variant of the crowding distance named "subvector-dominance-assignment"
      * proposed by K\"{o}ppen and Yoshida in :
-     * [1] Mario K\"{o}ppen and Kaori Yoshida, "Substitute Distance Assignments in NSGA-II for handling Many-objective
-     * Optimization Problems", Evolutionary Multi-Criterion Optimization, Volume 4403 of the series Lecture Notes
-     * in Computer Science pp 727-741.
+     * [1] Mario K\"{o}ppen and Kaori Yoshida, "Substitute Distance Assignments in NSGA-II for handling
+     * Many-objective Optimization Problems", Evolutionary Multi-Criterion Optimization, Volume 4403 of the series
+     * Lecture Notes in Computer Science pp 727-741.
      *
      * @param front front of non-dominated solutions/tests
      * @param set   set of goals/targets (e.g., branches) to consider
@@ -107,7 +108,8 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
 
         front.forEach(t -> t.setDistance(Double.MAX_VALUE));
 
-        int dominate1, dominate2;
+        int dominate1;
+        int dominate2;
         for (int i = 0; i < front.size() - 1; i++) {
             T p1 = front.get(i);
             for (int j = i + 1; j < front.size(); j++) {
@@ -117,10 +119,11 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
                 for (final FitnessFunction<T> ff : set) {
                     double value1 = p1.getFitness(ff);
                     double value2 = p2.getFitness(ff);
-                    if (value1 < value2)
+                    if (value1 < value2) {
                         dominate1++;
-                    else if (value1 > value2)
+                    } else if (value1 > value2) {
                         dominate2++;
+                    }
                 }
                 p1.setDistance(Math.min(dominate1, p1.getDistance()));
                 p2.setDistance(Math.min(dominate2, p2.getDistance()));
@@ -129,11 +132,11 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
     }
 
     /**
-     * This method implements a "fast" version of the variant of the crowding distance named "epsilon-dominance-assignment"
-     * proposed by K\"{o}ppen and Yoshida in :
-     * [1] Mario K\"{o}ppen and Kaori Yoshida, "Substitute Distance Assignments in NSGA-II for handling Many-objective
-     * Optimization Problems", Evolutionary Multi-Criterion Optimization, Volume 4403 of the series Lecture Notes
-     * in Computer Science pp 727-741.
+     * This method implements a "fast" version of the variant of the crowding distance named
+     * "epsilon-dominance-assignment" proposed by K\"{o}ppen and Yoshida.
+     * [1] Mario K\"{o}ppen and Kaori Yoshida, "Substitute Distance Assignments in NSGA-II for handling
+     * Many-objective Optimization Problems", Evolutionary Multi-Criterion Optimization, Volume 4403 of the series
+     * Lecture Notes in Computer Science pp 727-741.
      *
      * @param front front of non-dominated solutions/tests
      * @param set   set of goals/targets (e.g., branches) to consider
@@ -152,16 +155,18 @@ public class CrowdingDistance<T extends Chromosome<T>> implements Serializable {
                     min = value;
                     minSet.clear();
                     minSet.add(test);
-                } else if (value == min)
+                } else if (value == min) {
                     minSet.add(test);
+                }
 
                 if (value > max) {
                     max = value;
                 }
             }
 
-            if (max == min)
+            if (max == min) {
                 continue;
+            }
 
             for (T test : minSet) {
                 double numer = (front.size() - minSet.size());

--- a/client/src/main/java/org/evosuite/ga/operators/ranking/FastNonDominatedSorting.java
+++ b/client/src/main/java/org/evosuite/ga/operators/ranking/FastNonDominatedSorting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -27,7 +27,7 @@ import java.util.*;
 
 /**
  * This class ranks the test cases according to the
- * the "PreferenceCriterion" defined for the MOSA algorithm
+ * "PreferenceCriterion" defined for the MOSA algorithm.
  *
  * @author Annibale Panichella, Fitsum M. Kifetew
  */
@@ -37,33 +37,33 @@ public class FastNonDominatedSorting<T extends Chromosome<T>> implements Ranking
     private static final long serialVersionUID = -5649595833522859850L;
 
     /**
-     * An array containing all the fronts found during the search
+     * An array containing all the fronts found during the search.
      */
     private List<List<T>> ranking;
 
     @Override
     public void computeRankingAssignment(List<T> solutions,
-                                         Set<? extends FitnessFunction<T>> uncovered_goals) {
-        ranking = getNextNonDominatedFronts(solutions, uncovered_goals);
+                                         Set<? extends FitnessFunction<T>> uncoveredGoals) {
+        ranking = getNextNonDominatedFronts(solutions, uncoveredGoals);
     }
 
 
     /**
-     * This method ranks the remaining test cases using the traditional "Non-Dominated Sorting Algorithm"
+     * This method ranks the remaining test cases using the traditional "Non-Dominated Sorting Algorithm".
      *
      * @param solutionSet     set of test cases to rank with "Non-Dominated Sorting Algorithm"
-     * @param uncovered_goals set of goals
+     * @param uncoveredGoals  set of goals
      * @return the list of fronts according to the uncovered goals
      */
     private List<List<T>> getNextNonDominatedFronts(List<T> solutionSet,
-                                                    Set<? extends FitnessFunction<T>> uncovered_goals) {
-        DominanceComparator<T> criterion = new DominanceComparator<>(uncovered_goals);
+                                                    Set<? extends FitnessFunction<T>> uncoveredGoals) {
+        DominanceComparator<T> criterion = new DominanceComparator<>(uncoveredGoals);
 
         // dominateMe[i] contains the number of solutions dominating i
         int[] dominateMe = new int[solutionSet.size()];
 
-        // iDominate[k] contains the list of solutions dominated by k
-        List<List<Integer>> iDominate = new ArrayList<>(solutionSet.size());
+        // dominatedList[k] contains the list of solutions dominated by k
+        List<List<Integer>> dominatedList = new ArrayList<>(solutionSet.size());
 
         // front[i] contains the list of individuals belonging to the front i
         List<List<Integer>> front = new ArrayList<>(solutionSet.size() + 1);
@@ -72,8 +72,9 @@ public class FastNonDominatedSorting<T extends Chromosome<T>> implements Ranking
         int flagDominate;
 
         // Initialize the fronts
-        for (int i = 0; i < solutionSet.size() + 1; i++)
+        for (int i = 0; i < solutionSet.size() + 1; i++) {
             front.add(new LinkedList<>());
+        }
 
         // Initialize distance
         for (T solution : solutionSet) {
@@ -84,7 +85,7 @@ public class FastNonDominatedSorting<T extends Chromosome<T>> implements Ranking
         for (int p = 0; p < solutionSet.size(); p++) {
             // Initialize the list of individuals that i dominate and the number
             // of individuals that dominate me
-            iDominate.add(new LinkedList<>());
+            dominatedList.add(new LinkedList<>());
             dominateMe[p] = 0;
         }
 
@@ -94,10 +95,10 @@ public class FastNonDominatedSorting<T extends Chromosome<T>> implements Ranking
                 flagDominate = criterion.compare(solutionSet.get(p), solutionSet.get(q));
 
                 if (flagDominate == -1) {
-                    iDominate.get(p).add(q);
+                    dominatedList.get(p).add(q);
                     dominateMe[q]++;
                 } else if (flagDominate == 1) {
-                    iDominate.get(q).add(p);
+                    dominatedList.get(q).add(p);
                     dominateMe[p]++;
                 }
             }
@@ -112,12 +113,13 @@ public class FastNonDominatedSorting<T extends Chromosome<T>> implements Ranking
 
         // Obtain the rest of fronts
         int i = 0;
-        Iterator<Integer> it1, it2; // Iterators
+        Iterator<Integer> it1;
+        Iterator<Integer> it2; // Iterators
         while (front.get(i).size() != 0) {
             i++;
             it1 = front.get(i - 1).iterator();
             while (it1.hasNext()) {
-                it2 = iDominate.get(it1.next()).iterator();
+                it2 = dominatedList.get(it1.next()).iterator();
                 while (it2.hasNext()) {
                     int index = it2.next();
                     dominateMe[index]--;

--- a/client/src/main/java/org/evosuite/ga/operators/ranking/RankBasedPreferenceSorting.java
+++ b/client/src/main/java/org/evosuite/ga/operators/ranking/RankBasedPreferenceSorting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -14,22 +14,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser Public License for more details.
  * <p>
- * You should have received a copy of the GNU Lesser General Public
- * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
- */
-/*
- * This file is part of EvoSuite.
- *
- * EvoSuite is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3.0 of the License, or
- * (at your option) any later version.
- *
- * EvoSuite is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser Public License for more details.
- *
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -51,7 +35,7 @@ import java.util.Set;
 
 /**
  * This class ranks the test cases according to the
- * the "PreferenceCriterion" defined for the MOSA algorithm
+ * the "PreferenceCriterion" defined for the MOSA algorithm.
  *
  * @author Annibale Panichella, Fitsum M. Kifetew
  */
@@ -71,7 +55,7 @@ public class RankBasedPreferenceSorting<T extends Chromosome<T>> implements Rank
      */
     @Override
     public void computeRankingAssignment(List<T> solutions,
-                                         Set<? extends FitnessFunction<T>> uncovered_goals) {
+                                         Set<? extends FitnessFunction<T>> uncoveredGoals) {
         if (solutions.isEmpty()) {
             logger.debug("solution is empty");
             return;
@@ -81,29 +65,29 @@ public class RankBasedPreferenceSorting<T extends Chromosome<T>> implements Rank
 
         // first apply the "preference sorting" to the first front only
         // then compute the ranks according to the non-dominate sorting algorithm
-        List<T> zero_front = this.getZeroFront(solutions, uncovered_goals);
-        this.fronts.add(zero_front);
+        List<T> zeroFront = this.getZeroFront(solutions, uncoveredGoals);
+        this.fronts.add(zeroFront);
         int frontIndex = 1;
 
-        if (zero_front.size() < Properties.POPULATION) {
-            int rankedSolutions = zero_front.size();
-            DominanceComparator<T> comparator = new DominanceComparator<>(uncovered_goals);
+        if (zeroFront.size() < Properties.POPULATION) {
+            int rankedSolutions = zeroFront.size();
+            DominanceComparator<T> comparator = new DominanceComparator<>(uncoveredGoals);
 
             List<T> remaining = new ArrayList<>(solutions.size());
             remaining.addAll(solutions);
-            remaining.removeAll(zero_front);
+            remaining.removeAll(zeroFront);
             while (rankedSolutions < Properties.POPULATION && remaining.size() > 0) {
-                List<T> new_front = this.getNonDominatedSolutions(remaining, comparator, frontIndex);
-                this.fronts.add(new_front);
-                remaining.removeAll(new_front);
-                rankedSolutions += new_front.size();
+                List<T> newFront = this.getNonDominatedSolutions(remaining, comparator, frontIndex);
+                this.fronts.add(newFront);
+                remaining.removeAll(newFront);
+                rankedSolutions += newFront.size();
                 frontIndex++;
             }
 
         } else {
             List<T> remaining = new ArrayList<>(solutions.size());
             remaining.addAll(solutions);
-            remaining.removeAll(zero_front);
+            remaining.removeAll(zeroFront);
 
             for (T t : remaining) {
                 t.setRank(frontIndex);
@@ -116,12 +100,12 @@ public class RankBasedPreferenceSorting<T extends Chromosome<T>> implements Rank
      * Returns the first (i.e. non-dominated) sub-front.
      *
      * @param solutionSet     the solutions to rank
-     * @param uncovered_goals the goals used for ranking
+     * @param uncoveredGoals the goals used for ranking
      * @return the non-dominated solutions (first sub-front)
      */
-    private List<T> getZeroFront(List<T> solutionSet, Set<? extends FitnessFunction<T>> uncovered_goals) {
-        Set<T> zero_front = new LinkedHashSet<>(solutionSet.size());
-        for (FitnessFunction<T> f : uncovered_goals) {
+    private List<T> getZeroFront(List<T> solutionSet, Set<? extends FitnessFunction<T>> uncoveredGoals) {
+        Set<T> zeroFront = new LinkedHashSet<>(solutionSet.size());
+        for (FitnessFunction<T> f : uncoveredGoals) {
             // for each uncovered goal, pick the best test using the proper comparator
             PreferenceSortingComparator<T> comp = new PreferenceSortingComparator<>(f);
 
@@ -135,9 +119,9 @@ public class RankBasedPreferenceSorting<T extends Chromosome<T>> implements Rank
             assert best != null;
 
             best.setRank(0);
-            zero_front.add(best);
+            zeroFront.add(best);
         }
-        return new ArrayList<>(zero_front);
+        return new ArrayList<>(zeroFront);
     }
 
     private List<T> getNonDominatedSolutions(List<T> solutions, DominanceComparator<T> comparator, int frontIndex) {

--- a/client/src/main/java/org/evosuite/ga/operators/ranking/RankingFunction.java
+++ b/client/src/main/java/org/evosuite/ga/operators/ranking/RankingFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -42,10 +42,10 @@ public interface RankingFunction<T extends Chromosome<T>> extends Serializable {
      * used for computing the ranking is defined by subclasses implementing this interface.
      *
      * @param solutions       the population to rank
-     * @param uncovered_goals the set of coverage goals to consider for the ranking assignment
+     * @param uncoveredGoals  the set of coverage goals to consider for the ranking assignment
      */
     void computeRankingAssignment(List<T> solutions,
-                                  Set<? extends FitnessFunction<T>> uncovered_goals);
+                                  Set<? extends FitnessFunction<T>> uncoveredGoals);
 
     /**
      * Returns the sub-front of {@link org.evosuite.ga.Chromosome} objects of the given rank. Sub-

--- a/client/src/main/java/org/evosuite/ga/operators/selection/BestKSelection.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/BestKSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -27,8 +27,8 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * {@inheritDoc}
- * <p>
- * Select individual by highest fitness
+ *
+ * <p>Select individual by highest fitness.
  */
 public class BestKSelection<T extends Chromosome<T>> extends SelectionFunction<T> {
 
@@ -43,8 +43,8 @@ public class BestKSelection<T extends Chromosome<T>> extends SelectionFunction<T
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Population has to be sorted!
+     *
+     * <p>Population has to be sorted!
      */
     @Override
     public List<T> select(List<T> population, int number) {
@@ -55,8 +55,8 @@ public class BestKSelection<T extends Chromosome<T>> extends SelectionFunction<T
 
     /**
      * Selects index of best offspring.
-     * <p>
-     * Population has to be sorted!
+     *
+     * <p>Population has to be sorted!
      */
     @Override
     public int getIndex(List<T> population) {

--- a/client/src/main/java/org/evosuite/ga/operators/selection/BinaryTournamentSelectionCrowdedComparison.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/BinaryTournamentSelectionCrowdedComparison.java
@@ -26,7 +26,7 @@ import org.evosuite.utils.Randomness;
 import java.util.List;
 
 /**
- * Select an individual from a population using a Crowd Comparison Operator
+ * Select an individual from a population using a Crowd Comparison Operator.
  *
  * @author José Campos
  */
@@ -35,12 +35,12 @@ public class BinaryTournamentSelectionCrowdedComparison<T extends Chromosome<T>>
     private static final long serialVersionUID = -6887165634607218631L;
 
     /**
-     * index stores the actual index for selection
+     * index stores the actual index for selection.
      */
     private int index = 0;
 
     /**
-     * indexes stores a permutation of ints
+     * indexes stores a permutation of ints.
      */
     private int[] indexes;
 
@@ -56,8 +56,9 @@ public class BinaryTournamentSelectionCrowdedComparison<T extends Chromosome<T>>
 
     @Override
     public int getIndex(List<T> population) {
-        if (this.index == 0) // Create the permutation
+        if (this.index == 0) { // Create the permutation
             this.indexes = intPermutation(population.size());
+        }
 
         int index1 = this.index;
         T p1 = population.get(this.indexes[index1]);
@@ -68,16 +69,17 @@ public class BinaryTournamentSelectionCrowdedComparison<T extends Chromosome<T>>
         this.index = (this.index + 2) % (population.size());
 
         int flag = this.comparator.compare(p1, p2);
-        if (flag < 0)
+        if (flag < 0) {
             return this.indexes[index1];
-        else if (flag > 0)
+        } else if (flag > 0) {
             return this.indexes[index2];
+        }
 
         return this.indexes[index1]; // default
     }
 
     /**
-     * Returns a permutation vector between the 0 and (length - 1)
+     * Returns a permutation vector between the 0 and (length - 1).
      */
     private int[] intPermutation(int length) {
         int[] aux = new int[length];

--- a/client/src/main/java/org/evosuite/ga/operators/selection/FitnessProportionateSelection.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/FitnessProportionateSelection.java
@@ -27,7 +27,7 @@ import java.util.stream.DoubleStream;
 
 
 /**
- * Roulette wheel selection
+ * Roulette wheel selection.
  *
  * @author Gordon Fraser
  */
@@ -45,7 +45,7 @@ public class FitnessProportionateSelection<T extends Chromosome<T>> extends Sele
 
     /**
      * Sum of fitness values, depending on minimization/maximization of the
-     * fitness function
+     * fitness function.
      */
     private double sumValue = 0.0;
 
@@ -66,13 +66,15 @@ public class FitnessProportionateSelection<T extends Chromosome<T>> extends Sele
         for (int i = 0; i < population.size(); i++) {
             double fit = population.get(i).getFitness();
 
-            if (!maximize)
+            if (!maximize) {
                 fit = invert(fit);
+            }
 
-            if (fit >= rnd)
+            if (fit >= rnd) {
                 return i;
-            else
+            } else {
                 rnd = rnd - fit;
+            }
         }
 
         //now this should never happens, but possible issues with rounding errors in for example "rnd = rnd - fit"
@@ -83,13 +85,15 @@ public class FitnessProportionateSelection<T extends Chromosome<T>> extends Sele
     }
 
     /**
-     * Calculate total sum of fitnesses
+     * Calculate total sum of fitnesses.
      *
-     * @param population
+     * @param population a {@link java.util.List} object.
      */
     private void setSum(List<T> population) {
         DoubleStream fitnessValues = population.stream().mapToDouble(Chromosome::getFitness);
-        if (!maximize) fitnessValues = fitnessValues.map(FitnessProportionateSelection::invert);
+        if (!maximize) {
+            fitnessValues = fitnessValues.map(FitnessProportionateSelection::invert);
+        }
         sumValue = fitnessValues.sum();
     }
 
@@ -102,8 +106,8 @@ public class FitnessProportionateSelection<T extends Chromosome<T>> extends Sele
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Return n parents
+     *
+     * <p>Return n parents.
      */
     @Override
     public List<T> select(List<T> population, int number) {

--- a/client/src/main/java/org/evosuite/ga/operators/selection/RandomKSelection.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/RandomKSelection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -25,7 +25,7 @@ import org.evosuite.utils.Randomness;
 import java.util.List;
 
 /**
- * Select random individual
+ * Select random individual.
  */
 public class RandomKSelection<T extends Chromosome<T>> extends SelectionFunction<T> {
 

--- a/client/src/main/java/org/evosuite/ga/operators/selection/RankSelection.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/RankSelection.java
@@ -28,8 +28,8 @@ import java.util.List;
 
 /**
  * {@inheritDoc}
- * <p>
- * Selects an individual by its rank.
+ *
+ * <p>Selects an individual by its rank.
  */
 public class RankSelection<T extends Chromosome<T>> extends SelectionFunction<T> {
 
@@ -49,10 +49,10 @@ public class RankSelection<T extends Chromosome<T>> extends SelectionFunction<T>
      * @param population the population to select an individual from
      * @return the index of the selected individual in the population
      * @implNote Approximates the index of the selected individual in {@code
-     * O(1)} by transforming an equally distributed random variable {@code
-     * 0 <= r <= 1}, as described by Whitley in the GENITOR algorithm (1989).
-     * For rank biases between 1 and 2, this produces results almost identical
-     * to the text-book specification of rank selection.
+     *     O(1)} by transforming an equally distributed random variable {@code
+     *     0 <= r <= 1}, as described by Whitley in the GENITOR algorithm (1989).
+     *     For rank biases between 1 and 2, this produces results almost identical
+     *     to the text-book specification of rank selection.
      */
     @Override
     public int getIndex(List<T> population) {
@@ -70,7 +70,7 @@ public class RankSelection<T extends Chromosome<T>> extends SelectionFunction<T>
 
         //this is not needed because population is sorted based on Maximization
         //if(maximize)
-        //	d = 1.0 - d; // to do that if we want to have Maximisation
+        //    d = 1.0 - d; // to do that if we want to have Maximisation
 
         int index = (int) (length * d);
         return index;

--- a/client/src/main/java/org/evosuite/ga/operators/selection/SelectionFunction.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/SelectionFunction.java
@@ -41,17 +41,17 @@ public abstract class SelectionFunction<T extends Chromosome<T>> implements Seri
     private static final long serialVersionUID = -2514933149542277609L;
 
     /**
-     * Constant <code>logger</code>
+     * Constant <code>logger</code>.
      */
     protected static final Logger logger = LoggerFactory.getLogger(SelectionFunction.class);
 
     /**
-     * Do we want to minimize or maximize fitness?
+     * Do we want to minimize or maximize fitness.
      */
     protected boolean maximize = true;
 
     /**
-     * Return index of next offspring
+     * Return index of next offspring.
      *
      * @param population a {@link List} object.
      * @return a int.
@@ -59,7 +59,7 @@ public abstract class SelectionFunction<T extends Chromosome<T>> implements Seri
     public abstract int getIndex(List<T> population);
 
     /**
-     * Return two parents
+     * Return two parents.
      *
      * @param population a {@link List} object.
      * @return a {@link org.evosuite.ga.Chromosome} object.
@@ -69,7 +69,7 @@ public abstract class SelectionFunction<T extends Chromosome<T>> implements Seri
     }
 
     /**
-     * Return n parents
+     * Return n parents.
      *
      * @param population a {@link List} object.
      * @param number     n
@@ -83,7 +83,7 @@ public abstract class SelectionFunction<T extends Chromosome<T>> implements Seri
     }
 
     /**
-     * Are we maximizing or minimizing fitness?
+     * Are we maximizing or minimizing fitness.
      *
      * @param max a boolean.
      */
@@ -92,9 +92,7 @@ public abstract class SelectionFunction<T extends Chromosome<T>> implements Seri
     }
 
     /**
-     * <p>
-     * isMaximize
-     * </p>
+     * <p>isMaximize.</p>
      *
      * @return true is we have to maximize
      */

--- a/client/src/main/java/org/evosuite/ga/operators/selection/TournamentSelection.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/TournamentSelection.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 
 /**
- * Select an individual from a population as winner of a number of tournaments
+ * Select an individual from a population as winner of a number of tournaments.
  *
  * @author Gordon Fraser
  */
@@ -44,27 +44,27 @@ public class TournamentSelection<T extends Chromosome<T>> extends SelectionFunct
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Perform the tournament on the population, return one index
+     *
+     * <p>Perform the tournament on the population, return one index.
      */
     @Override
     public int getIndex(List<T> population) {
-        int new_num = Randomness.nextInt(population.size());
-        int winner = new_num;
+        int newNum = Randomness.nextInt(population.size());
+        int winner = newNum;
 
         int round = 0;
 
         while (round < Properties.TOURNAMENT_SIZE - 1) {
-            new_num = Randomness.nextInt(population.size());
-            T selected = population.get(new_num);
+            newNum = Randomness.nextInt(population.size());
+            T selected = population.get(newNum);
 
             if (maximize) {
                 if (selected.getFitness() > population.get(winner).getFitness()) {
-                    winner = new_num;
+                    winner = newNum;
                 }
             } else {
                 if (selected.getFitness() < population.get(winner).getFitness()) {
-                    winner = new_num;
+                    winner = newNum;
                 }
             }
             round++;

--- a/client/src/main/java/org/evosuite/ga/operators/selection/TournamentSelectionRankAndCrowdingDistanceComparator.java
+++ b/client/src/main/java/org/evosuite/ga/operators/selection/TournamentSelectionRankAndCrowdingDistanceComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -55,24 +55,25 @@ public class TournamentSelectionRankAndCrowdingDistanceComparator<T extends Chro
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Perform the tournament on the population, return one index
+     *
+     * <p>Perform the tournament on the population, return one index.
      */
     @Override
     public int getIndex(List<T> population) {
-        int new_num = Randomness.nextInt(population.size());
-        int winner = new_num;
+        int newNum = Randomness.nextInt(population.size());
+        int winner = newNum;
 
         int round = 0;
 
         while (round < Properties.TOURNAMENT_SIZE - 1) {
-            new_num = Randomness.nextInt(population.size());
-            if (new_num == winner)
-                new_num = (new_num + 1) % population.size();
-            T selected = population.get(new_num);
+            newNum = Randomness.nextInt(population.size());
+            if (newNum == winner) {
+                newNum = (newNum + 1) % population.size();
+            }
+            T selected = population.get(newNum);
             int flag = comparator.compare(selected, population.get(winner));
             if (flag < 0) {
-                winner = new_num;
+                winner = newNum;
             }
             round++;
         }


### PR DESCRIPTION
This PR applies Checkstyle fixes to the `org.evosuite.ga.operators` package in the `client` module. 
The changes address various violations such as Javadoc formatting, naming conventions, missing braces, and license header issues. 
Code logic remains unchanged. Verified by running `mvn checkstyle:check` and compiling the client module.

---
*PR created automatically by Jules for task [4720650594544036861](https://jules.google.com/task/4720650594544036861) started by @gofraser*