### PR TITLE
Apply Checkstyle to org.evosuite.testsuite package

### DIFF
--- a/client/src/main/java/org/evosuite/testsuite/AbstractTestSuiteChromosome.java
+++ b/client/src/main/java/org/evosuite/testsuite/AbstractTestSuiteChromosome.java
@@ -39,6 +39,8 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 
 /**
+ * AbstractTestSuiteChromosome class.
+ *
  * @param <E> Class for SelfTyped Pattern
  */
 public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChromosome<T, E>,
@@ -53,7 +55,7 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     protected ChromosomeFactory<E> testChromosomeFactory;
 
     /**
-     * only used for testing/debugging
+     * only used for testing/debugging.
      */
     protected AbstractTestSuiteChromosome() {
         super();
@@ -61,7 +63,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
 
 
     /**
-     * <p>Constructor for AbstractTestSuiteChromosome.</p>
+     * <p>
+     * Constructor for AbstractTestSuiteChromosome.
+     * </p>
      *
      * @param testChromosomeFactory a {@link org.evosuite.ga.ChromosomeFactory} object.
      */
@@ -70,7 +74,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>Getter for the field <code>testChromosomeFactory</code>.</p>
+     * <p>
+     * Getter for the field <code>testChromosomeFactory</code>.
+     * </p>
      *
      * @return a {@link org.evosuite.ga.ChromosomeFactory} object.
      */
@@ -102,7 +108,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>addTest</p>
+     * <p>
+     * addTest.
+     * </p>
      *
      * @param test a T object.
      */
@@ -113,21 +121,25 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
 
     public void deleteTest(E test) {
         boolean changed = tests.remove(test);
-        if (changed)
+        if (changed) {
             this.setChanged(true);
+        }
     }
 
     public abstract E addTest(TestCase testCase);
 
     /**
-     * <p>addTests</p>
+     * <p>
+     * addTests.
+     * </p>
      *
      * @param tests a {@link java.util.Collection} object.
      */
     public void addTests(Collection<E> tests) {
         this.tests.addAll(tests);
-        if (!tests.isEmpty())
+        if (!tests.isEmpty()) {
             this.setChanged(true);
+        }
     }
 
     public abstract void addTestChromosome(TestChromosome testChromosome);
@@ -137,7 +149,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>addUnmodifiableTest</p>
+     * <p>
+     * addUnmodifiableTest.
+     * </p>
      *
      * @param test a T object.
      */
@@ -149,10 +163,10 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Replace chromosome at position.
+     *
+     * <p>Replace chromosome at position.
      * Note: Current implementation appends the test from the other chromosome at the given position to this chromosome,
-     * instead of replacing.
+     * instead of replacing.</p>
      */
     @Override
     public void crossOver(T other, int position) throws ConstructionFailedException {
@@ -166,8 +180,8 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Keep up to position1, append copy of other from position2 on
+     *
+     * <p>Keep up to position1, append copy of other from position2 on.</p>
      */
     @Override
     public void crossOver(T other, int position1, int position2)
@@ -191,15 +205,18 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
+        }
 
-        if (obj == null || getClass() != obj.getClass())
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
+        }
 
         AbstractTestSuiteChromosome<?, ?> other = (AbstractTestSuiteChromosome<?, ?>) obj;
-        if (other.size() != size())
+        if (other.size() != size()) {
             return false;
+        }
 
         return tests.equals(other.tests);
     }
@@ -214,8 +231,8 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Apply mutation on test suite level
+     *
+     * <p>Apply mutation on test suite level.</p>
      */
     @Override
     public void mutate() {
@@ -228,8 +245,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
             E test = tests.get(i);
             if (probabilityDistribution.toMutate(i)) {
                 test.mutate();
-                if (test.isChanged())
+                if (test.isChanged()) {
                     changed = true;
+                }
             }
         }
 
@@ -253,7 +271,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>totalLengthOfTestCases</p>
+     * <p>
+     * totalLengthOfTestCases.
+     * </p>
      *
      * @return Sum of the lengths of the test cases
      */
@@ -272,13 +292,15 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     /**
      * {@inheritDoc}
      *
-     * @return
+     * @return a T object.
      */
     @Override
     public abstract T clone();
 
     /**
-     * <p>getTestChromosome</p>
+     * <p>
+     * getTestChromosome.
+     * </p>
      *
      * @param index a int.
      * @return a T object.
@@ -288,7 +310,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>getTestChromosomes</p>
+     * <p>
+     * getTestChromosomes.
+     * </p>
      *
      * @return a {@link java.util.List} object.
      */
@@ -313,7 +337,9 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * <p>setTestChromosome</p>
+     * <p>
+     * setTestChromosome.
+     * </p>
      *
      * @param index a int.
      * @param test  a T object.
@@ -324,7 +350,7 @@ public abstract class AbstractTestSuiteChromosome<T extends AbstractTestSuiteChr
     }
 
     /**
-     * Remove all tests
+     * Remove all tests.
      */
     public void clearTests() {
         tests.clear();

--- a/client/src/main/java/org/evosuite/testsuite/MaxLengthBloatControl.java
+++ b/client/src/main/java/org/evosuite/testsuite/MaxLengthBloatControl.java
@@ -42,8 +42,8 @@ public class MaxLengthBloatControl implements BloatControlFunction<TestSuiteChro
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Check whether the chromosome is bigger than the max length constant
+     *
+     * <p>Check whether the chromosome is bigger than the max length constant.</p>
      */
     @Override
     public boolean isTooLong(TestSuiteChromosome chromosome) {

--- a/client/src/main/java/org/evosuite/testsuite/RelativeSuiteLengthBloatControl.java
+++ b/client/src/main/java/org/evosuite/testsuite/RelativeSuiteLengthBloatControl.java
@@ -38,67 +38,73 @@ public class RelativeSuiteLengthBloatControl<T extends Chromosome<T>> implements
     private static final long serialVersionUID = -2352882640530431653L;
 
     /**
-     * Longest individual in current generation
+     * Longest individual in current generation.
      */
-    protected int current_max;
+    protected int currentMax;
 
-    protected double best_fitness;
+    protected double bestFitness;
 
     public RelativeSuiteLengthBloatControl() {
-        current_max = 0;
-        best_fitness = Double.MAX_VALUE; // FIXXME: Assuming
+        currentMax = 0;
+        bestFitness = Double.MAX_VALUE; // FIXXME: Assuming
         // minimizing fitness!
     }
 
     public RelativeSuiteLengthBloatControl(final RelativeSuiteLengthBloatControl<?> that) {
-        this.current_max = that.current_max;
-        this.best_fitness = that.best_fitness;
+        this.currentMax = that.currentMax;
+        this.bestFitness = that.bestFitness;
     }
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Reject individuals that are larger than twice the length of the current
-     * best individual
+     *
+     * <p>Reject individuals that are larger than twice the length of the current
+     * best individual.</p>
      */
     @Override
     public boolean isTooLong(T chromosome) {
 
         // Always accept if fitness is better
-        if (chromosome.getFitness() < best_fitness)
+        if (chromosome.getFitness() < bestFitness) {
             return false;
+        }
 
-        // logger.debug("Current - max: "+((TestSuiteChromosome)chromosome).length()+" - "+current_max);
-        if (current_max > 0) {
+        // logger.debug("Current - max: "+((TestSuiteChromosome)chromosome).length()+" - "+currentMax);
+        if (currentMax > 0) {
             // if(((TestSuiteChromosome)chromosome).length() > bloat_factor *
-            // current_max)
+            // currentMax)
             // logger.debug("Bloat control: "+((TestSuiteChromosome)chromosome).length()
-            // +" > "+ bloat_factor * current_max);
+            // +" > "+ bloat_factor * currentMax);
 
             int length = 0;
-            if (chromosome instanceof TestSuiteChromosome)
+            if (chromosome instanceof TestSuiteChromosome) {
                 length = ((TestSuiteChromosome) chromosome).totalLengthOfTestCases();
-            if (chromosome instanceof TestChromosome)
+            }
+            if (chromosome instanceof TestChromosome) {
                 length = chromosome.size();
-            return length > (Properties.BLOAT_FACTOR * current_max);
-        } else
+            }
+            return length > (Properties.BLOAT_FACTOR * currentMax);
+        } else {
             return false; // Don't know max length so can't reject!
+        }
 
     }
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Set current max length to max of best chromosome
+     *
+     * <p>Set current max length to max of best chromosome.</p>
      */
     @Override
     public void iteration(GeneticAlgorithm<T> algorithm) {
         T best = algorithm.getBestIndividual();
-        if (best instanceof TestSuiteChromosome)
-            current_max = ((TestSuiteChromosome) best).totalLengthOfTestCases();
-        if (best instanceof TestChromosome)
-            current_max = best.size();
-        best_fitness = best.getFitness();
+        if (best instanceof TestSuiteChromosome) {
+            currentMax = ((TestSuiteChromosome) best).totalLengthOfTestCases();
+        }
+        if (best instanceof TestChromosome) {
+            currentMax = best.size();
+        }
+        bestFitness = best.getFitness();
     }
 
     /**

--- a/client/src/main/java/org/evosuite/testsuite/StatementsPopulationLimit.java
+++ b/client/src/main/java/org/evosuite/testsuite/StatementsPopulationLimit.java
@@ -41,14 +41,18 @@ public class StatementsPopulationLimit<T extends Chromosome<T>>
     }
 
     /**
-     * Copy Constructor
+     * Copy Constructor.
+     *
      * <p>
      * This constructor is used by {@link org.evosuite.ga.metaheuristics.TestSuiteAdapter} to adapt the generic type
      * parameter.
+     * </p>
+     *
      * <p>
      * This constructor shall preserve the current state of the StatementsPopulationLimit (if existing).
+     * </p>
      *
-     * @param other
+     * @param other a {@link org.evosuite.testsuite.StatementsPopulationLimit} object.
      */
     public StatementsPopulationLimit(StatementsPopulationLimit<?> other) {
     }
@@ -63,12 +67,14 @@ public class StatementsPopulationLimit<T extends Chromosome<T>>
     @Override
     public boolean isPopulationFull(List<T> population) {
         int numStatements = population.stream().map(x -> {
-                    if (x instanceof TestSuiteChromosome)
-                        return x;
-                    if (x instanceof TestChromosome)
-                        return ((TestChromosome) x).toSuite();
-                    throw new IllegalArgumentException("Could not transform population to TestSuites");
-                })
+            if (x instanceof TestSuiteChromosome) {
+                return x;
+            }
+            if (x instanceof TestChromosome) {
+                return ((TestChromosome) x).toSuite();
+            }
+            throw new IllegalArgumentException("Could not transform population to TestSuites");
+        })
                 .mapToInt(x -> ((TestSuiteChromosome) x).totalLengthOfTestCases())
                 .sum();
         return numStatements >= Properties.POPULATION;

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteChromosome.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteChromosome.java
@@ -37,15 +37,17 @@ import static java.util.stream.Collectors.toCollection;
  * TestSuiteChromosome class.
  * </p>
  *
- * @author Gordon Fraser
  * <p>
  * Final in order to prevent breaking of self type.
+ * </p>
+ *
+ * @author Gordon Fraser
  */
 public final class TestSuiteChromosome
         extends AbstractTestSuiteChromosome<TestSuiteChromosome, TestChromosome> {
 
     /**
-     * Secondary objectives used during ranking
+     * Secondary objectives used during ranking.
      */
     private static final List<SecondaryObjective<TestSuiteChromosome>>
             secondaryObjectives = new ArrayList<>();
@@ -54,7 +56,7 @@ public final class TestSuiteChromosome
 
     /**
      * Add an additional secondary objective to the end of the list of
-     * objectives
+     * objectives.
      *
      * @param objective a {@link org.evosuite.ga.SecondaryObjective} object.
      */
@@ -71,13 +73,15 @@ public final class TestSuiteChromosome
     }
 
     public static void disableFirstSecondaryObjective() {
-        if (secondaryObjIndex != 1)
+        if (secondaryObjIndex != 1) {
             secondaryObjIndex = 1;
+        }
     }
 
     public static void enableFirstSecondaryObjective() {
-        if (secondaryObjIndex != 0)
+        if (secondaryObjIndex != 0) {
             secondaryObjIndex = 0;
+        }
     }
 
     public static void reverseSecondaryObjective() {
@@ -85,7 +89,7 @@ public final class TestSuiteChromosome
     }
 
     /**
-     * Remove secondary objective from list, if it is there
+     * Remove secondary objective from list, if it is there.
      *
      * @param objective a {@link org.evosuite.ga.SecondaryObjective} object.
      */
@@ -135,9 +139,10 @@ public final class TestSuiteChromosome
     }
 
     /**
-     * Add a test to a test suite
+     * Add a test to a test suite.
      *
      * @param test a {@link org.evosuite.testcase.TestCase} object.
+     * @return a {@link org.evosuite.testcase.TestChromosome} object.
      */
     public TestChromosome addTest(TestCase test) {
         TestChromosome c = new TestChromosome();
@@ -160,10 +165,10 @@ public final class TestSuiteChromosome
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Create a deep copy of this test suite
      *
-     * @return
+     * <p>Create a deep copy of this test suite.</p>
+     *
+     * @return a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
     @Override
     public TestSuiteChromosome clone() {
@@ -183,8 +188,9 @@ public final class TestSuiteChromosome
         int c = 0;
         while (c == 0 && objective < secondaryObjectives.size()) {
             SecondaryObjective<TestSuiteChromosome> so = secondaryObjectives.get(objective++);
-            if (so == null)
+            if (so == null) {
                 break;
+            }
             c = so.compareChromosomes(this.self(), o);
         }
         return c;
@@ -192,7 +198,7 @@ public final class TestSuiteChromosome
 
 
     /**
-     * For manual algorithm
+     * For manual algorithm.
      *
      * @param testCase to remove
      */
@@ -204,7 +210,7 @@ public final class TestSuiteChromosome
 
     /**
      * <p>
-     * getCoveredGoals
+     * getCoveredGoals.
      * </p>
      *
      * @return a {@link java.util.Set} object.
@@ -224,7 +230,7 @@ public final class TestSuiteChromosome
 
     /**
      * <p>
-     * getTests
+     * getTests.
      * </p>
      *
      * @return a {@link java.util.List} object.
@@ -244,8 +250,8 @@ public final class TestSuiteChromosome
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Apply mutation on test suite level
+     *
+     * <p>Apply mutation on test suite level.</p>
      */
     @Override
     public void mutate() {
@@ -254,17 +260,15 @@ public final class TestSuiteChromosome
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Determine relative ordering of this chromosome to another chromosome If
-     * fitness is equal, the shorter chromosome comes first
-     */
     /*
      * public int compareTo(Chromosome o) { if(RANK_LENGTH && getFitness() ==
      * o.getFitness()) { return (int) Math.signum((length() -
      * ((TestSuiteChromosome)o).length())); } else return (int)
      * Math.signum(getFitness() - o.getFitness()); }
+     */
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public String toString() {

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteFitnessFuncToTestFitnessFactoryAdapter.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteFitnessFuncToTestFitnessFactoryAdapter.java
@@ -30,20 +30,20 @@ import java.util.List;
  *
  * @author Sebastian Steenbuck
  */
-public class TestSuiteFitnessFunc_to_TestFitnessFactory_Adapter implements
+public class TestSuiteFitnessFuncToTestFitnessFactoryAdapter implements
         TestFitnessFactory<TestFitnessFunction> {
 
     private final TestSuiteFitnessFunction testSuiteFitness;
 
     /**
      * <p>
-     * Constructor for TestSuiteFitnessFunc_to_TestFitnessFactory_Adapter.
+     * Constructor for TestSuiteFitnessFuncToTestFitnessFactoryAdapter.
      * </p>
      *
      * @param testSuiteFitness a {@link org.evosuite.testsuite.TestSuiteFitnessFunction}
      *                         object.
      */
-    public TestSuiteFitnessFunc_to_TestFitnessFactory_Adapter(
+    public TestSuiteFitnessFuncToTestFitnessFactoryAdapter(
             TestSuiteFitnessFunction testSuiteFitness) {
         this.testSuiteFitness = testSuiteFitness;
     }

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteFitnessFunction.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteFitnessFunction.java
@@ -43,13 +43,13 @@ public abstract class TestSuiteFitnessFunction extends FitnessFunction<TestSuite
     private static final long serialVersionUID = 7243635497292960457L;
 
     /**
-     * Constant <code>logger</code>
+     * Constant <code>logger</code>.
      */
     protected static final Logger logger = LoggerFactory.getLogger(TestSuiteFitnessFunction.class);
 
 
     /**
-     * Execute a test case
+     * Execute a test case.
      *
      * @param test The test case to execute
      * @return Result of the execution
@@ -69,7 +69,7 @@ public abstract class TestSuiteFitnessFunction extends FitnessFunction<TestSuite
 
     /**
      * <p>
-     * runTestSuite
+     * runTestSuite.
      * </p>
      *
      * @param suite a {@link org.evosuite.testsuite.AbstractTestSuiteChromosome}

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteMinimizer.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteMinimizer.java
@@ -54,14 +54,14 @@ import static java.util.Comparator.comparingInt;
 public class TestSuiteMinimizer {
 
     /**
-     * Logger
+     * Logger.
      */
-    private final static Logger logger = LoggerFactory.getLogger(TestSuiteMinimizer.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestSuiteMinimizer.class);
 
     private final List<TestFitnessFactory<?>> testFitnessFactories = new ArrayList<>();
 
     /**
-     * Assume the search has not started until startTime != 0
+     * Assume the search has not started until startTime != 0.
      */
     protected static long startTime = 0L;
 
@@ -82,7 +82,7 @@ public class TestSuiteMinimizer {
 
     /**
      * <p>
-     * minimize
+     * minimize.
      * </p>
      *
      * @param suite           a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
@@ -101,10 +101,11 @@ public class TestSuiteMinimizer {
         logger.info("Minimization Strategy: " + strategy + ", " + suite.size() + " tests");
         suite.clearMutationHistory();
 
-        if (minimizePerTest)
+        if (minimizePerTest) {
             minimizeTests(suite);
-        else
+        } else {
             minimizeSuite(suite);
+        }
 
         ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Minimized_Size,
                 suite.size());
@@ -120,16 +121,19 @@ public class TestSuiteMinimizer {
     }
 
     private void filterJUnitCoveredGoals(List<TestFitnessFunction> goals) {
-        if (Properties.JUNIT.isEmpty())
+        if (Properties.JUNIT.isEmpty()) {
             return;
+        }
 
         LoggingUtils.getEvoLogger().info("* Determining coverage of existing tests");
         String[] testClasses = Properties.JUNIT.split(":");
         for (String testClass : testClasses) {
             try {
-                Class<?> junitClass = Class.forName(testClass, true, TestGenerationContext.getInstance().getClassLoaderForSUT());
+                Class<?> junitClass = Class.forName(testClass, true,
+                        TestGenerationContext.getInstance().getClassLoaderForSUT());
                 Set<TestFitnessFunction> coveredGoals = CoverageAnalysis.getCoveredGoals(junitClass, goals);
-                LoggingUtils.getEvoLogger().info("* Removing " + coveredGoals.size() + " goals already covered by JUnit (total: " + goals.size() + ")");
+                LoggingUtils.getEvoLogger().info("* Removing " + coveredGoals.size()
+                        + " goals already covered by JUnit (total: " + goals.size() + ")");
                 //logger.warn("Removing " + coveredGoals + " goals already covered by JUnit (total: " + goals + ")");
                 goals.removeAll(coveredGoals);
                 logger.info("Remaining goals: " + goals.size() + ": " + goals);
@@ -141,7 +145,7 @@ public class TestSuiteMinimizer {
 
     /**
      * Minimize test suite with respect to the isCovered Method of the goals
-     * defined by the supplied TestFitnessFactory
+     * defined by the supplied TestFitnessFactory.
      *
      * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
@@ -164,8 +168,9 @@ public class TestSuiteMinimizer {
         int currentGoal = 0;
         int numGoals = goals.size();
 
-        if (Properties.MINIMIZE_SORT)
+        if (Properties.MINIMIZE_SORT) {
             Collections.sort(goals);
+        }
 
         Set<TestFitnessFunction> covered = new LinkedHashSet<>();
         List<TestChromosome> minimizedTests = new ArrayList<>();
@@ -197,7 +202,9 @@ public class TestSuiteMinimizer {
                         break;
                     }
                 }
-                if (innerTimeout) break;
+                if (innerTimeout) {
+                    break;
+                }
             }
             if (covered.contains(goal)) {
                 logger.info("Already covered: " + goal);
@@ -252,13 +259,15 @@ public class TestSuiteMinimizer {
 
         List<TestCase> originalTestCases = null;
         if (timeout) {
-             originalTestCases = suite.getTests();
+            originalTestCases = suite.getTests();
         }
 
         suite.tests.clear();
 
         if (timeout && originalTestCases != null) {
-             for (TestCase test : originalTestCases) suite.addTest(test);
+            for (TestCase test : originalTestCases) {
+                suite.addTest(test);
+            }
         }
 
         for (TestCase test : minimizedSuite.getTestCases()) {
@@ -279,8 +288,9 @@ public class TestSuiteMinimizer {
         ClientServices.getInstance().getClientNode().changeState(state, information);
 
         for (TestFitnessFunction goal : goals) {
-            if (!covered.contains(goal))
+            if (!covered.contains(goal)) {
                 logger.info("Failed to cover: " + goal);
+            }
         }
         // suite.tests = minimizedTests;
     }
@@ -291,7 +301,7 @@ public class TestSuiteMinimizer {
 
     /**
      * Minimize test suite with respect to the isCovered Method of the goals
-     * defined by the supplied TestFitnessFactory
+     * defined by the supplied TestFitnessFactory.
      *
      * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
@@ -330,12 +340,14 @@ public class TestSuiteMinimizer {
             removeEmptyTestCases(suite);
 
             for (TestChromosome testChromosome : suite.tests) {
-                if (isTimeoutReached())
+                if (isTimeoutReached()) {
                     break;
+                }
 
                 for (int i = testChromosome.size() - 1; i >= 0; i--) {
-                    if (isTimeoutReached())
+                    if (isTimeoutReached()) {
                         break;
+                    }
 
                     logger.debug("Current size: " + suite.size() + "/"
                             + suite.totalLengthOfTestCases());
@@ -363,38 +375,40 @@ public class TestSuiteMinimizer {
                     testChromosome.getTestCase().clearCoveredGoals();
 
                     List<Double> modifiedVerFitness = new ArrayList<>();
-                    for (TestFitnessFactory<?> ff : testFitnessFactories)
+                    for (TestFitnessFactory<?> ff : testFitnessFactories) {
                         modifiedVerFitness.add(ff.getFitness(suite));
+                    }
 
-                    int compare_ff = 0;
-                    for (int i_fit = 0; i_fit < modifiedVerFitness.size(); i_fit++) {
-                        if (Double.compare(modifiedVerFitness.get(i_fit), fitness.get(i_fit)) < 0) {
-                            compare_ff = -1; // new value is lower than previous one
+                    int compareFf = 0;
+                    for (int fitnessIndex = 0; fitnessIndex < modifiedVerFitness.size(); fitnessIndex++) {
+                        if (Double.compare(modifiedVerFitness.get(fitnessIndex),
+                                fitness.get(fitnessIndex)) < 0) {
+                            compareFf = -1; // new value is lower than previous one
                             break;
-                        } else if (Double.compare(modifiedVerFitness.get(i_fit), fitness.get(i_fit)) > 0) {
-                            compare_ff = 1; // new value is greater than previous one
+                        } else if (Double.compare(modifiedVerFitness.get(fitnessIndex),
+                                fitness.get(fitnessIndex)) > 0) {
+                            compareFf = 1; // new value is greater than previous one
                             break;
                         }
                     }
 
                     // the value 0 if d1 (previous fitness) is numerically equal to d2 (new fitness)
-                    if (compare_ff == 0) {
-                        continue; // if we can guarantee that we have the same fitness value with less statements, better
-                    } else if (compare_ff == -1) // a value less than 0 if d1 is numerically less than d2
-                    {
+                    if (compareFf == 0) {
+                        // if we can guarantee that we have the same fitness value with less statements, better
+                        continue;
+                    } else if (compareFf == -1) {
+                        // a value less than 0 if d1 is numerically less than d2
                         fitness = modifiedVerFitness;
                         changed = true;
-                        /**
-                         * This means, that we try to delete statements equally
-                         * from each test case (If size is 'false'.) The hope is
-                         * that the median length of the test cases is shorter,
-                         * as opposed to the average length.
-                         */
-                        if (!size)
+                        // This means, that we try to delete statements equally
+                        // from each test case (If size is 'false'.) The hope is
+                        // that the median length of the test cases is shorter,
+                        // as opposed to the average length.
+                        if (!size) {
                             break;
-                    }
-                    // and a value greater than 0 if d1 is numerically greater than d2
-                    else if (compare_ff == 1) {
+                        }
+                    } else if (compareFf == 1) {
+                        // and a value greater than 0 if d1 is numerically greater than d2
                         // Restore previous state
                         logger.debug("Can't remove statement "
                                 + originalTestChromosome.getTestCase().getStatement(i).getCode());

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteReplacementFunction.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteReplacementFunction.java
@@ -55,7 +55,7 @@ public class TestSuiteReplacementFunction extends ReplacementFunction<TestSuiteC
 
     /**
      * <p>
-     * getLengthSum
+     * getLengthSum.
      * </p>
      *
      * @param chromosome1 a {@link org.evosuite.testsuite.AbstractTestSuiteChromosome}

--- a/client/src/main/java/org/evosuite/testsuite/TestSuiteSerialization.java
+++ b/client/src/main/java/org/evosuite/testsuite/TestSuiteSerialization.java
@@ -86,7 +86,8 @@ public class TestSuiteSerialization {
     }
 
 
-    public static boolean saveTests(List<TestSuiteChromosome> ts, File folder, String fileName) throws IllegalArgumentException {
+    public static boolean saveTests(List<TestSuiteChromosome> ts, File folder, String fileName)
+            throws IllegalArgumentException {
         Inputs.checkNull(ts, folder, fileName);
 
         if (!folder.exists()) {
@@ -131,7 +132,8 @@ public class TestSuiteSerialization {
             } catch (EOFException e) {
                 //fine
             } catch (Exception e) {
-                logger.warn("Problems when reading a serialized test from " + target.getAbsolutePath() + " : " + e.getMessage());
+                logger.warn("Problems when reading a serialized test from " + target.getAbsolutePath() + " : "
+                        + e.getMessage());
             }
 
             in.close();

--- a/client/src/main/java/org/evosuite/testsuite/factories/FixedSizeTestSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/FixedSizeTestSuiteChromosomeFactory.java
@@ -37,7 +37,7 @@ public class FixedSizeTestSuiteChromosomeFactory implements
     private static final long serialVersionUID = 6269582177138945987L;
 
     /**
-     * Factory to manipulate and generate method sequences
+     * Factory to manipulate and generate method sequences.
      */
     private final ChromosomeFactory<TestChromosome> testChromosomeFactory;
 

--- a/client/src/main/java/org/evosuite/testsuite/factories/SerializationSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/SerializationSuiteChromosomeFactory.java
@@ -47,7 +47,7 @@ public class SerializationSuiteChromosomeFactory
      * The carved test cases are used only with a certain probability P. So, with probability 1-P the 'default' factory
      * is rather used.
      *
-     * @param defaultFactory
+     * @param defaultFactory a {@link org.evosuite.ga.ChromosomeFactory} object.
      * @throws IllegalStateException if Properties are not properly set
      */
     public SerializationSuiteChromosomeFactory(ChromosomeFactory<TestChromosome> defaultFactory)
@@ -57,7 +57,8 @@ public class SerializationSuiteChromosomeFactory
         if (Properties.CTG_SEEDS_FILE_IN != null) {
             this.previousSuite.addAll(TestSuiteSerialization.loadTests(Properties.CTG_SEEDS_FILE_IN));
         } else {
-            this.previousSuite.addAll(TestSuiteSerialization.loadTests(Properties.SEED_DIR + File.separator + Properties.TARGET_CLASS));
+            this.previousSuite.addAll(TestSuiteSerialization.loadTests(Properties.SEED_DIR + File.separator
+                    + Properties.TARGET_CLASS));
         }
     }
 

--- a/client/src/main/java/org/evosuite/testsuite/factories/TestSuiteChromosomeFactory.java
+++ b/client/src/main/java/org/evosuite/testsuite/factories/TestSuiteChromosomeFactory.java
@@ -41,7 +41,7 @@ public class TestSuiteChromosomeFactory implements ChromosomeFactory<TestSuiteCh
     }
 
     /**
-     * Factory to manipulate and generate method sequences
+     * Factory to manipulate and generate method sequences.
      */
     protected ChromosomeFactory<TestChromosome> testChromosomeFactory;
 
@@ -62,7 +62,7 @@ public class TestSuiteChromosomeFactory implements ChromosomeFactory<TestSuiteCh
     }
 
     /**
-     * <p>setTestFactory</p>
+     * <p>setTestFactory.</p>
      *
      * @param factory a {@link org.evosuite.ga.ChromosomeFactory} object.
      */

--- a/client/src/main/java/org/evosuite/testsuite/localsearch/TestSuiteLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testsuite/localsearch/TestSuiteLocalSearch.java
@@ -45,15 +45,15 @@ import java.util.*;
 import java.util.Map.Entry;
 
 /**
- * . This class applies local search on a test suite. Depending on the values
+ * This class applies local search on a test suite. Depending on the values
  * for properties <code>DSE_PROBABILITY</code> and <code>LOCAL_SEARCH_DSE</code>
  * one of the following three modes is applied:
- * <p>
- * - apply DSE on all test cases
- * <p>
- * - apply AVM on all test cases
- * <p>
- * - apply DSE on some tests and AVM on other tests
+ *
+ * <p>- apply DSE on all test cases</p>
+ *
+ * <p>- apply AVM on all test cases</p>
+ *
+ * <p>- apply DSE on some tests and AVM on other tests</p>
  *
  * @author galeotti
  */
@@ -63,7 +63,7 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * Updates the given list of fitness functions using for the individual
-     * passed as a parameter
+     * passed as a parameter.
      *
      * @param individual       an individual
      * @param fitnessFunctions the list of fitness functions to be updated
@@ -79,7 +79,7 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
      * Decides the kind of local search that will be applied to the Test Suite.
      *
      * @return a <code>TestSuiteLocalSearch</code> instance to use for local
-     * search
+     *     search
      */
     public static TestSuiteLocalSearch selectTestSuiteLocalSearch() {
         return new TestSuiteLocalSearch();
@@ -87,16 +87,16 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * Before applying DSE we expand test cases, such that each primitive value
-     * is used at only exactly one position as a parameter
-     * <p>
-     * For example, given the following test case:
+     * is used at only exactly one position as a parameter.
+     *
+     * <p>For example, given the following test case:</p>
      *
      * <code>
      * foo0.bar(1);
      * foo1.bar(1);
      * </code>
-     * <p>
-     * is rewritten as:
+     *
+     * <p>is rewritten as:</p>
      *
      * <code>
      * int int0 = 1;
@@ -105,11 +105,11 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
      * foo1.bar(int1);
      * </code>
      *
-     * @param suite
-     * @return
+     * @param suite a T object.
+     * @param objective a {@link org.evosuite.ga.localsearch.LocalSearchObjective} object.
      */
     private static <T extends AbstractTestSuiteChromosome<T, E>, E extends AbstractTestChromosome<E>>
-    void expandTestSuite(T suite, LocalSearchObjective<T> objective) {
+            void expandTestSuite(T suite, LocalSearchObjective<T> objective) {
         logger.debug("Expanding tests for local search");
 
         TestSuiteChromosome newTestSuite = new TestSuiteChromosome();
@@ -151,8 +151,8 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
      * foo0.bar(1);
      * foo1.bar(1);
      * </code>
-     * <p>
-     * is rewritten as:
+     *
+     * <p>is rewritten as:</p>
      *
      * <code>
      * int int0 = 1;
@@ -165,8 +165,9 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
      * @return the expanded test case
      */
     private static TestCase expandTestCase(TestCase test) {
-        if (!Properties.LOCAL_SEARCH_EXPAND_TESTS)
+        if (!Properties.LOCAL_SEARCH_EXPAND_TESTS) {
             return test;
+        }
 
         TestCaseExpander expander = new TestCaseExpander();
         return expander.expandTestCase(test);
@@ -176,10 +177,10 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
      * Ensure that all branches are executed twice For each branch such that
      * exists only one test case in the suite that covers that branch, it
      * creates a duplicate of that test case.
-     * <p>
-     * By doing this, we avoid to incorrectly mark a new test case produced by
+     *
+     * <p>By doing this, we avoid to incorrectly mark a new test case produced by
      * the local search as an improving test case because it simply executes
-     * again a predicate.
+     * again a predicate.</p>
      */
     protected static void ensureDoubleExecution(TestSuiteChromosome individual,
                                                 LocalSearchObjective<TestSuiteChromosome> objective) {
@@ -235,13 +236,13 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * Returns the set of predicate indexes whose true branches were covered by
-     * the suite
+     * the suite.
      *
-     * @param suite
-     * @return
+     * @param suite a {@link org.evosuite.testsuite.AbstractTestSuiteChromosome} object.
+     * @return a {@link java.util.Set} object.
      */
     private static <T extends AbstractTestSuiteChromosome<T, E>, E extends AbstractTestChromosome<E>> Set<Integer>
-    getCoveredTrueBranches(AbstractTestSuiteChromosome<T, E> suite) {
+            getCoveredTrueBranches(AbstractTestSuiteChromosome<T, E> suite) {
         Set<Integer> covered = new LinkedHashSet<>();
         for (E testChromosome : suite.getTestChromosomes()) {
             ExecutionResult lastResult = testChromosome.getLastExecutionResult();
@@ -254,13 +255,13 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * Returns the set of the predicate indexes whose false branch were covered
-     * by the test suite
+     * by the test suite.
      *
-     * @param suite
+     * @param suite a {@link org.evosuite.testsuite.AbstractTestSuiteChromosome} object.
      * @return the set of predicate indexes whose false branch were covered
      */
     private static <T extends AbstractTestSuiteChromosome<T, E>, E extends AbstractTestChromosome<E>> Set<Integer>
-    getCoveredFalseBranches(AbstractTestSuiteChromosome<T, E> suite) {
+            getCoveredFalseBranches(AbstractTestSuiteChromosome<T, E> suite) {
         Set<Integer> covered = new LinkedHashSet<>();
         for (E testChromosome : suite.getTestChromosomes()) {
             ExecutionResult lastResult = testChromosome.getLastExecutionResult();
@@ -272,7 +273,7 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
     }
 
     /**
-     * Ensure that all branches are executed twice
+     * Ensure that all branches are executed twice.
      */
     private void restoreBranchCoverage(TestSuiteChromosome individual) {
         logger.debug("Adding branches already covered previously");
@@ -295,7 +296,7 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * Indicates if the fitness of the individual has improved with respected to
-     * parameter <code>fitnessBefore</code>
+     * parameter <code>fitnessBefore</code>.
      *
      * @param fitnessBefore the previous fitness of the individual
      * @param individual    the individual
@@ -383,22 +384,22 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
 
     /**
      * This enumerate represents which type of local search will be applied on
-     * the suite
+     * the suite.
      *
      * @author galeotti
      */
     enum LocalSearchSuiteType {
         /**
-         * Always apply DSE on all test cases in the suite
+         * Always apply DSE on all test cases in the suite.
          */
         ALWAYS_DSE,
         /**
-         * Always apply AVM on all test cases in the suite
+         * Always apply AVM on all test cases in the suite.
          */
         ALWAYS_AVM,
         /**
          * Apply AVM/DSE on a test case according to the
-         * <code>DSE_PROBABILITY</code>
+         * <code>DSE_PROBABILITY</code>.
          */
         DSE_AND_AVM
     }
@@ -493,13 +494,13 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
     }
 
     /**
-     * Applies AVM on the test case in the suite
+     * Applies AVM on the test case in the suite.
      *
-     * @param suite
-     * @param testIndex
-     * @param test
-     * @param objective
-     * @return
+     * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @param testIndex a int.
+     * @param test a {@link org.evosuite.testcase.TestChromosome} object.
+     * @param objective a {@link org.evosuite.ga.localsearch.LocalSearchObjective} object.
+     * @return a boolean.
      */
     private boolean applyAVM(TestSuiteChromosome suite,
                              int testIndex,
@@ -517,13 +518,13 @@ public class TestSuiteLocalSearch implements LocalSearch<TestSuiteChromosome> {
     }
 
     /**
-     * Applies DSE on the test case of the suite
+     * Applies DSE on the test case of the suite.
      *
-     * @param suite
-     * @param testIndex
-     * @param test
-     * @param objective
-     * @return
+     * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @param testIndex a int.
+     * @param test a {@link org.evosuite.testcase.TestChromosome} object.
+     * @param objective a {@link org.evosuite.ga.localsearch.LocalSearchObjective} object.
+     * @return a boolean.
      */
     private boolean applyDSE(TestSuiteChromosome suite, int testIndex, TestChromosome test,
                              LocalSearchObjective<TestSuiteChromosome> objective) {

--- a/client/src/main/java/org/evosuite/testsuite/localsearch/TestSuiteLocalSearchObjective.java
+++ b/client/src/main/java/org/evosuite/testsuite/localsearch/TestSuiteLocalSearchObjective.java
@@ -91,20 +91,21 @@ public class TestSuiteLocalSearchObjective implements LocalSearchObjective<TestC
      * Creates a new <code>TestSuiteLocalSearchObjective</code> for a given list
      * of fitness functions, a test suite and a <code>testIndex</code> for
      * replacing an optimised test case (i.e. a test case over which was applied
-     * local search)
+     * local search).
      *
      * @param fitness the list of fitness functions to be used on the modified test
      *                suite
      * @param suite   the original test suite
      * @param index   the index (between 0 and the suite length) that will be
      *                replaced with a new test case
-     * @return
+     * @param <T>     a T object.
+     * @return a {@link org.evosuite.testsuite.localsearch.TestSuiteLocalSearchObjective} object.
      */
     public static <T extends Chromosome<T>> TestSuiteLocalSearchObjective
-    buildNewTestSuiteLocalSearchObjective(
-            List<FitnessFunction<T>> fitness,
-            TestSuiteChromosome suite,
-            int index) {
+            buildNewTestSuiteLocalSearchObjective(
+                    List<FitnessFunction<T>> fitness,
+                    TestSuiteChromosome suite,
+                    int index) {
         List<TestSuiteFitnessFunction> ffs = new ArrayList<>();
         for (FitnessFunction<T> ff : fitness) {
             TestSuiteFitnessFunction tff = (TestSuiteFitnessFunction) ff;
@@ -130,14 +131,15 @@ public class TestSuiteLocalSearchObjective implements LocalSearchObjective<TestC
 
     /**
      * Returns true if all the fitness functions are minimising and the fitness
-     * value for each of them is 0.0
+     * value for each of them is 0.0.
      */
     @Override
     public boolean isDone() {
 
         for (TestSuiteFitnessFunction fitness : fitnessFunctions) {
-            if (fitness.isMaximizationFunction() || fitness.getFitness(suite) != 0.0)
+            if (fitness.isMaximizationFunction() || fitness.getFitness(suite) != 0.0) {
                 return false;
+            }
         }
         return true;
     }
@@ -154,7 +156,7 @@ public class TestSuiteLocalSearchObjective implements LocalSearchObjective<TestC
     /**
      * Returns true if by replacing the test case at position
      * <code>testIndex</code> with the argument <code>testCase</code>, the
-     * resulting test suite has not worsened the fitness
+     * resulting test suite has not worsened the fitness.
      */
     @Override
     public boolean hasNotWorsened(TestChromosome testCase) {
@@ -188,8 +190,9 @@ public class TestSuiteLocalSearchObjective implements LocalSearchObjective<TestC
         testCase.setChanged(true);
         suite.setTestChromosome(testIndex, testCase);
         LocalSearchBudget.getInstance().countFitnessEvaluation();
-        for (TestSuiteFitnessFunction fitnessFunction : fitnessFunctions)
+        for (TestSuiteFitnessFunction fitnessFunction : fitnessFunctions) {
             fitnessFunction.getFitness(suite);
+        }
         double newFitness = suite.getFitness();
 
         if (isFitnessBetter(newFitness, lastFitnessSum)) {
@@ -215,7 +218,7 @@ public class TestSuiteLocalSearchObjective implements LocalSearchObjective<TestC
      * this local search objective, this function should not belong. TODO: Why
      * not simply returning the fitness functions of the suite?
      *
-     * @return
+     * @return a {@link java.util.List} object.
      */
     @Override
     public List<FitnessFunction<TestChromosome>> getFitnessFunctions() {

--- a/client/src/main/java/org/evosuite/testsuite/secondaryobjectives/MinimizeExceptionsSecondaryObjective.java
+++ b/client/src/main/java/org/evosuite/testsuite/secondaryobjectives/MinimizeExceptionsSecondaryObjective.java
@@ -37,8 +37,9 @@ public class MinimizeExceptionsSecondaryObjective extends SecondaryObjective<Tes
     private int getNumExceptions(TestSuiteChromosome chromosome) {
         int sum = 0;
         for (TestChromosome test : chromosome.getTestChromosomes()) {
-            if (test.getLastExecutionResult() != null)
+            if (test.getLastExecutionResult() != null) {
                 sum += test.getLastExecutionResult().getNumberOfThrownExceptions();
+            }
         }
         return sum;
     }

--- a/client/src/main/java/org/evosuite/testsuite/secondaryobjectives/TestSuiteSecondaryObjective.java
+++ b/client/src/main/java/org/evosuite/testsuite/secondaryobjectives/TestSuiteSecondaryObjective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -15,7 +15,7 @@
  * Lesser Public License for more details.
  * <p>
  * You should have received a copy of the GNU Lesser General Public
- * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ * License along with EvoSuite. If not, see http://www.gnu.org/licenses/.
  */
 package org.evosuite.testsuite.secondaryobjectives;
 

--- a/client/src/main/java/org/evosuite/testsuite/similarity/DiversityObserver.java
+++ b/client/src/main/java/org/evosuite/testsuite/similarity/DiversityObserver.java
@@ -72,11 +72,11 @@ public class DiversityObserver implements SearchListener<TestSuiteChromosome> {
 
     /**
      * Naive similarity comparison between suites simply consists of merging all tests to a single test
-     * for each suite, and then comparing these tests
+     * for each suite, and then comparing these tests.
      *
-     * @param suite1
-     * @param suite2
-     * @return
+     * @param suite1 a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @param suite2 a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @return a double.
      */
     public static double getSuiteSimilarity(TestSuiteChromosome suite1, TestSuiteChromosome suite2) {
         TestCase test1 = new DefaultTestCase();
@@ -100,24 +100,27 @@ public class DiversityObserver implements SearchListener<TestSuiteChromosome> {
     // TODO: Similarity based on vectors of types of calls
 
     /**
-     * Sequence alignment based distance
+     * Sequence alignment based distance.
      *
-     * @param test1
-     * @param test2
-     * @return
+     * @param test1 a {@link org.evosuite.testcase.TestCase} object.
+     * @param test2 a {@link org.evosuite.testcase.TestCase} object.
+     * @return a double.
      */
     public static double getNeedlemanWunschScore(TestCase test1, TestCase test2) {
         int[][] matrix = new int[test1.size() + 1][test2.size() + 1];
 
-        for (int i = 0; i <= test1.size(); i++)
+        for (int i = 0; i <= test1.size(); i++) {
             matrix[i][0] = GAP_PENALTY * i;
+        }
 
-        for (int i = 0; i <= test2.size(); i++)
+        for (int i = 0; i <= test2.size(); i++) {
             matrix[0][i] = GAP_PENALTY * i;
+        }
 
         for (int x = 1; x <= test1.size(); x++) {
             for (int y = 1; y <= test2.size(); y++) {
-                int upLeft = matrix[x - 1][y - 1] + getStatementSimilarity(test1.getStatement(x - 1), test2.getStatement(y - 1));
+                int upLeft = matrix[x - 1][y - 1] + getStatementSimilarity(test1.getStatement(x - 1),
+                        test2.getStatement(y - 1));
                 int insert = matrix[x - 1][y] + GAP_PENALTY;
                 int delete = matrix[x][y - 1] + GAP_PENALTY;
                 matrix[x][y] = Math.max(upLeft, Math.max(delete, insert));
@@ -138,17 +141,25 @@ public class DiversityObserver implements SearchListener<TestSuiteChromosome> {
         if (s1.getClass() == s2.getClass()) {
             similarity += 1;
             if (s1 instanceof ConstructorStatement) {
-                if (getUnderlyingType((ConstructorStatement) s1).equals(getUnderlyingType((ConstructorStatement) s2)))
+                if (getUnderlyingType((ConstructorStatement) s1).equals(
+                        getUnderlyingType((ConstructorStatement) s2))) {
                     similarity += 1;
+                }
             } else if (s1 instanceof PrimitiveStatement) {
-                if (getUnderlyingType((PrimitiveStatement<?>) s1).equals(getUnderlyingType((PrimitiveStatement<?>) s2)))
+                if (getUnderlyingType((PrimitiveStatement<?>) s1).equals(
+                        getUnderlyingType((PrimitiveStatement<?>) s2))) {
                     similarity += 1;
+                }
             } else if (s1 instanceof MethodStatement) {
-                if (getUnderlyingType((MethodStatement) s1).equals(getUnderlyingType((MethodStatement) s2)))
+                if (getUnderlyingType((MethodStatement) s1).equals(
+                        getUnderlyingType((MethodStatement) s2))) {
                     similarity += 1;
+                }
             } else if (s1 instanceof FieldStatement) {
-                if (getUnderlyingType((FieldStatement) s1).equals(getUnderlyingType((FieldStatement) s2)))
+                if (getUnderlyingType((FieldStatement) s1).equals(
+                        getUnderlyingType((FieldStatement) s2))) {
                     similarity += 1;
+                }
             }
             // TODO: If underlying type is the same, further benefit
         } else {


### PR DESCRIPTION
This PR applies Checkstyle fixes to the `org.evosuite.testsuite` package in the `client` module.

Changes include:
- Renaming `TestSuiteFitnessFunc_to_TestFitnessFactory_Adapter` to `TestSuiteFitnessFuncToTestFitnessFactoryAdapter`.
- Fixing Javadoc formatting (missing periods, empty descriptions, paragraph tags).
- Enforcing code style (braces, line lengths, indentation, modifier order).
- Fixing naming conventions for variables and members.

Verified with `mvn checkstyle:check` and `mvn compile`.

---
*PR created automatically by Jules for task [18023776250248058072](https://jules.google.com/task/18023776250248058072) started by @gofraser*