### PR TITLE
Fix Checkstyle violations in org.evosuite.junit package

### DIFF
--- a/client/src/main/java/org/evosuite/junit/CoverageAnalysis.java
+++ b/client/src/main/java/org/evosuite/junit/CoverageAnalysis.java
@@ -67,9 +67,7 @@ import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 /**
- * <p>
  * CoverageAnalysis class.
- * </p>
  *
  * @author Gordon Fraser
  * @author José Campos
@@ -77,17 +75,17 @@ import java.util.zip.ZipFile;
 public class CoverageAnalysis {
 
     /**
-     * FIXME
-     * <p>
-     * OUTPUT
+     * FIXME.
+     *
+     * <p>OUTPUT
      * METHOD
      * METHODNOEXCEPTION
-     * <p>
-     * relies on Observers. to have coverage of these criteria, JUnit test cases
+     *
+     * <p>relies on Observers. to have coverage of these criteria, JUnit test cases
      * must have to be converted to some format that EvoSuite can understand
      */
 
-    private final static Logger logger = LoggerFactory.getLogger(CoverageAnalysis.class);
+    private static final Logger logger = LoggerFactory.getLogger(CoverageAnalysis.class);
 
     private static int totalGoals = 0;
     private static int totalCoveredGoals = 0;
@@ -95,7 +93,7 @@ public class CoverageAnalysis {
 
     /**
      * Identify all JUnit tests starting with the given name prefix, instrument
-     * and run tests
+     * and run tests.
      */
     public static void analyzeCoverage() {
         Sandbox.goingToExecuteSUTCode();
@@ -115,7 +113,8 @@ public class CoverageAnalysis {
                         Arrays.asList(cp.split(File.pathSeparator)));
             }
 
-            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Finished analyzing classpath");
+            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier()
+                    + "Finished analyzing classpath");
         } catch (Throwable e) {
             LoggingUtils.getEvoLogger().error("* " + ClientProcess.getPrettyPrintIdentifier()
                     + "Error while initializing target class: "
@@ -132,8 +131,9 @@ public class CoverageAnalysis {
         List<Class<?>> testClasses = getTestClasses();
         LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Found " + testClasses.size()
                 + " test class(es)");
-        if (testClasses.isEmpty())
+        if (testClasses.isEmpty()) {
             return;
+        }
 
         /*
          * sort them in a deterministic way, in case there are
@@ -180,17 +180,19 @@ public class CoverageAnalysis {
 
             StatisticsSender.executedAndThenSendIndividualToMaster(testSuite);
             ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, goals);
-            if (Properties.COVERAGE_MATRIX)
-                throw new IllegalArgumentException("Coverage matrix not yet available when measuring coverage of a carved test suite");
+            if (Properties.COVERAGE_MATRIX) {
+                throw new IllegalArgumentException(
+                        "Coverage matrix not yet available when measuring coverage of a carved test suite");
+            }
         }
     }
 
     /**
-     * Return the number of covered goals
+     * Return the number of covered goals.
      *
-     * @param testClass
-     * @param allGoals
-     * @return
+     * @param testClass class to test
+     * @param allGoals list of all goals
+     * @return set of covered goals
      */
     public static Set<TestFitnessFunction> getCoveredGoals(Class<?> testClass, List<TestFitnessFunction> allGoals) {
 
@@ -222,8 +224,9 @@ public class CoverageAnalysis {
         List<Class<?>> classes = new ArrayList<>();
         for (String prefix : Properties.JUNIT.split(":")) {
 
-            Set<String> suts = ResourceList.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getAllClasses(
-                    ClassPathHandler.getInstance().getTargetProjectClasspath(), prefix, false);
+            Set<String> suts = ResourceList
+                    .getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                    .getAllClasses(ClassPathHandler.getInstance().getTargetProjectClasspath(), prefix, false);
 
             LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Found " + suts.size()
                     + " classes with prefix '" + prefix + "'");
@@ -259,15 +262,17 @@ public class CoverageAnalysis {
 
         for (String prefix : Properties.JUNIT.split(":")) {
 
-            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Analyzing entry: " + prefix);
+            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier()
+                    + "Analyzing entry: " + prefix);
 
             // If the target name is a path analyze it
             File path = new File(prefix);
             if (path.exists()) {
-                if (Properties.JUNIT.endsWith(".jar"))
+                if (Properties.JUNIT.endsWith(".jar")) {
                     testClasses.addAll(getTestClassesJar(path));
-                else
+                } else {
                     testClasses.addAll(getTestClasses(path));
+                }
             } else {
 
                 try {
@@ -285,7 +290,7 @@ public class CoverageAnalysis {
     }
 
     /**
-     * Analyze all classes that can be found in a given directory
+     * Analyze all classes that can be found in a given directory.
      *
      * @param directory a {@link java.io.File} object.
      * @return a {@link java.util.List} object.
@@ -318,8 +323,9 @@ public class CoverageAnalysis {
                 LoggingUtils.restorePreviousOutAndErrStream();
 
                 //clazz = Class.forName(clazz.getName());
-                if (isTest(clazz))
+                if (isTest(clazz)) {
                     testClasses.add(clazz);
+                }
 
             } catch (IllegalAccessError e) {
                 LoggingUtils.restorePreviousOutAndErrStream();
@@ -367,9 +373,7 @@ public class CoverageAnalysis {
     }
 
     /**
-     * <p>
-     * getClassesJar
-     * </p>
+     * getClassesJar.
      *
      * @param file a {@link java.io.File} object.
      * @return a {@link java.util.List} object.
@@ -391,13 +395,14 @@ public class CoverageAnalysis {
         while (e.hasMoreElements()) {
             final ZipEntry ze = (ZipEntry) e.nextElement();
             final String fileName = ze.getName();
-            if (!fileName.endsWith(".class"))
+            if (!fileName.endsWith(".class")) {
                 continue;
-			/*if (fileName.contains("$"))
+            }
+            /*if (fileName.contains("$"))
                 continue;*/
 
-            PrintStream old_out = System.out;
-            PrintStream old_err = System.err;
+            PrintStream oldOut = System.out;
+            PrintStream oldErr = System.err;
             //System.setOut(outStream);
             //System.setErr(outStream);
 
@@ -407,38 +412,39 @@ public class CoverageAnalysis {
                         true,
                         TestGenerationContext.getInstance().getClassLoaderForSUT());
 
-                if (isTest(clazz))
+                if (isTest(clazz)) {
                     testClasses.add(clazz);
+                }
             } catch (IllegalAccessError ex) {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
                 System.out.println("Cannot access class "
                         + file.getName().substring(0, file.getName().length() - 6));
             } catch (NoClassDefFoundError ex) {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
                 System.out.println("Cannot find dependent class " + ex);
             } catch (ExceptionInInitializerError ex) {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
                 System.out.println("Exception in initializer of "
                         + file.getName().substring(0, file.getName().length() - 6));
             } catch (ClassNotFoundException ex) {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
                 System.out.println("Cannot find class "
                         + file.getName().substring(0, file.getName().length() - 6) + ": "
                         + ex);
             } catch (Throwable t) {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
 
                 System.out.println("  Unexpected error: "
                         + file.getName().substring(0, file.getName().length() - 6) + ": "
                         + t);
             } finally {
-                System.setOut(old_out);
-                System.setErr(old_err);
+                System.setOut(oldOut);
+                System.setErr(oldErr);
             }
         }
         try {
@@ -462,7 +468,8 @@ public class CoverageAnalysis {
 
         if (criterion == Criterion.MUTATION
                 || criterion == Criterion.STRONGMUTATION) {
-            goals = MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutants();
+            goals = MutationPool.getInstance(
+                    TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutants();
         } else {
             goals = factory.getCoverageGoals();
         }
@@ -478,32 +485,34 @@ public class CoverageAnalysis {
         // coverage matrix (each row represents the coverage of each test case
         // and each column represents the coverage of each component (e.g., line)
         // this coverage matrix is useful for Rho fitness
-        boolean[][] coverage_matrix = new boolean[results.size()][goals.size() + 1]; // +1 because we also want to include the test result
+        // +1 because we also want to include the test result
+        boolean[][] coverageMatrix = new boolean[results.size()][goals.size() + 1];
         BitSet covered = new BitSet(goals.size());
 
-        for (int index_test = 0; index_test < results.size(); index_test++) {
-            JUnitResult tR = results.get(index_test);
+        for (int indexTest = 0; indexTest < results.size(); indexTest++) {
+            JUnitResult junitResult = results.get(indexTest);
 
-            ExecutionTrace trace = tR.getExecutionTrace();
+            ExecutionTrace trace = junitResult.getExecutionTrace();
             executionResult.setTrace(trace);
             dummy.getTestCase().clearCoveredGoals();
             dummy.setLastExecutionResult(executionResult);
 
             if (criterion == Criterion.MUTATION
                     || criterion == Criterion.STRONGMUTATION) {
-                for (Integer mutationID : trace.getTouchedMutants()) {
-                    Mutation mutation = MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutant(mutationID);
+                for (Integer mutationId : trace.getTouchedMutants()) {
+                    Mutation mutation = MutationPool.getInstance(
+                            TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutant(mutationId);
 
                     if (goals.contains(mutation)) {
-                        MutationObserver.activateMutation(mutationID);
-                        List<JUnitResult> mutationResults = executeTests(tR.getJUnitClass());
+                        MutationObserver.activateMutation(mutationId);
+                        List<JUnitResult> mutationResults = executeTests(junitResult.getJUnitClass());
                         MutationObserver.deactivateMutation();
 
-                        for (JUnitResult mR : mutationResults) {
-                            if (mR.getFailureCount() != tR.getFailureCount()) {
-                                logger.info("Mutation killed: " + mutationID);
+                        for (JUnitResult mutationResult : mutationResults) {
+                            if (mutationResult.getFailureCount() != junitResult.getFailureCount()) {
+                                logger.info("Mutation killed: " + mutationId);
                                 covered.set(mutation.getId());
-                                coverage_matrix[index_test][mutationID] = true;
+                                coverageMatrix[indexTest][mutationId] = true;
                                 break;
                             }
                         }
@@ -515,29 +524,29 @@ public class CoverageAnalysis {
                     // TODO collect exception goals from execution results
                 }
 
-                for (int index_component = 0; index_component < goals.size(); index_component++) {
-                    TestFitnessFunction goal = (TestFitnessFunction) goals.get(index_component);
+                for (int indexComponent = 0; indexComponent < goals.size(); indexComponent++) {
+                    TestFitnessFunction goal = (TestFitnessFunction) goals.get(indexComponent);
 
                     if (goal.isCovered(dummy)) {
-                        covered.set(index_component);
-                        coverage_matrix[index_test][index_component] = true;
+                        covered.set(indexComponent);
+                        coverageMatrix[indexTest][indexComponent] = true;
                     } else {
-                        coverage_matrix[index_test][index_component] = false;
+                        coverageMatrix[indexTest][indexComponent] = false;
                     }
                 }
             }
 
-            coverage_matrix[index_test][goals.size()] = tR.wasSuccessful();
+            coverageMatrix[indexTest][goals.size()] = junitResult.wasSuccessful();
         }
         totalCoveredGoals += covered.cardinality();
 
         if (Properties.COVERAGE_MATRIX) {
-            CoverageReportGenerator.writeCoverage(coverage_matrix, criterion);
+            CoverageReportGenerator.writeCoverage(coverageMatrix, criterion);
         }
 
         StringBuilder str = new StringBuilder();
-        for (int index_component = 0; index_component < goals.size(); index_component++) {
-            str.append(covered.get(index_component) ? "1" : "0");
+        for (int indexComponent = 0; indexComponent < goals.size(); indexComponent++) {
+            str.append(covered.get(indexComponent) ? "1" : "0");
         }
         logger.info("* CoverageBitString " + str);
 
@@ -545,18 +554,20 @@ public class CoverageAnalysis {
         if (goals.isEmpty()) {
             LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Coverage of criterion "
                     + criterion + ": 100% (no goals)");
-            ClientServices.getInstance().getClientNode().trackOutputVariable(CoverageCriteriaAnalyzer.getCoverageVariable(criterion), 1.0);
+            ClientServices.getInstance().getClientNode().trackOutputVariable(
+                    CoverageCriteriaAnalyzer.getCoverageVariable(criterion), 1.0);
             if (bitStringVariable != null) {
                 ClientServices.getInstance().getClientNode().trackOutputVariable(bitStringVariable, "1");
             }
         } else {
             double coverage = ((double) covered.cardinality()) / ((double) goals.size());
-            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Coverage of criterion " + criterion
-                    + ": " + NumberFormat.getPercentInstance().format(coverage));
-            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Number of covered goals: "
-                    + covered.cardinality() + " / " + goals.size());
+            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Coverage of criterion "
+                    + criterion + ": " + NumberFormat.getPercentInstance().format(coverage));
+            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier()
+                    + "Number of covered goals: " + covered.cardinality() + " / " + goals.size());
 
-            ClientServices.getInstance().getClientNode().trackOutputVariable(CoverageCriteriaAnalyzer.getCoverageVariable(criterion), coverage);
+            ClientServices.getInstance().getClientNode().trackOutputVariable(
+                    CoverageCriteriaAnalyzer.getCoverageVariable(criterion), coverage);
             if (bitStringVariable != null) {
                 ClientServices.getInstance().getClientNode().trackOutputVariable(bitStringVariable, str.toString());
             }
@@ -589,10 +600,11 @@ public class CoverageAnalysis {
             // restore
             Properties.CRITERION = criterion;
 
-            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Total number of covered goals: "
-                    + totalCoveredGoals + " / " + "" + totalGoals);
+            LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier()
+                    + "Total number of covered goals: " + totalCoveredGoals + " / " + "" + totalGoals);
             ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, totalGoals);
-            ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Covered_Goals, totalCoveredGoals);
+            ClientServices.getInstance().getClientNode().trackOutputVariable(
+                    RuntimeVariable.Covered_Goals, totalCoveredGoals);
 
             double coverage = totalGoals == 0 ? 1.0 : ((double) totalCoveredGoals) / ((double) totalGoals);
             LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Total coverage: "
@@ -624,25 +636,26 @@ public class CoverageAnalysis {
             LoggingUtils.getEvoLogger().info("  Executing " + testClass.getSimpleName());
             // Set the context classloader in case the SUT requests it
             Thread.currentThread().setContextClassLoader(testClass.getClassLoader());
-            JUnitRunner jR = new JUnitRunner(testClass);
-            jR.run();
-            results.addAll(jR.getTestResults());
+            JUnitRunner junitRunner = new JUnitRunner(testClass);
+            junitRunner.run();
+            results.addAll(junitRunner.getTestResults());
         }
 
         ExecutionTracer.disable();
 
-        LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Executed " + results.size() + " unit "
-                + "test(s)");
-        ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Tests_Executed, results.size());
+        LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier()
+                + "Executed " + results.size() + " unit " + "test(s)");
+        ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Tests_Executed,
+                results.size());
 
         return results;
     }
 
     /**
-     * Determine if a class contains JUnit tests
+     * Determine if a class contains JUnit tests.
      *
-     * @param cls
-     * @return
+     * @param cls class to check
+     * @return true if class contains tests
      */
     public static boolean isTest(Class<?> cls) {
         if (Modifier.isAbstract(cls.getModifiers())) {
@@ -692,18 +705,16 @@ public class CoverageAnalysis {
     }
 
     /**
-     * re-order test classes
+     * re-order test classes.
      *
-     * @param tests
+     * @param tests list of test classes
      */
     private static void sortTestClasses(List<Class<?>> tests) {
         tests.sort((t0, t1) -> Integer.compare(t1.getName().length(), t0.getName().length()));
     }
 
     /**
-     * <p>
-     * run
-     * </p>
+     * run.
      */
     public void run() {
 

--- a/client/src/main/java/org/evosuite/junit/CoverageReportGenerator.java
+++ b/client/src/main/java/org/evosuite/junit/CoverageReportGenerator.java
@@ -26,9 +26,7 @@ import org.evosuite.utils.FileIOUtils;
 import java.io.File;
 
 /**
- * <p>
- * CoverageReportGenerator class
- * </p>
+ * CoverageReportGenerator class.
  *
  * @author José Campos
  */
@@ -41,42 +39,47 @@ public class CoverageReportGenerator {
             StringBuilder test = new StringBuilder();
 
             for (int j = 0; j < c.length - 1; j++) {
-                if (c[j])
+                if (c[j]) {
                     test.append("1 ");
-                else
+                } else {
                     test.append("0 ");
+                }
             }
 
-            if (!test.toString().contains("1")) // if a test case does not contains a "1", means it does not coverage anything
+            // if a test case does not contains a "1", means it does not coverage anything
+            if (!test.toString().contains("1")) {
                 continue;
+            }
 
-            if (c[c.length - 1])
+            if (c[c.length - 1]) {
                 test.append("+\n");
-            else
+            } else {
                 test.append("-\n");
+            }
 
             suite.append(test);
         }
 
-        FileIOUtils.writeFile(suite.toString(), new File(getReportDir().getAbsolutePath() +
-                File.separator + "data" + File.separator +
-                Properties.TARGET_CLASS + File.separator +
-                criterion.toString() + File.separator + Properties.COVERAGE_MATRIX_FILENAME));
+        FileIOUtils.writeFile(suite.toString(), new File(getReportDir().getAbsolutePath()
+                + File.separator + "data" + File.separator
+                + Properties.TARGET_CLASS + File.separator
+                + criterion.toString() + File.separator + Properties.COVERAGE_MATRIX_FILENAME));
     }
 
     /**
      * Return the folder of where reports should be generated.
      * If the folder does not exist, try to create it
      *
-     * @return
+     * @return the report directory
      * @throws RuntimeException if folder does not exist, and we cannot create it
      */
     private static File getReportDir() throws RuntimeException {
         File dir = new File(Properties.REPORT_DIR);
 
         if (!dir.exists()) {
-            if (!dir.mkdirs())
+            if (!dir.mkdirs()) {
                 throw new RuntimeException("Cannot create report dir: " + Properties.REPORT_DIR);
+            }
         }
 
         return dir;

--- a/client/src/main/java/org/evosuite/junit/DetermineSUT.java
+++ b/client/src/main/java/org/evosuite/junit/DetermineSUT.java
@@ -44,7 +44,7 @@ import java.util.*;
  */
 public class DetermineSUT {
 
-    private final static Logger logger = LoggerFactory.getLogger(DetermineSUT.class);
+    private static final Logger logger = LoggerFactory.getLogger(DetermineSUT.class);
 
     private String targetName = "";
 
@@ -80,7 +80,8 @@ public class DetermineSUT {
             // TODO Auto-generated catch block
             e1.printStackTrace();
         }
-        Set<String> targetClasses = ResourceList.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getAllClasses(targetClassPath, false);
+        Set<String> targetClasses = ResourceList.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                .getAllClasses(targetClassPath, false);
         Set<String> candidateClasses = new HashSet<>();
         boolean hasJUnit = false;
         try {
@@ -92,14 +93,16 @@ public class DetermineSUT {
             logger.error("Class not found: " + e, e);
             return "";
         } catch (NoJUnitClassException e) {
-
+            // Ignored
         }
 
-        if (!hasJUnit)
+        if (!hasJUnit) {
             throw new NoJUnitClassException();
+        }
 
-        if (candidateClasses.isEmpty())
+        if (candidateClasses.isEmpty()) {
             return "<UNKNOWN>";
+        }
 
         List<String> sortedNames = new ArrayList<>(candidateClasses);
         sortedNames.sort(new TargetClassSorter(fullyQualifiedTargetClass));
@@ -152,9 +155,7 @@ public class DetermineSUT {
     }
 
     /**
-     * <p>
-     * isJavaClass
-     * </p>
+     * isJavaClass.
      *
      * @param classNameWithDots a {@link java.lang.String} object.
      * @return a boolean.
@@ -168,20 +169,25 @@ public class DetermineSUT {
     }
 
     private boolean isValidClass(String name) throws IOException {
-        if (isJavaClass(name))
+        if (isJavaClass(name)) {
             return false;
+        }
 
-        if (name.startsWith("junit"))
+        if (name.startsWith("junit")) {
             return false;
+        }
 
-        if (name.startsWith("org.junit"))
+        if (name.startsWith("org.junit")) {
             return false;
+        }
 
-        if (name.startsWith(targetName))
+        if (name.startsWith(targetName)) {
             return false;
+        }
 
-        if (superClasses.contains(name))
+        if (superClasses.contains(name)) {
             return false;
+        }
 
         ClassNode sutNode = loadClassNode(name);
         return !isJUnitTest(sutNode);
@@ -197,11 +203,13 @@ public class DetermineSUT {
             AbstractInsnNode insn = iterator.next();
             if (insn instanceof MethodInsnNode) {
                 String name = ResourceList.getClassNameFromResourcePath(((MethodInsnNode) insn).owner);
-                if (!targetClasses.contains(name))
+                if (!targetClasses.contains(name)) {
                     continue;
+                }
 
-                if (isValidClass(name))
+                if (isValidClass(name)) {
                     calledClasses.add(name);
+                }
             }
         }
     }
@@ -209,20 +217,23 @@ public class DetermineSUT {
     @SuppressWarnings("unchecked")
     private boolean isJUnitTest(ClassNode cn) throws IOException {
         // We do not consider abstract classes
-        if ((cn.access & Opcodes.ACC_ABSTRACT) == Opcodes.ACC_ABSTRACT)
+        if ((cn.access & Opcodes.ACC_ABSTRACT) == Opcodes.ACC_ABSTRACT) {
             return false;
+        }
 
-        if (hasJUnitSuperclass(cn))
+        if (hasJUnitSuperclass(cn)) {
             return true;
+        }
 
         List<MethodNode> methods = cn.methods;
         for (MethodNode mn : methods) {
             List<AnnotationNode> annotations = mn.visibleAnnotations;
             if (annotations != null) {
                 for (AnnotationNode an : annotations) {
-                    if (an.desc.equals("Lorg/junit/Test;") ||
-                            an.desc.equals("L" + PackageInfo.getNameWithSlash(EvoSuiteTest.class) + ";"))
+                    if (an.desc.equals("Lorg/junit/Test;") || an.desc.equals(
+                            "L" + PackageInfo.getNameWithSlash(EvoSuiteTest.class) + ";")) {
                         return true;
+                    }
                 }
             }
         }
@@ -242,18 +253,21 @@ public class DetermineSUT {
     }
 
     private boolean hasJUnitSuperclass(ClassNode cn) throws IOException {
-        if (cn.superName.equals("java/lang/Object"))
+        if (cn.superName.equals("java/lang/Object")) {
             return false;
+        }
 
-        if (cn.superName.equals("junit/framework/TestCase"))
+        if (cn.superName.equals("junit/framework/TestCase")) {
             return true;
+        }
 
         ClassNode superClass = loadClassNode(cn.superName);
         return hasJUnitSuperclass(superClass);
     }
 
     private ClassNode loadClassNode(String className) throws IOException {
-        ClassReader reader = new ClassReader(ResourceList.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getClassAsStream(className));
+        ClassReader reader = new ClassReader(ResourceList.getInstance(
+                TestGenerationContext.getInstance().getClassLoaderForSUT()).getClassAsStream(className));
 
         ClassNode cn = new ClassNode();
         reader.accept(cn, ClassReader.SKIP_FRAMES); // | ClassReader.SKIP_DEBUG);
@@ -261,7 +275,9 @@ public class DetermineSUT {
     }
 
     /**
-     * @param args
+     * Main method.
+     *
+     * @param args command line arguments
      */
     public static void main(String[] args) {
         if (args.length != 2) {

--- a/client/src/main/java/org/evosuite/junit/JUnit3TestAdapter.java
+++ b/client/src/main/java/org/evosuite/junit/JUnit3TestAdapter.java
@@ -29,15 +29,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * <p>JUnit3TestAdapter class.</p>
+ * JUnit3TestAdapter class.
  *
  * @author fraser
  */
 public class JUnit3TestAdapter implements UnitTestAdapter {
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getImports()
-     */
 
     /**
      * {@inheritDoc}
@@ -47,10 +43,6 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
         return "import junit.framework.TestCase;\n";
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getClassDefinition(java.lang.String)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -59,10 +51,6 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
         return "public class " + testName + " extends TestCase";
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getMethodDefinition(java.lang.String)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -70,10 +58,6 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
     public String getMethodDefinition(String testName) {
         return "public void " + testName + "() ";
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getSuite(java.util.List)
-     */
 
     /**
      * {@inheritDoc}
@@ -109,10 +93,6 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
         return builder.toString();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(org.evosuite.testcase.TestCase, java.util.Map)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -120,10 +100,6 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
     public String getTestString(int id, TestCase test, Map<Integer, Throwable> exceptions) {
         return test.toCode(exceptions);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(int, org.evosuite.testcase.TestCase, java.util.Map, org.evosuite.testcase.TestCodeVisitor)
-     */
 
     /**
      * {@inheritDoc}
@@ -167,7 +143,8 @@ public class JUnit3TestAdapter implements UnitTestAdapter {
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
         builder.append("@").append(org.junit.Rule.class.getCanonicalName()).append("\n");
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
-        builder.append("public ").append(NonFunctionalRequirementRule.class.getName()).append(" nfr = new ").append(NonFunctionalRequirementRule.class.getName()).append("();\n\n");
+        builder.append("public ").append(NonFunctionalRequirementRule.class.getName())
+                .append(" nfr = new ").append(NonFunctionalRequirementRule.class.getName()).append("();\n\n");
     }
 
 }

--- a/client/src/main/java/org/evosuite/junit/JUnit4RunListener.java
+++ b/client/src/main/java/org/evosuite/junit/JUnit4RunListener.java
@@ -28,9 +28,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
 /**
- * <p>
- * JUnitRunListener class
- * </p>
+ * JUnitRunListener class.
  *
  * @author José Campos
  */
@@ -46,14 +44,16 @@ public class JUnit4RunListener extends RunListener {
     private long start;
 
     /**
-     * @param jr
+     * Constructor.
+     *
+     * @param runner the junit runner
      */
-    public JUnit4RunListener(JUnitRunner jR) {
-        this.junitRunner = jR;
+    public JUnit4RunListener(JUnitRunner runner) {
+        this.junitRunner = runner;
     }
 
     /**
-     * Called before any tests have been run
+     * Called before any tests have been run.
      */
     @Override
     public void testRunStarted(Description description) {
@@ -61,7 +61,7 @@ public class JUnit4RunListener extends RunListener {
     }
 
     /**
-     * Called when all tests have finished
+     * Called when all tests have finished.
      */
     @Override
     public void testRunFinished(Result result) {
@@ -69,23 +69,26 @@ public class JUnit4RunListener extends RunListener {
     }
 
     /**
-     * Called when an atomic test is about to be started
+     * Called when an atomic test is about to be started.
      */
     @Override
     public void testStarted(Description description) {
-        LoggingUtils.getEvoLogger().info("* Started: " + "ClassName: " + description.getClassName() + ", MethodName: " + description.getMethodName());
+        LoggingUtils.getEvoLogger().info("* Started: " + "ClassName: " + description.getClassName()
+                + ", MethodName: " + description.getMethodName());
 
         this.start = System.nanoTime();
 
-        this.testResult = new JUnitResult(description.getClassName() + "#" + description.getMethodName(), this.junitRunner.getJUnitClass());
+        this.testResult = new JUnitResult(description.getClassName() + "#" + description.getMethodName(),
+                this.junitRunner.getJUnitClass());
     }
 
     /**
-     * Called when an atomic test has finished. whether the test successes or fails
+     * Called when an atomic test has finished. whether the test successes or fails.
      */
     @Override
     public void testFinished(Description description) {
-        LoggingUtils.getEvoLogger().info("* Finished: " + "ClassName: " + description.getClassName() + ", MethodName: " + description.getMethodName());
+        LoggingUtils.getEvoLogger().info("* Finished: " + "ClassName: " + description.getClassName()
+                + ", MethodName: " + description.getMethodName());
 
         this.testResult.setRuntime(System.nanoTime() - this.start);
         this.testResult.setExecutionTrace(ExecutionTracer.getExecutionTracer().getTrace());
@@ -96,7 +99,7 @@ public class JUnit4RunListener extends RunListener {
     }
 
     /**
-     * Called when an atomic test fails
+     * Called when an atomic test fails.
      */
     @Override
     public void testFailure(Failure failure) {
@@ -111,10 +114,11 @@ public class JUnit4RunListener extends RunListener {
     }
 
     /**
-     * Called when a test will not be run, generally because a test method is annotated with Ignore
+     * Called when a test will not be run, generally because a test method is annotated with Ignore.
      */
     @Override
     public void testIgnored(Description description) throws java.lang.Exception {
-        LoggingUtils.getEvoLogger().info("* Ignored: " + "ClassName: " + description.getClassName() + ", MethodName: " + description.getMethodName());
+        LoggingUtils.getEvoLogger().info("* Ignored: " + "ClassName: " + description.getClassName()
+                + ", MethodName: " + description.getMethodName());
     }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnit4TestAdapter.java
+++ b/client/src/main/java/org/evosuite/junit/JUnit4TestAdapter.java
@@ -30,9 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * <p>
  * JUnit4TestAdapter class.
- * </p>
  *
  * @author fraser
  */
@@ -66,23 +64,21 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
     private String getJUnitTestShortName() {
         if (Properties.ECLIPSE_PLUGIN) {
             String res = "";
-            if (Properties.TARGET_CLASS.equals("EvoSuiteTest"))
+            if (Properties.TARGET_CLASS.equals("EvoSuiteTest")) {
                 res = org.evosuite.annotations.EvoSuiteTest.class.getName();
-            else
+            } else {
                 res = "EvoSuiteTest";
+            }
             res += " (checked = false)";
             return res;
         } else {
-            if (Properties.TARGET_CLASS.equals("Test"))
+            if (Properties.TARGET_CLASS.equals("Test")) {
                 return "org.junit.Test";
-            else
+            } else {
                 return "Test";
+            }
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getImports()
-     */
 
     /**
      * {@inheritDoc}
@@ -90,18 +86,16 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
     @Override
     public String getImports() {
         String imports = "";
-        if ((Properties.ECLIPSE_PLUGIN) && (!Properties.TARGET_CLASS.equals("EvoSuiteTest")))
+        if ((Properties.ECLIPSE_PLUGIN) && (!Properties.TARGET_CLASS.equals("EvoSuiteTest"))) {
             imports += "import " + org.evosuite.annotations.EvoSuiteTest.class.getName() + ";\n";
-        if (!Properties.TARGET_CLASS.equals("Test"))
+        }
+        if (!Properties.TARGET_CLASS.equals("Test")) {
             imports += "import org.junit.Test;\n";
+        }
         imports += "import static org.junit.Assert.*;\n";
 
         return imports;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getClassDefinition(java.lang.String)
-     */
 
     /**
      * {@inheritDoc}
@@ -110,10 +104,6 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
     public String getClassDefinition(String testName) {
         return "public class " + testName;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getMethodDefinition(java.lang.String)
-     */
 
     /**
      * {@inheritDoc}
@@ -128,10 +118,6 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
         builder.append("  public void " + testName + "() ");
         return builder.toString();
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getSuite(java.util.List)
-     */
 
     /**
      * {@inheritDoc}
@@ -171,10 +157,6 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
         return builder.toString();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(org.evosuite.testcase.TestCase, java.util.Map)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -182,10 +164,6 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
     public String getTestString(int id, TestCase test, Map<Integer, Throwable> exceptions) {
         return test.toCode(exceptions);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(int, org.evosuite.testcase.TestCase, java.util.Map, org.evosuite.testcase.TestCodeVisitor)
-     */
 
     /**
      * {@inheritDoc}
@@ -204,6 +182,7 @@ public class JUnit4TestAdapter implements UnitTestAdapter {
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
         builder.append("@").append(org.junit.Rule.class.getCanonicalName()).append("\n");
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
-        builder.append("public ").append(NonFunctionalRequirementRule.class.getName()).append(" nfr = new ").append(NonFunctionalRequirementRule.class.getName()).append("();\n\n");
+        builder.append("public ").append(NonFunctionalRequirementRule.class.getName());
+        builder.append(" nfr = new ").append(NonFunctionalRequirementRule.class.getName()).append("();\n\n");
     }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnit5RunListener.java
+++ b/client/src/main/java/org/evosuite/junit/JUnit5RunListener.java
@@ -1,21 +1,21 @@
 /**
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
- * <p>
- * This file is part of EvoSuite.
- * <p>
- * EvoSuite is free software: you can redistribute it and/or modify it
+ *
+ * <p>This file is part of EvoSuite.
+ *
+ * <p>EvoSuite is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation, either version 3.0 of the License, or
  * (at your option) any later version.
- * <p>
- * EvoSuite is distributed in the hope that it will be useful, but
+ *
+ * <p>EvoSuite is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser Public License for more details.
- * <p>
- * You should have received a copy of the GNU Lesser General Public
- * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see http://www.gnu.org/licenses/.
  */
 package org.evosuite.junit;
 
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class JUnit5RunListener implements TestExecutionListener {
     private static final Logger logger = LoggerFactory.getLogger(JUnit5RunListener.class);
-    private final JUnitRunner jUnitRunner;
+    private final JUnitRunner junitRunner;
 
 
     private JUnitResult testResult = null;
@@ -40,13 +40,14 @@ public class JUnit5RunListener implements TestExecutionListener {
 
     private long start;
 
-    public JUnit5RunListener(JUnitRunner jUnitRunner) {
-        this.jUnitRunner = jUnitRunner;
+    public JUnit5RunListener(JUnitRunner junitRunner) {
+        this.junitRunner = junitRunner;
     }
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
-        LoggingUtils.getEvoLogger().info("* Number of test cases to execute: " + testPlan.countTestIdentifiers(ignored -> true));
+        LoggingUtils.getEvoLogger().info("* Number of test cases to execute: "
+                + testPlan.countTestIdentifiers(ignored -> true));
     }
 
     @Override
@@ -70,7 +71,7 @@ public class JUnit5RunListener implements TestExecutionListener {
 
         this.start = System.nanoTime();
 
-        this.testResult = new JUnitResult(testIdentifier.getDisplayName(), this.jUnitRunner.getJUnitClass());
+        this.testResult = new JUnitResult(testIdentifier.getDisplayName(), this.junitRunner.getJUnitClass());
     }
 
     @Override
@@ -83,7 +84,7 @@ public class JUnit5RunListener implements TestExecutionListener {
             this.testResult.incrementRunCount();
             ExecutionTracer.getExecutionTracer().clear();
 
-            this.jUnitRunner.addResult(this.testResult);
+            this.junitRunner.addResult(this.testResult);
         } else if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {
 
             Throwable throwable = testExecutionResult.getThrowable().get();

--- a/client/src/main/java/org/evosuite/junit/JUnit5TestAdapter.java
+++ b/client/src/main/java/org/evosuite/junit/JUnit5TestAdapter.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Used to adapt the internal representations of test suites to JUnit 5 test cases
+ * Used to adapt the internal representations of test suites to JUnit 5 test cases.
  */
 public class JUnit5TestAdapter implements UnitTestAdapter {
 
@@ -63,23 +63,21 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
     private String getJUnitTestShortName() {
         if (Properties.ECLIPSE_PLUGIN) {
             String res = "";
-            if (Properties.TARGET_CLASS.equals("EvoSuiteTest"))
+            if (Properties.TARGET_CLASS.equals("EvoSuiteTest")) {
                 res = org.evosuite.annotations.EvoSuiteTest.class.getName();
-            else
+            } else {
                 res = "EvoSuiteTest";
+            }
             res += " (checked = false)";
             return res;
         } else {
-            if (Properties.TARGET_CLASS.equals("Test"))
+            if (Properties.TARGET_CLASS.equals("Test")) {
                 return "org.junit.jupiter.api.Test";
-            else
+            } else {
                 return "Test";
+            }
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getImports()
-     */
 
     /**
      * {@inheritDoc}
@@ -87,20 +85,18 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
     @Override
     public String getImports() {
         String imports = "";
-        if ((Properties.ECLIPSE_PLUGIN) && (!Properties.TARGET_CLASS.equals("EvoSuiteTest")))
+        if ((Properties.ECLIPSE_PLUGIN) && (!Properties.TARGET_CLASS.equals("EvoSuiteTest"))) {
             imports += "import " + org.evosuite.annotations.EvoSuiteTest.class.getName() + ";\n";
-        if (!Properties.TARGET_CLASS.equals("Test"))
+        }
+        if (!Properties.TARGET_CLASS.equals("Test")) {
             imports += "import org.junit.jupiter.api.Test;\n";
+        }
         imports += "import static org.junit.jupiter.api.Assertions.*;\n";
         imports += "import org.junit.jupiter.api.Timeout;\n";
         imports += "import java.util.concurrent.TimeUnit;\n";
 
         return imports;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getClassDefinition(java.lang.String)
-     */
 
     /**
      * {@inheritDoc}
@@ -115,10 +111,6 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
         return "@Timeout(value = " + (Properties.TIMEOUT + 1000) + " , unit = TimeUnit.MILLISECONDS)";
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getMethodDefinition(java.lang.String)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -129,10 +121,6 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
                 + "\n" + "  public void " + testName + "() ";
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getSuite(java.util.List)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -141,10 +129,6 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
         throw new UnsupportedOperationException("getSuite is not supported in JUNIT 5");
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(org.evosuite.testcase.TestCase, java.util.Map)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -152,10 +136,6 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
     public String getTestString(int id, TestCase test, Map<Integer, Throwable> exceptions) {
         return test.toCode(exceptions);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.junit.UnitTestAdapter#getTestString(int, org.evosuite.testcase.TestCase, java.util.Map, org.evosuite.testcase.TestCodeVisitor)
-     */
 
     /**
      * {@inheritDoc}
@@ -174,6 +154,7 @@ public class JUnit5TestAdapter implements UnitTestAdapter {
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
         builder.append("@").append(RegisterExtension.class.getCanonicalName()).append("\n");
         builder.append(TestSuiteWriterUtils.METHOD_SPACE);
-        builder.append("public ").append(NonFunctionalRequirementExtension.class.getName()).append(" nfr = new ").append(NonFunctionalRequirementExtension.class.getName()).append("();\n\n");
+        builder.append("public ").append(NonFunctionalRequirementExtension.class.getName())
+                .append(" nfr = new ").append(NonFunctionalRequirementExtension.class.getName()).append("();\n\n");
     }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnitFailure.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitFailure.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 /**
  * The information regarding a failure from executing a JUnit test case needed
- * by the JUnitAnalyzer
+ * by the JUnitAnalyzer.
  *
  * @author galeotti
  */
@@ -95,38 +95,52 @@ public class JUnitFailure {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         JUnitFailure other = (JUnitFailure) obj;
         if (exceptionClassName == null) {
-            if (other.exceptionClassName != null)
+            if (other.exceptionClassName != null) {
                 return false;
-        } else if (!exceptionClassName.equals(other.exceptionClassName))
+            }
+        } else if (!exceptionClassName.equals(other.exceptionClassName)) {
             return false;
+        }
         if (exceptionStackTrace == null) {
-            if (other.exceptionStackTrace != null)
+            if (other.exceptionStackTrace != null) {
                 return false;
-        } else if (!exceptionStackTrace.equals(other.exceptionStackTrace))
+            }
+        } else if (!exceptionStackTrace.equals(other.exceptionStackTrace)) {
             return false;
-        if (isAssertionError != other.isAssertionError)
+        }
+        if (isAssertionError != other.isAssertionError) {
             return false;
+        }
         if (message == null) {
-            if (other.message != null)
+            if (other.message != null) {
                 return false;
-        } else if (!message.equals(other.message))
+            }
+        } else if (!message.equals(other.message)) {
             return false;
+        }
         if (descriptionMethodName == null) {
-            if (other.descriptionMethodName != null)
+            if (other.descriptionMethodName != null) {
                 return false;
-        } else if (!descriptionMethodName.equals(other.descriptionMethodName))
+            }
+        } else if (!descriptionMethodName.equals(other.descriptionMethodName)) {
             return false;
+        }
         if (trace == null) {
             return other.trace == null;
-        } else return trace.equals(other.trace);
+        } else {
+            return trace.equals(other.trace);
+        }
     }
 
     public boolean isAssertionError() {

--- a/client/src/main/java/org/evosuite/junit/JUnitResult.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitResult.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The information from executing a JUnit test case
+ * The information from executing a JUnit test case.
  *
  * @author galeotti
  * @author José Campos
@@ -77,9 +77,11 @@ public class JUnitResult {
     }
 
     /**
-     * @param wasSuccessful
-     * @param failureCount
-     * @param runCount
+     * Constructor.
+     *
+     * @param wasSuccessful whether the test was successful
+     * @param failureCount number of failures
+     * @param runCount number of runs
      */
     public JUnitResult(boolean wasSuccessful, int failureCount, int runCount) {
         this.successful = wasSuccessful;
@@ -88,77 +90,99 @@ public class JUnitResult {
     }
 
     /**
-     * @return
+     * Getter for name.
+     *
+     * @return the name
      */
     public String getName() {
         return this.name;
     }
 
     /**
-     * @param n
+     * Setter for name.
+     *
+     * @param n the name to set
      */
     public void setName(String n) {
         this.name = n;
     }
 
     /**
-     * @return
+     * Checks if successful.
+     *
+     * @return true if successful
      */
     public boolean wasSuccessful() {
         return this.successful;
     }
 
     /**
-     * @param s
+     * Sets success status.
+     *
+     * @param s success status
      */
     public void setSuccessful(boolean s) {
         this.successful = s;
     }
 
     /**
-     * @return
+     * Getter for runtime.
+     *
+     * @return the runtime
      */
     public long getRuntime() {
         return this.runtime;
     }
 
     /**
-     * @param r
+     * Setter for runtime.
+     *
+     * @param r the runtime to set
      */
     public void setRuntime(long r) {
         this.runtime = r;
     }
 
     /**
-     * @return
+     * Getter for trace.
+     *
+     * @return the trace
      */
     public String getTrace() {
         return this.trace;
     }
 
     /**
-     * @param t
+     * Setter for trace.
+     *
+     * @param t the trace to set
      */
     public void setTrace(String t) {
         this.trace = t;
     }
 
     /**
-     * @return
+     * Getter for execution trace.
+     *
+     * @return the execution trace
      */
     public ExecutionTrace getExecutionTrace() {
         return this.executionTrace;
     }
 
     /**
-     * @param et
+     * Setter for execution trace.
+     *
+     * @param et the execution trace to set
      */
     public void setExecutionTrace(ExecutionTrace et) {
         this.executionTrace = et;
     }
 
     /**
-     * @return
+     * Getter for failure count.
+     *
+     * @return the failure count
      */
     public int getFailureCount() {
         return this.failureCount;
@@ -169,7 +193,9 @@ public class JUnitResult {
     }
 
     /**
-     * @return
+     * Getter for run count.
+     *
+     * @return the run count
      */
     public int getRunCount() {
         return runCount;
@@ -180,14 +206,18 @@ public class JUnitResult {
     }
 
     /**
-     * @return
+     * Getter for failures.
+     *
+     * @return the list of failures
      */
     public List<JUnitFailure> getFailures() {
         return junitFailures;
     }
 
     /**
-     * @param junitFailure
+     * Adds a failure.
+     *
+     * @param junitFailure the failure to add
      */
     public void addFailure(JUnitFailure junitFailure) {
         junitFailures.add(junitFailure);
@@ -213,22 +243,29 @@ public class JUnitResult {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         JUnitResult other = (JUnitResult) obj;
-        if (this.failureCount != other.failureCount)
+        if (this.failureCount != other.failureCount) {
             return false;
+        }
         if (this.junitFailures == null) {
-            if (other.junitFailures != null)
+            if (other.junitFailures != null) {
                 return false;
-        } else if (!this.junitFailures.equals(other.junitFailures))
+            }
+        } else if (!this.junitFailures.equals(other.junitFailures)) {
             return false;
-        if (this.runCount != other.runCount)
+        }
+        if (this.runCount != other.runCount) {
             return false;
+        }
         return this.successful == other.successful;
     }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnitResultBuilder.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitResultBuilder.java
@@ -45,8 +45,8 @@ public class JUnitResultBuilder {
      * Translates <i>part</i> of the org.junit.runner.Result object
      * into an evosuite independent object.
      *
-     * @param result
-     * @return
+     * @param result the result to build from
+     * @return the junit result
      */
     public JUnitResult build(Result result) {
         boolean wasSuccessful = result.wasSuccessful();
@@ -82,16 +82,19 @@ public class JUnitResultBuilder {
     }
 
     public JUnitResult build(List<Pair<TestIdentifier, TestExecutionResult>> results) {
-        boolean wasSuccessful = results.stream().map(Pair::getRight).noneMatch(r -> r.getStatus() != TestExecutionResult.Status.SUCCESSFUL);
-        int failureCount = (int) results.stream().map(Pair::getRight).filter(r -> r.getStatus() != TestExecutionResult.Status.SUCCESSFUL).count();
+        boolean wasSuccessful = results.stream().map(Pair::getRight)
+                .noneMatch(r -> r.getStatus() != TestExecutionResult.Status.SUCCESSFUL);
+        int failureCount = (int) results.stream().map(Pair::getRight)
+                .filter(r -> r.getStatus() != TestExecutionResult.Status.SUCCESSFUL).count();
         int runCount = results.size();
 
-        JUnitResult jUnitResult = new JUnitResult(wasSuccessful, failureCount, runCount);
+        JUnitResult junitResult = new JUnitResult(wasSuccessful, failureCount, runCount);
 
         List<Pair<TestIdentifier, TestExecutionResult>> failures =
-                results.stream().filter(r -> r.getRight().getStatus() == TestExecutionResult.Status.FAILED).collect(Collectors.toList());
-        failures.stream().map(f -> toFailure(f.getLeft(), f.getRight())).forEach(jUnitResult::addFailure);
-        return jUnitResult;
+                results.stream().filter(r -> r.getRight().getStatus() == TestExecutionResult.Status.FAILED)
+                        .collect(Collectors.toList());
+        failures.stream().map(f -> toFailure(f.getLeft(), f.getRight())).forEach(junitResult::addFailure);
+        return junitResult;
     }
 
     private static JUnitFailure toFailure(TestIdentifier identifier, TestExecutionResult failure) {
@@ -102,11 +105,12 @@ public class JUnitResultBuilder {
         String trace = Throwables.getStacktrace(throwable);
         boolean isAssertionError = (throwable instanceof java.lang.AssertionError);
 
-        JUnitFailure jUnitFailure = new JUnitFailure(message, exceptionClassName, descriptionMethodName, isAssertionError, trace);
+        JUnitFailure junitFailure = new JUnitFailure(message, exceptionClassName, descriptionMethodName,
+                isAssertionError, trace);
         for (StackTraceElement elem : throwable.getStackTrace()) {
             String elemToString = elem.toString();
-            jUnitFailure.addToExceptionStackTrace(elemToString);
+            junitFailure.addToExceptionStackTrace(elemToString);
         }
-        return jUnitFailure;
+        return junitFailure;
     }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnitRunner.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitRunner.java
@@ -38,9 +38,7 @@ import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNa
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 
 /**
- * <p>
- * JUnitRunner class
- * </p>
+ * JUnitRunner class.
  *
  * @author José Campos
  */
@@ -70,36 +68,42 @@ public class JUnitRunner {
         } else if (Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT5) {
             logger.warn("Running Junit 5 test");
 
-            LauncherDiscoveryRequest request_ = LauncherDiscoveryRequestBuilder.request()
+            LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
                     .selectors(selectPackage("com.baeldung.junit5.runfromjava"))
                     .filters(includeClassNamePatterns(".*Test"))
                     .build();
             Launcher launcher = LauncherFactory.create();
-            TestPlan testPlan = launcher.discover(request_);
+            TestPlan testPlan = launcher.discover(request);
             launcher.registerTestExecutionListeners(new JUnit5RunListener(this));
 
-            launcher.execute(request_);
+            launcher.execute(request);
         } else {
             logger.warn("Can't run junit test with test format: {}", Properties.TEST_FORMAT);
         }
     }
 
     /**
-     * @param testResult
+     * Add result.
+     *
+     * @param testResult the result to add
      */
     public void addResult(JUnitResult testResult) {
         this.testResults.add(testResult);
     }
 
     /**
-     * @return
+     * Get test results.
+     *
+     * @return list of test results
      */
     public List<JUnitResult> getTestResults() {
         return this.testResults;
     }
 
     /**
-     * @return
+     * Get JUnit class.
+     *
+     * @return the junit class
      */
     public Class<?> getJUnitClass() {
         return this.junitClass;

--- a/client/src/main/java/org/evosuite/junit/JUnitTestSuite.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitTestSuite.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 
 /**
- * <p>JUnitTestSuite class.</p>
+ * JUnitTestSuite class.
  *
  * @author Gordon Fraser
  */
@@ -52,7 +52,7 @@ public class JUnitTestSuite {
     private final TestCaseExecutor executor = TestCaseExecutor.getInstance();
 
     /**
-     * <p>runSuite</p>
+     * Run suite.
      *
      * @param name a {@link java.lang.String} object.
      */
@@ -69,8 +69,9 @@ public class JUnitTestSuite {
             coveredBranchesFalse = trace.getCoveredFalseBranches();
 
             for (String methodName : trace.getCoveredMethods()) {
-                if (!methodName.contains("$"))
+                if (!methodName.contains("$")) {
                     coveredMethods.add(methodName);
+                }
             }
 
         } catch (ClassNotFoundException e) {
@@ -79,7 +80,7 @@ public class JUnitTestSuite {
     }
 
     /**
-     * <p>runSuite</p>
+     * Run suite.
      *
      * @param chromosome a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      */
@@ -97,7 +98,7 @@ public class JUnitTestSuite {
     }
 
     /**
-     * <p>Getter for the field <code>coveredMethods</code>.</p>
+     * Getter for the field <code>coveredMethods</code>.
      *
      * @return a {@link java.util.Set} object.
      */
@@ -106,7 +107,7 @@ public class JUnitTestSuite {
     }
 
     /**
-     * <p>getTrueCoveredBranches</p>
+     * getTrueCoveredBranches.
      *
      * @return a {@link java.util.Set} object.
      */
@@ -115,7 +116,7 @@ public class JUnitTestSuite {
     }
 
     /**
-     * <p>getFalseCoveredBranches</p>
+     * getFalseCoveredBranches.
      *
      * @return a {@link java.util.Set} object.
      */
@@ -124,7 +125,7 @@ public class JUnitTestSuite {
     }
 
     /**
-     * <p>runTest</p>
+     * runTest.
      *
      * @param test a {@link org.evosuite.testcase.TestCase} object.
      * @return a {@link org.evosuite.testcase.execution.ExecutionResult} object.

--- a/client/src/main/java/org/evosuite/junit/MutationAnalysisRunner.java
+++ b/client/src/main/java/org/evosuite/junit/MutationAnalysisRunner.java
@@ -92,9 +92,10 @@ public class MutationAnalysisRunner extends BlockJUnit4ClassRunner {
         Set<Integer> touchedMutants = ExecutionTracer.getExecutionTracer().getTrace().getTouchedMutants();
         logger.info("Touched mutants: " + touchedMutants.size());
         // Now run it for all touched mutants
-        for (Integer mutantID : touchedMutants) {
+        for (Integer mutantId : touchedMutants) {
             // logger.info("Current mutant: "+mutantID);
-            Mutation m = MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT()).getMutant(mutantID);
+            Mutation m = MutationPool.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                    .getMutant(mutantId);
             if (killedMutants.contains(m)) {
                 // logger.info("Already dead: "+mutantID);
                 continue;
@@ -108,7 +109,7 @@ public class MutationAnalysisRunner extends BlockJUnit4ClassRunner {
 
             // If killed
             if (resultListener.hasFailure != result) {
-                logger.info("Now killed: " + mutantID);
+                logger.info("Now killed: " + mutantId);
                 try {
                     liveMutants.remove(m);
                 } catch (Throwable t) {
@@ -123,7 +124,7 @@ public class MutationAnalysisRunner extends BlockJUnit4ClassRunner {
                 }
 
                 //} else {
-                //	logger.info("Remains live: "+mutantID);
+                //    logger.info("Remains live: "+mutantID);
             }
         }
         notifier.removeListener(resultListener);

--- a/client/src/main/java/org/evosuite/junit/UnitTestAdapter.java
+++ b/client/src/main/java/org/evosuite/junit/UnitTestAdapter.java
@@ -29,21 +29,21 @@ import java.util.Map;
 
 
 /**
- * <p>UnitTestAdapter interface.</p>
+ * UnitTestAdapter interface.
  *
  * @author fraser
  */
 public interface UnitTestAdapter extends JUnitAnnotationProvider {
 
     /**
-     * Get all the framework dependent imports
+     * Get all the framework dependent imports.
      *
      * @return a {@link java.lang.String} object.
      */
     String getImports();
 
     /**
-     * Get the framework specific definition of the test class
+     * Get the framework specific definition of the test class.
      *
      * @param testName a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
@@ -51,7 +51,7 @@ public interface UnitTestAdapter extends JUnitAnnotationProvider {
     String getClassDefinition(String testName);
 
     /**
-     * Get the framework specific definition of a test method
+     * Get the framework specific definition of a test method.
      *
      * @param testName a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
@@ -59,7 +59,7 @@ public interface UnitTestAdapter extends JUnitAnnotationProvider {
     String getMethodDefinition(String testName);
 
     /**
-     * Get the class definition of a test suite
+     * Get the class definition of a test suite.
      *
      * @param tests a {@link java.util.List} object.
      * @return a {@link java.lang.String} object.
@@ -67,7 +67,7 @@ public interface UnitTestAdapter extends JUnitAnnotationProvider {
     String getSuite(List<String> tests);
 
     /**
-     * Return the sequence of method calls for a test
+     * Return the sequence of method calls for a test.
      *
      * @param test       a {@link org.evosuite.testcase.TestCase} object.
      * @param exceptions a {@link java.util.Map} object.
@@ -77,7 +77,7 @@ public interface UnitTestAdapter extends JUnitAnnotationProvider {
     String getTestString(int id, TestCase test, Map<Integer, Throwable> exceptions);
 
     /**
-     * Return the sequence of method calls for a test
+     * Return the sequence of method calls for a test.
      *
      * @param test       a {@link org.evosuite.testcase.TestCase} object.
      * @param exceptions a {@link java.util.Map} object.

--- a/client/src/main/java/org/evosuite/junit/naming/methods/CoverageGoalTestNameGenerationStrategy.java
+++ b/client/src/main/java/org/evosuite/junit/naming/methods/CoverageGoalTestNameGenerationStrategy.java
@@ -45,6 +45,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
+ * Strategy to generate test names based on coverage goals.
+ *
  * @author Gordon Fraser
  * @author Ermira Daka
  */
@@ -89,9 +91,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * This assumes all goals are already saved in the tests
+     * This assumes all goals are already saved in the tests.
      *
-     * @param testCases
+     * @param testCases list of test cases
      */
     public CoverageGoalTestNameGenerationStrategy(List<TestCase> testCases) {
         Map<TestCase, Set<TestFitnessFunction>> testToGoals = initializeCoverageMapFromTests(testCases);
@@ -99,9 +101,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Initially, set to the top level goals
+     * Initially, set to the top level goals.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private void initializeNameGoals(Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
         // Start off with only the top goals and then iteratively add more goals
@@ -129,9 +131,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Calculate the test names from the current goals
+     * Calculate the test names from the current goals.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private void setTestNames(Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
         for (Map.Entry<TestCase, Set<TestFitnessFunction>> entry : testToGoals.entrySet()) {
@@ -140,9 +142,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Helper method that does the bulk of the work
+     * Helper method that does the bulk of the work.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private void generateNames(Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
         initializeMethodCoverageCount(testToGoals);
@@ -162,13 +164,14 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
                 }
 
                 // Try adding something unique for the given test set
-                if (resolveAmbiguity(testToGoals, entry.getValue(), true))
+                if (resolveAmbiguity(testToGoals, entry.getValue(), true)) {
                     changed = true;
-                else {
+                } else {
                     // If there is nothing unique, try using something that reduces
                     // the number of tests in this ambiguity group
-                    if (resolveAmbiguity(testToGoals, entry.getValue(), false))
+                    if (resolveAmbiguity(testToGoals, entry.getValue(), false)) {
                         changed = true;
+                    }
                 }
             }
         }
@@ -176,7 +179,8 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         // If there is absolutely nothing unique, add the top goals so that the test at least has a name
         for (Map.Entry<TestCase, Set<TestFitnessFunction>> entry : testToGoals.entrySet()) {
             if (entry.getValue().isEmpty()) {
-                List<TestFitnessFunction> goals = new ArrayList<>(getUniqueNonMethodGoals(entry.getKey(), testToGoals));
+                List<TestFitnessFunction> goals = new ArrayList<>(
+                        getUniqueNonMethodGoals(entry.getKey(), testToGoals));
                 if (goals.isEmpty()) {
                     goals.addAll(filterSupportedGoals(entry.getKey().getCoveredGoals()));
                 }
@@ -195,19 +199,22 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * There is nothing unique about the test, so we have to add goals until we find a unique name
+     * There is nothing unique about the test, so we have to add goals until we find a unique name.
      */
-    private Set<TestFitnessFunction> getUniqueNonMethodGoals(TestCase test, Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
+    private Set<TestFitnessFunction> getUniqueNonMethodGoals(TestCase test,
+                                                             Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
         Set<TestFitnessFunction> allGoals = new LinkedHashSet<>();
         for (Set<TestFitnessFunction> goals : testToGoals.values()) {
             allGoals.addAll(goals);
         }
         Set<TestFitnessFunction> goals = new LinkedHashSet<>();
         for (TestFitnessFunction goal : filterSupportedGoals(test.getCoveredGoals())) {
-            if (goal instanceof MethodCoverageTestFitness)
+            if (goal instanceof MethodCoverageTestFitness) {
                 continue;
-            if (goal instanceof MethodNoExceptionCoverageTestFitness)
+            }
+            if (goal instanceof MethodNoExceptionCoverageTestFitness) {
                 continue;
+            }
             if (!allGoals.contains(goal)) {
                 goals.add(goal);
             }
@@ -216,14 +223,15 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Add additional goals for tests to testsToGoals to make them distinguishable
+     * Add additional goals for tests to testsToGoals to make them distinguishable.
      *
-     * @param testToGoals
-     * @param tests
-     * @param unique
-     * @return
+     * @param testToGoals map of test case to goals
+     * @param tests       set of test cases
+     * @param unique      whether to find unique goals
+     * @return true if added
      */
-    private boolean resolveAmbiguity(Map<TestCase, Set<TestFitnessFunction>> testToGoals, Set<TestCase> tests, boolean unique) {
+    private boolean resolveAmbiguity(Map<TestCase, Set<TestFitnessFunction>> testToGoals, Set<TestCase> tests,
+                                     boolean unique) {
 
         // Full list of goals for given tests
         Map<TestCase, Set<TestFitnessFunction>> fullTestToGoals = new LinkedHashMap<>();
@@ -234,10 +242,11 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         }
 
         // Find out what is unique about each one, or at least helps reduce the number of ambiguous names
-        if (unique)
+        if (unique) {
             findUniqueGoals(fullTestToGoals);
-        else
+        } else {
             findNonUbiquitousGoals(fullTestToGoals);
+        }
 
         // Select the next best goal from the new unique goal sets
         boolean added = false;
@@ -249,8 +258,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
                 newGoals.add(newGoal);
                 String newName = getTestName(test, newGoals);
                 if (newName.length() < MAX_CHARS) {
-                    if (testToGoals.get(test).add(newGoal))
+                    if (testToGoals.get(test).add(newGoal)) {
                         added = true;
+                    }
                 }
             } else {
                 Set<TestFitnessFunction> newGoals = new LinkedHashSet<>(testToGoals.get(test));
@@ -260,8 +270,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
                     TestFitnessFunction newGoal = iterator.next();
                     newGoals.add(newGoal);
                     newName = getTestName(test, newGoals);
-                    if (testToGoals.get(test).add(newGoal))
+                    if (testToGoals.get(test).add(newGoal)) {
                         added = true;
+                    }
                 }
             }
         }
@@ -270,10 +281,10 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
 
 
     /**
-     * Builds the name map based on coverage goal stored as covered in each of the tests
+     * Builds the name map based on coverage goal stored as covered in each of the tests.
      *
-     * @param tests
-     * @return
+     * @param tests list of tests
+     * @return map of test to goals
      */
     private Map<TestCase, Set<TestFitnessFunction>> initializeCoverageMapFromTests(List<TestCase> tests) {
         Map<TestCase, Set<TestFitnessFunction>> testToGoals = new LinkedHashMap<>();
@@ -284,10 +295,10 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Builds the name map based on coverage goals stored as covered in the tests pointed to by results
+     * Builds the name map based on coverage goals stored as covered in the tests pointed to by results.
      *
-     * @param results
-     * @return
+     * @param results list of execution results
+     * @return map of test to goals
      */
     private Map<TestCase, Set<TestFitnessFunction>> initializeCoverageMapFromResults(List<ExecutionResult> results) {
         Map<TestCase, Set<TestFitnessFunction>> testToGoals = new LinkedHashMap<>();
@@ -301,10 +312,15 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
      * Name generation assumes that certain coverage criteria are included. If we haven't targeted them yet,
      * we need to determine the covered goals. This may require re-executing the tests with observers.
      *
-     * @param results
+     * @param results list of execution results
      */
     private void addGoalsNotIncludedInTargetCriteria(List<ExecutionResult> results) {
-        List<Properties.Criterion> requiredCriteria = new ArrayList<>(Arrays.asList(Properties.Criterion.OUTPUT, Properties.Criterion.INPUT, Properties.Criterion.METHOD, Properties.Criterion.METHODNOEXCEPTION, Properties.Criterion.EXCEPTION));
+        List<Properties.Criterion> requiredCriteria = new ArrayList<>(Arrays.asList(
+                Properties.Criterion.OUTPUT,
+                Properties.Criterion.INPUT,
+                Properties.Criterion.METHOD,
+                Properties.Criterion.METHODNOEXCEPTION,
+                Properties.Criterion.EXCEPTION));
         requiredCriteria.removeAll(Arrays.asList(Properties.CRITERION));
         results = getUpdatedResults(requiredCriteria, results);
         for (Properties.Criterion c : requiredCriteria) {
@@ -312,21 +328,23 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             List<? extends TestFitnessFunction> goals = goalFactory.getCoverageGoals();
             for (ExecutionResult result : results) {
                 for (TestFitnessFunction goal : goals) {
-                    if (goal.isCovered(result))
+                    if (goal.isCovered(result)) {
                         result.test.addCoveredGoal(goal);
+                    }
                 }
             }
         }
     }
 
     /**
-     * Some criteria require re-execution with observers. Make sure the results are up-to-date
+     * Some criteria require re-execution with observers. Make sure the results are up-to-date.
      *
-     * @param requiredCriteria
-     * @param origResults
-     * @return
+     * @param requiredCriteria list of criteria
+     * @param origResults      original results
+     * @return updated results
      */
-    private List<ExecutionResult> getUpdatedResults(List<Properties.Criterion> requiredCriteria, List<ExecutionResult> origResults) {
+    private List<ExecutionResult> getUpdatedResults(List<Properties.Criterion> requiredCriteria,
+                                                    List<ExecutionResult> origResults) {
         List<ExecutionObserver> newObservers = new ArrayList<>();
         if (requiredCriteria.contains(Properties.Criterion.INPUT)) {
             newObservers.add(new InputObserver());
@@ -337,8 +355,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         if (newObservers.isEmpty()) {
             return origResults;
         }
-        for (ExecutionObserver observer : newObservers)
+        for (ExecutionObserver observer : newObservers) {
             TestCaseExecutor.getInstance().addObserver(observer);
+        }
 
         List<ExecutionResult> newResults = new ArrayList<>();
         for (ExecutionResult result : origResults) {
@@ -346,32 +365,37 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             newResults.add(newResult);
         }
 
-        for (ExecutionObserver observer : newObservers)
+        for (ExecutionObserver observer : newObservers) {
             TestCaseExecutor.getInstance().removeObserver(observer);
+        }
 
         return newResults;
     }
 
     /**
-     * We use only a subset of the possible criteria to determine names
+     * We use only a subset of the possible criteria to determine names.
      */
-    private final List<Class<?>> supportedClasses = Arrays.asList(new Class<?>[]{MethodCoverageTestFitness.class, MethodNoExceptionCoverageTestFitness.class,
-            ExceptionCoverageTestFitness.class, OutputCoverageTestFitness.class, InputCoverageTestFitness.class});
+    private final List<Class<?>> supportedClasses = Arrays.asList(new Class<?>[]{
+            MethodCoverageTestFitness.class,
+            MethodNoExceptionCoverageTestFitness.class,
+            ExceptionCoverageTestFitness.class,
+            OutputCoverageTestFitness.class,
+            InputCoverageTestFitness.class});
 
     /**
-     * Remove any goals that are irrelevant for name generation
+     * Remove any goals that are irrelevant for name generation.
      *
-     * @param goals
-     * @return
+     * @param goals set of goals
+     * @return filtered goals
      */
     private Set<TestFitnessFunction> filterSupportedGoals(Set<TestFitnessFunction> goals) {
         return goals.stream().filter(c -> supportedClasses.contains(c.getClass())).collect(Collectors.toSet());
     }
 
     /**
-     * Determine if we have overloaded methods, which requires the use of signatures
+     * Determine if we have overloaded methods, which requires the use of signatures.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private void initializeMethodCoverageCount(Map<TestCase, Set<TestFitnessFunction>> testToGoals) {
         for (Set<TestFitnessFunction> goals : testToGoals.values()) {
@@ -386,9 +410,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Determine for each test the set of coverage goals uniquely covered by this test
+     * Determine for each test the set of coverage goals uniquely covered by this test.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private static <T> void findUniqueGoals(Map<TestCase, Set<T>> testToGoals) {
         // Could be optimised
@@ -397,8 +421,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         for (Map.Entry<TestCase, Set<T>> entry : testToGoals.entrySet()) {
             Set<T> goalSet = new LinkedHashSet<>(entry.getValue());
             for (Map.Entry<TestCase, Set<T>> otherEntry : testToGoals.entrySet()) {
-                if (entry == otherEntry)
+                if (entry == otherEntry) {
                     continue;
+                }
                 goalSet.removeAll(otherEntry.getValue());
             }
             goalMapCopy.put(entry.getKey(), goalSet);
@@ -408,9 +433,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Determine for each test the set of coverage goals that remain if we remove those that are covered by all tests
+     * Determine for each test the set of coverage goals that remain if we remove those that are covered by all tests.
      *
-     * @param testToGoals
+     * @param testToGoals map of test case to goals
      */
     private static <T> void findNonUbiquitousGoals(Map<TestCase, Set<T>> testToGoals) {
         // Could be optimised
@@ -436,9 +461,9 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Create a map of test name to all the tests that lead to it
+     * Create a map of test name to all the tests that lead to it.
      *
-     * @return
+     * @return map of name to test cases
      */
     private Map<String, Set<TestCase>> determineDuplicateNames() {
         Map<String, Set<TestCase>> testMap = new LinkedHashMap<>();
@@ -459,15 +484,15 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * There may be tests with the same calculated name, in which case we add a number suffix
+     * There may be tests with the same calculated name, in which case we add a number suffix.
      */
     private void fixAmbiguousTestNames() {
         Map<String, Integer> nameCount = new LinkedHashMap<>();
         Map<String, Integer> testCount = new LinkedHashMap<>();
         for (String methodName : testToName.values()) {
-            if (nameCount.containsKey(methodName))
+            if (nameCount.containsKey(methodName)) {
                 nameCount.put(methodName, nameCount.get(methodName) + 1);
-            else {
+            } else {
                 nameCount.put(methodName, 1);
                 testCount.put(methodName, 0);
             }
@@ -482,10 +507,10 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Make first letter upper case
+     * Make first letter upper case.
      *
-     * @param input
-     * @return
+     * @param input string
+     * @return capitalized string
      */
     private static String capitalize(String input) {
         final char[] buffer = input.toCharArray();
@@ -494,11 +519,11 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Determine name for the given test
+     * Determine name for the given test.
      *
-     * @param test
-     * @param uniqueGoals
-     * @return
+     * @param test        test case
+     * @param uniqueGoals set of unique goals
+     * @return test name
      */
     private String getTestName(TestCase test, Set<TestFitnessFunction> uniqueGoals) {
         List<TestFitnessFunction> goalList = new ArrayList<>(uniqueGoals); // getTopGoals(uniqueGoals);
@@ -511,34 +536,37 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             name += getGoalPairName(goalList.get(0), goalList.get(1));
         } else {
             name += getGoalName(goalList.get(0));
-            for (int i = 1; i < goalList.size(); i++)
+            for (int i = 1; i < goalList.size(); i++) {
                 name += STR_AND + getGoalName(goalList.get(i));
+            }
             // name += capitalize(getGoalName(chooseRepresentativeGoal(test, goalList)));
         }
         return name;
     }
 
     /**
-     * Retrieve all goals at the highest level of priority
+     * Retrieve all goals at the highest level of priority.
      *
-     * @param coveredGoals
-     * @return
+     * @param coveredGoals set of covered goals
+     * @return list of top goals
      */
     private List<TestFitnessFunction> getTopGoals(Set<TestFitnessFunction> coveredGoals) {
         List<TestFitnessFunction> goalList = new ArrayList<>(coveredGoals);
         goalList.sort(new GoalComparator());
 
         List<TestFitnessFunction> topGoals = new ArrayList<>();
-        if (coveredGoals.isEmpty())
+        if (coveredGoals.isEmpty()) {
             return topGoals;
+        }
 
         Iterator<TestFitnessFunction> iterator = goalList.iterator();
         TestFitnessFunction lastGoal = iterator.next();
         topGoals.add(lastGoal);
         while (iterator.hasNext()) {
             TestFitnessFunction nextGoal = iterator.next();
-            if (!nextGoal.getClass().equals(lastGoal.getClass()))
+            if (!nextGoal.getClass().equals(lastGoal.getClass())) {
                 break;
+            }
             topGoals.add(nextGoal);
             lastGoal = nextGoal;
         }
@@ -547,11 +575,11 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
 
     /**
      * Out of a set of multiple goals, select one that is representative.
-     * Assumes that goals is not empty, and all items in goals have the same type
+     * Assumes that goals is not empty, and all items in goals have the same type.
      *
-     * @param test
-     * @param goals
-     * @return
+     * @param test  test case
+     * @param goals collection of goals
+     * @return chosen goal
      */
     private TestFitnessFunction chooseRepresentativeGoal(TestCase test, Collection<TestFitnessFunction> goals) {
         Map<String, Integer> methodToPosition = new LinkedHashMap<>();
@@ -581,10 +609,10 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Helper function to redirect name retrieval to the right method
+     * Helper function to redirect name retrieval to the right method.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(TestFitnessFunction goal) {
         if (goal instanceof MethodCoverageTestFitness) {
@@ -599,76 +627,81 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             return getGoalName((OutputCoverageTestFitness) goal);
         } else {
             return formatMethodName(goal.getTargetClass(), goal.getTargetMethod());
-//            throw new RuntimeException("Not implemented yet: "+goal.getClass());
+            // throw new RuntimeException("Not implemented yet: "+goal.getClass());
         }
     }
 
     /**
-     * Get name for a single method goal
+     * Get name for a single method goal.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(MethodCoverageTestFitness goal) {
         return formatMethodName(goal.getClassName(), goal.getMethod());
     }
 
     /**
-     * Get name for a single method without exception goal
+     * Get name for a single method without exception goal.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(MethodNoExceptionCoverageTestFitness goal) {
         return formatMethodName(goal.getClassName(), goal.getMethod());
     }
 
     /**
-     * Get name for a single exception goal
+     * Get name for a single exception goal.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(ExceptionCoverageTestFitness goal) {
         Class<?> ex = goal.getExceptionClass();
-        while (!Modifier.isPublic(ex.getModifiers()) || EvoSuiteMock.class.isAssignableFrom(ex) ||
-                ex.getCanonicalName().startsWith("com.sun.")) {
+        while (!Modifier.isPublic(ex.getModifiers()) || EvoSuiteMock.class.isAssignableFrom(ex)
+                || ex.getCanonicalName().startsWith("com.sun.")) {
             ex = ex.getSuperclass();
         }
 
         if (goal.getTargetMethod().startsWith("<init>")) {
-            return STR_CREATE_EXCEPTION + capitalize(getUniqueConstructorName(goal.getTargetClass(), goal.getTargetMethod())) + STR_THROWS + capitalize(ex.getSimpleName());
+            return STR_CREATE_EXCEPTION + capitalize(
+                    getUniqueConstructorName(goal.getTargetClass(), goal.getTargetMethod())) + STR_THROWS + capitalize(
+                    ex.getSimpleName());
         }
-        return formatMethodName(goal.getTargetClass(), goal.getTargetMethod()) + STR_THROWS + capitalize(ex.getSimpleName());
+        return formatMethodName(goal.getTargetClass(), goal.getTargetMethod()) + STR_THROWS + capitalize(
+                ex.getSimpleName());
     }
 
     /**
-     * Get name for a single input goal
+     * Get name for a single input goal.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(InputCoverageTestFitness goal) {
         String descriptor = goal.getValueDescriptor();
-        return formatMethodName(goal.getClassName(), goal.getMethod()) + STR_WITH + formatValueDescriptor(descriptor);
+        return formatMethodName(goal.getClassName(), goal.getMethod()) + STR_WITH
+                + formatValueDescriptor(descriptor);
     }
 
     /**
-     * Get name for a single output goal
+     * Get name for a single output goal.
      *
-     * @param goal
-     * @return
+     * @param goal fitness function
+     * @return name
      */
     private String getGoalName(OutputCoverageTestFitness goal) {
         String descriptor = goal.getValueDescriptor();
-        return formatMethodName(goal.getClassName(), goal.getMethod()) + STR_RETURNS + formatValueDescriptor(descriptor);
+        return formatMethodName(goal.getClassName(), goal.getMethod()) + STR_RETURNS
+                + formatValueDescriptor(descriptor);
     }
 
     /**
-     * Format the value descriptors used by input and output goals
+     * Format the value descriptors used by input and output goals.
      *
-     * @param descriptor
-     * @return
+     * @param descriptor value descriptor
+     * @return formatted string
      */
     private String formatValueDescriptor(String descriptor) {
         String[] components = descriptor.split(":");
@@ -682,25 +715,27 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             return capitalize(components[2]);
         } else if (components.length == 4) {
             // Inspector
-            return capitalize(getShortClassName(components[1])) + STR_WHERE + capitalize(getMethodNameWithoutDescriptor(components[2])) + STR_IS + capitalize(components[3]);
+            return capitalize(getShortClassName(components[1])) + STR_WHERE + capitalize(
+                    getMethodNameWithoutDescriptor(components[2])) + STR_IS + capitalize(components[3]);
         } else {
             throw new RuntimeException("Unsupported value descriptor: " + descriptor);
         }
     }
 
     /**
-     * Some goals require special treatment when combining two
+     * Some goals require special treatment when combining two.
      *
-     * @param goal1
-     * @param goal2
-     * @return
+     * @param goal1 first goal
+     * @param goal2 second goal
+     * @return name
      */
     private String getGoalPairName(TestFitnessFunction goal1, TestFitnessFunction goal2) {
         if (goal1.getClass().equals(goal2.getClass())) {
             if (goal1 instanceof MethodCoverageTestFitness) {
                 return getGoalPairName((MethodCoverageTestFitness) goal1, (MethodCoverageTestFitness) goal2);
             }
-            if (goal1.getTargetClass().equals(goal2.getTargetClass()) && goal1.getTargetMethod().equals(goal2.getTargetMethod())) {
+            if (goal1.getTargetClass().equals(goal2.getTargetClass()) && goal1.getTargetMethod().equals(
+                    goal2.getTargetMethod())) {
                 if (goal1 instanceof InputCoverageTestFitness) {
                     return getGoalPairName((InputCoverageTestFitness) goal1, (InputCoverageTestFitness) goal2);
                 } else if (goal1 instanceof OutputCoverageTestFitness) {
@@ -712,80 +747,86 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Determine name for pair of method goals
+     * Determine name for pair of method goals.
      *
-     * @param goal1
-     * @param goal2
-     * @return
+     * @param goal1 first goal
+     * @param goal2 second goal
+     * @return name
      */
     private String getGoalPairName(MethodCoverageTestFitness goal1, MethodCoverageTestFitness goal2) {
         boolean isConstructor1 = goal1.getTargetMethod().startsWith("<init>");
         boolean isConstructor2 = goal2.getTargetMethod().startsWith("<init>");
 
         if (isConstructor1 != isConstructor2) {
-            if (isConstructor1)
+            if (isConstructor1) {
                 return getGoalName(goal1) + "AndCalls" + getGoalName(goal2);
-            else
+            } else {
                 return getGoalName(goal2) + "AndCalls" + getGoalName(goal1);
+            }
         } else {
             return getGoalName(goal1) + STR_AND + getGoalName(goal2);
         }
     }
 
     /**
-     * Determine name for pair of input goals
+     * Determine name for pair of input goals.
      *
-     * @param goal1
-     * @param goal2
-     * @return
+     * @param goal1 first goal
+     * @param goal2 second goal
+     * @return name
      */
     private String getGoalPairName(InputCoverageTestFitness goal1, InputCoverageTestFitness goal2) {
-        return formatMethodName(goal1.getClassName(), goal1.getMethod()) + STR_WITH + formatValueDescriptor(goal1.getValueDescriptor()) + STR_AND + formatValueDescriptor(goal2.getValueDescriptor());
+        return formatMethodName(goal1.getClassName(), goal1.getMethod()) + STR_WITH + formatValueDescriptor(
+                goal1.getValueDescriptor()) + STR_AND + formatValueDescriptor(goal2.getValueDescriptor());
     }
 
     /**
-     * Determine name for pair of output goals
+     * Determine name for pair of output goals.
      *
-     * @param goal1
-     * @param goal2
-     * @return
+     * @param goal1 first goal
+     * @param goal2 second goal
+     * @return name
      */
     private String getGoalPairName(OutputCoverageTestFitness goal1, OutputCoverageTestFitness goal2) {
-        return formatMethodName(goal1.getClassName(), goal1.getMethod()) + STR_RETURNS + formatValueDescriptor(goal1.getValueDescriptor()) + STR_AND + formatValueDescriptor(goal2.getValueDescriptor());
+        return formatMethodName(goal1.getClassName(), goal1.getMethod()) + STR_RETURNS + formatValueDescriptor(
+                goal1.getValueDescriptor()) + STR_AND + formatValueDescriptor(goal2.getValueDescriptor());
     }
 
     /**
-     * Make sure package names are omitted and array brackets are not used in names
+     * Make sure package names are omitted and array brackets are not used in names.
      *
-     * @param className
-     * @return
+     * @param className class name
+     * @return short class name
      */
     private String getShortClassName(String className) {
         int pos = className.lastIndexOf(".");
-        if (pos >= 0)
+        if (pos >= 0) {
             return className.substring(pos + 1).replace("[]", "Array");
-        else
+        } else {
             return className.replace("[]", "Array");
+        }
     }
 
     /**
-     * Distinguish between constructors and methods in creating call goals
+     * Distinguish between constructors and methods in creating call goals.
      *
-     * @param className
-     * @param method
-     * @return
+     * @param className class name
+     * @param method    method name
+     * @return formatted method name
      */
     private String formatMethodName(String className, String method) {
         if (method.startsWith("<init>")) {
             String methodWithoutDescriptor = getMethodNameWithoutDescriptor(method);
-            if (methodCount.containsKey(methodWithoutDescriptor) && methodCount.get(methodWithoutDescriptor).size() > 1) {
+            if (methodCount.containsKey(methodWithoutDescriptor)
+                    && methodCount.get(methodWithoutDescriptor).size() > 1) {
                 return STR_CREATE + capitalize(getUniqueConstructorName(getShortClassName(className), method));
             } else {
                 return STR_CREATE + capitalize(getShortClassName(className));
             }
         } else {
             String methodWithoutDescriptor = getMethodNameWithoutDescriptor(method);
-            if (methodCount.containsKey(methodWithoutDescriptor) && methodCount.get(methodWithoutDescriptor).size() > 1) {
+            if (methodCount.containsKey(methodWithoutDescriptor)
+                    && methodCount.get(methodWithoutDescriptor).size() > 1) {
                 return capitalize(getUniqueMethodName(methodWithoutDescriptor, method));
             } else {
                 return capitalize(methodWithoutDescriptor);
@@ -794,17 +835,19 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Get a unique method name, depending on whether it is unique or overloaded
+     * Get a unique method name, depending on whether it is unique or overloaded.
      *
-     * @param methodNameWithoutDescriptor
-     * @param methodName
-     * @return
+     * @param methodNameWithoutDescriptor method name
+     * @param methodName                  full method name
+     * @return unique method name
      */
     private String getUniqueMethodName(String methodNameWithoutDescriptor, String methodName) {
-        if (!methodCount.containsKey(methodNameWithoutDescriptor))
+        if (!methodCount.containsKey(methodNameWithoutDescriptor)) {
             return methodNameWithoutDescriptor;
-        if (methodCount.get(methodNameWithoutDescriptor).size() == 1)
+        }
+        if (methodCount.get(methodNameWithoutDescriptor).size() == 1) {
             return methodNameWithoutDescriptor;
+        }
         int pos = methodName.indexOf('(');
         if (pos < 0) {
             return methodName; // TODO: Should this really be possible?
@@ -812,10 +855,11 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         String descriptor = methodName.substring(pos);
         Type[] argumentTypes = Type.getArgumentTypes(descriptor);
         // TODO: Dummy for now
-        if (argumentTypes.length == 0)
+        if (argumentTypes.length == 0) {
             return methodNameWithoutDescriptor + STR_WITHOUT + STR_ARGUMENTS;
-        else if (argumentTypes.length == 1) {
-            return methodNameWithoutDescriptor + STR_TAKING + capitalize(getShortClassName(argumentTypes[0].getClassName()));
+        } else if (argumentTypes.length == 1) {
+            return methodNameWithoutDescriptor + STR_TAKING + capitalize(
+                    getShortClassName(argumentTypes[0].getClassName()));
         } else {
             // is there any other implementation of the same method with same number of arguments?
             Set<String> otherMethods = new HashSet<>(methodCount.get(methodNameWithoutDescriptor));
@@ -831,16 +875,17 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
             }
             if (sameCardinality) { // synthesise descriptor based on arguments' types
                 return methodNameWithoutDescriptor + STR_TAKING + getTypeArgumentsDescription(argumentTypes);
-            } else // only method with this number of arguments
+            } else { // only method with this number of arguments
                 return methodNameWithoutDescriptor + STR_TAKING + argumentTypes.length + STR_ARGUMENTS;
+            }
         }
     }
 
     /**
-     * Concatenate argument types when there is more than one arguments
+     * Concatenate argument types when there is more than one arguments.
      *
-     * @param argumentTypes
-     * @return
+     * @param argumentTypes types of arguments
+     * @return description
      */
     private String getTypeArgumentsDescription(Type[] argumentTypes) {
         assert (argumentTypes.length > 1);
@@ -848,21 +893,23 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         Map<String, Integer> typeDescs = new LinkedHashMap<>();
         for (Type t : argumentTypes) {
             String d = capitalize(getShortClassName(t.getClassName()));
-            if (!typeDescs.containsKey(d))
+            if (!typeDescs.containsKey(d)) {
                 typeDescs.put(d, 1);
-            else
+            } else {
                 typeDescs.put(d, typeDescs.get(d) + 1);
+            }
         }
 
         StringBuilder builder = new StringBuilder();
         Object[] args = typeDescs.keySet().toArray();
         for (int i = 0; i < args.length; i++) {
             String arg = (String) args[i];
-            if (args.length > 1 && i == args.length - 1)
+            if (args.length > 1 && i == args.length - 1) {
                 builder.append(STR_AND);
-            if (typeDescs.get(arg) == 1)
+            }
+            if (typeDescs.get(arg) == 1) {
                 builder.append(typeDescs.get(arg));
-            else {
+            } else {
                 builder.append(typeDescs.get(arg));
                 builder.append(arg);
                 builder.append('s');
@@ -872,17 +919,19 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
     }
 
     /**
-     * Get a unique constructor name, depending on whether it is unique or overloaded
+     * Get a unique constructor name, depending on whether it is unique or overloaded.
      *
-     * @param className
-     * @param methodName
-     * @return
+     * @param className  class name
+     * @param methodName method name
+     * @return unique constructor name
      */
     private String getUniqueConstructorName(String className, String methodName) {
-        if (!methodCount.containsKey("<init>"))
+        if (!methodCount.containsKey("<init>")) {
             return getShortClassName(className);
-        if (methodCount.get("<init>").size() == 1)
+        }
+        if (methodCount.get("<init>").size() == 1) {
             return getShortClassName(className);
+        }
         int pos = methodName.indexOf('(');
         if (pos < 0) {
             return getShortClassName(className); // TODO: Should this really be possible?
@@ -890,27 +939,30 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         String descriptor = methodName.substring(pos);
         Type[] argumentTypes = Type.getArgumentTypes(descriptor);
         // TODO: Dummy for now
-        if (argumentTypes.length == 0)
+        if (argumentTypes.length == 0) {
             return getShortClassName(className) + STR_WITHOUT + STR_ARGUMENTS;
-        else if (argumentTypes.length == 1) {
-            return getShortClassName(className) + STR_TAKING + capitalize(getShortClassName(argumentTypes[0].getClassName()));
-        } else
+        } else if (argumentTypes.length == 1) {
+            return getShortClassName(className) + STR_TAKING + capitalize(
+                    getShortClassName(argumentTypes[0].getClassName()));
+        } else {
             return getShortClassName(className) + STR_TAKING + argumentTypes.length + STR_ARGUMENTS;
+        }
     }
 
     /**
-     * Cut off descriptor from method name
+     * Cut off descriptor from method name.
      *
-     * @param methodName
-     * @return
+     * @param methodName method name
+     * @return method name without descriptor
      */
     private String getMethodNameWithoutDescriptor(String methodName) {
         // Should have a descriptor
         int pos = methodName.indexOf('(');
-        if (pos > 0)
+        if (pos > 0) {
             return methodName.substring(0, pos);
-        else
+        } else {
             return methodName;
+        }
 
     }
 
@@ -923,4 +975,3 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
         return testToName.get(test);
     }
 }
-

--- a/client/src/main/java/org/evosuite/junit/naming/methods/GoalComparator.java
+++ b/client/src/main/java/org/evosuite/junit/naming/methods/GoalComparator.java
@@ -44,33 +44,39 @@ public class GoalComparator implements Comparator<TestFitnessFunction> {
     public int compare(TestFitnessFunction o1, TestFitnessFunction o2) {
         Class<?> c1 = o1.getClass();
         Class<?> c2 = o2.getClass();
-        if (c1.equals(c2))
+        if (c1.equals(c2)) {
             return o1.compareTo(o2);
+        }
 
-        if (c1.equals(ExceptionCoverageTestFitness.class))
+        if (c1.equals(ExceptionCoverageTestFitness.class)) {
             return -1;
-        else if (c2.equals(ExceptionCoverageTestFitness.class))
+        } else if (c2.equals(ExceptionCoverageTestFitness.class)) {
             return 1;
+        }
 
-        if (c1.equals(MethodCoverageTestFitness.class))
+        if (c1.equals(MethodCoverageTestFitness.class)) {
             return -1;
-        else if (c2.equals(MethodCoverageTestFitness.class))
+        } else if (c2.equals(MethodCoverageTestFitness.class)) {
             return 1;
+        }
 
-        if (c1.equals(MethodNoExceptionCoverageTestFitness.class))
+        if (c1.equals(MethodNoExceptionCoverageTestFitness.class)) {
             return -1;
-        else if (c2.equals(MethodNoExceptionCoverageTestFitness.class))
+        } else if (c2.equals(MethodNoExceptionCoverageTestFitness.class)) {
             return 1;
+        }
 
-        if (c1.equals(OutputCoverageTestFitness.class))
+        if (c1.equals(OutputCoverageTestFitness.class)) {
             return -1;
-        else if (c2.equals(OutputCoverageTestFitness.class))
+        } else if (c2.equals(OutputCoverageTestFitness.class)) {
             return 1;
+        }
 
-        if (c1.equals(InputCoverageTestFitness.class))
+        if (c1.equals(InputCoverageTestFitness.class)) {
             return -1;
-        else if (c2.equals(InputCoverageTestFitness.class))
+        } else if (c2.equals(InputCoverageTestFitness.class)) {
             return 1;
+        }
 
         // TODO: Assertion
 

--- a/client/src/main/java/org/evosuite/junit/rules/InitializeClasses.java
+++ b/client/src/main/java/org/evosuite/junit/rules/InitializeClasses.java
@@ -40,6 +40,7 @@ public class InitializeClasses extends BaseRule {
             } catch (ExceptionInInitializerError ex) {
                 System.err.println("Could not initialize " + className);
             } catch (Throwable t) {
+                // Ignored
             }
         }
         org.evosuite.runtime.agent.InstrumentingAgent.deactivate();

--- a/client/src/main/java/org/evosuite/junit/rules/Instrumentation.java
+++ b/client/src/main/java/org/evosuite/junit/rules/Instrumentation.java
@@ -20,7 +20,7 @@
 package org.evosuite.junit.rules;
 
 /**
- * Should be used as MethodRule
+ * Should be used as MethodRule.
  */
 public class Instrumentation extends BaseRule {
 

--- a/client/src/main/java/org/evosuite/junit/rules/StaticStateResetter.java
+++ b/client/src/main/java/org/evosuite/junit/rules/StaticStateResetter.java
@@ -24,7 +24,7 @@ import org.evosuite.TestGenerationContext;
 import java.util.Arrays;
 
 /**
- * Should be used as MethodRule
+ * Should be used as MethodRule.
  */
 public class StaticStateResetter extends BaseRule {
 
@@ -51,6 +51,7 @@ public class StaticStateResetter extends BaseRule {
             try {
                 org.evosuite.runtime.classhandling.ClassResetter.getInstance().reset(classNameToReset);
             } catch (Throwable t) {
+                // Ignored
             }
         }
     }

--- a/client/src/main/java/org/evosuite/junit/rules/Stubbing.java
+++ b/client/src/main/java/org/evosuite/junit/rules/Stubbing.java
@@ -32,7 +32,8 @@ public class Stubbing extends BaseRule {
 
     private final Set<String> propertiesToClear = new LinkedHashSet<>();
 
-    private static final java.util.Properties defaultProperties = (java.util.Properties) java.lang.System.getProperties().clone();
+    private static final java.util.Properties defaultProperties = (java.util.Properties) java.lang.System
+            .getProperties().clone();
 
     private PrintStream systemOut = null;
 

--- a/client/src/main/java/org/evosuite/junit/writer/JUnitAnnotationProvider.java
+++ b/client/src/main/java/org/evosuite/junit/writer/JUnitAnnotationProvider.java
@@ -1,28 +1,28 @@
 /**
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
- * <p>
- * This file is part of EvoSuite.
- * <p>
- * EvoSuite is free software: you can redistribute it and/or modify it
+ *
+ * <p>This file is part of EvoSuite.
+ *
+ * <p>EvoSuite is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation, either version 3.0 of the License, or
  * (at your option) any later version.
- * <p>
- * EvoSuite is distributed in the hope that it will be useful, but
+ *
+ * <p>EvoSuite is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser Public License for more details.
- * <p>
- * You should have received a copy of the GNU Lesser General Public
- * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * <p>You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see http://www.gnu.org/licenses/.
  */
 package org.evosuite.junit.writer;
 
 public interface JUnitAnnotationProvider {
 
     /**
-     * Get the annotation for a test case
+     * Get the annotation for a test case.
      *
      * @return the annotation.
      */

--- a/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
+++ b/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
@@ -53,7 +53,7 @@ import static org.evosuite.junit.writer.TestSuiteWriterUtils.*;
 /**
  * Class used to generate all the scaffolding code that ends up in methods
  * like @After/@Before and that are used to setup the EvoSuite framework (eg
- * mocking of classes, reset of static state)
+ * mocking of classes, reset of static state).
  *
  * @author arcuri
  */
@@ -66,10 +66,12 @@ public class Scaffolding {
     private static final String THREAD_STOPPER = "threadStopper";
 
     /**
-     * Return full JUnit code for scaffolding file for the give test
+     * Return full JUnit code for scaffolding file for the give test.
      *
-     * @param testName
-     * @return
+     * @param testName name of the test
+     * @param results execution results
+     * @param wasSecurityException if a security exception occurred
+     * @return content of the scaffolding file
      */
     public static String getScaffoldingFileContent(String testName, List<ExecutionResult> results,
                                                    boolean wasSecurityException) {
@@ -135,11 +137,11 @@ public class Scaffolding {
     }
 
     /**
-     * Return all classes for which we need an import statement
+     * Return all classes for which we need an import statement.
      *
-     * @param wasSecurityException
-     * @param results
-     * @return
+     * @param wasSecurityException if a security exception occurred
+     * @param results execution results
+     * @return list of imports
      */
     public static List<String> getScaffoldingImports(boolean wasSecurityException, List<ExecutionResult> results) {
         List<String> list = new ArrayList<>();
@@ -155,7 +157,8 @@ public class Scaffolding {
             list.add(adapter.afterEach().getCanonicalName());
         }
 
-        if (Properties.RESET_STATIC_FIELDS || wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results)) {
+        if (Properties.RESET_STATIC_FIELDS || wasSecurityException
+                || TestSuiteWriterUtils.shouldResetProperties(results)) {
             list.add(getAdapter().afterAll().getCanonicalName());
         }
 
@@ -180,13 +183,16 @@ public class Scaffolding {
     }
 
     /**
-     * Get the code of methods for @BeforeClass, @Before, @AfterClass and
+     * Get the code of methods for @BeforeClass, @Before, @AfterClass and.
      *
-     * @return @After.
-     * <p>
-     * In those methods, the EvoSuite framework for running the
+     * <p>In those methods, the EvoSuite framework for running the
      * generated test cases is handled (e.g., use of customized
      * SecurityManager and runtime bytecode replacement)
+     *
+     * @param name test name
+     * @param wasSecurityException if a security exception occurred
+     * @param results execution results
+     * @return @After.
      */
     public String getBeforeAndAfterMethods(String name, boolean wasSecurityException, List<ExecutionResult> results) {
 
@@ -249,8 +255,9 @@ public class Scaffolding {
      * some seconds (successive calls would be based on cached data), and so tests might
      * timeout. So here we force the mock initialization in a @BeforeClass
      *
-     * @param bd
-     * @param results
+     * @param testClassName name of the test class
+     * @param bd string builder
+     * @param results execution results
      */
     private void generateMockInitialization(String testClassName, StringBuilder bd, List<ExecutionResult> results) {
         if (!TestSuiteWriterUtils.doesUseMocks(results)) {
@@ -258,7 +265,8 @@ public class Scaffolding {
         }
 
 
-        // In order to make sure this is called *after* initializeClasses this method is now called directly from initEvoSuiteFramework
+        // In order to make sure this is called *after* initializeClasses
+        // this method is now called directly from initEvoSuiteFramework
         // bd.append(METHOD_SPACE);
         // bd.append("@BeforeClass \n");
 
@@ -271,7 +279,8 @@ public class Scaffolding {
                 if (st instanceof FunctionalMockStatement) {
                     FunctionalMockStatement fms = (FunctionalMockStatement) st;
                     String name = GenericClassFactory.get(fms.getReturnType()).getRawClass().getTypeName();
-                    mockStatements.add("mock(Class.forName(\"" + name + "\", false, " + testClassName + ".class.getClassLoader()));");
+                    mockStatements.add("mock(Class.forName(\"" + name + "\", false, "
+                            + testClassName + ".class.getClassLoader()));");
                 }
             }
         }
@@ -290,11 +299,11 @@ public class Scaffolding {
 
     private void generateNFRRule(StringBuilder bd) {
         getAdapter().addNFR(bd);
-//		bd.append(METHOD_SPACE);
-//		bd.append("@org.junit.Rule \n");
-//		bd.append(METHOD_SPACE);
-//		bd.append("public " + NonFunctionalRequirementRule.class.getName() + " nfr = new "
-//				+ NonFunctionalRequirementRule.class.getName() + "();\n\n");
+        // bd.append(METHOD_SPACE);
+        // bd.append("@org.junit.Rule \n");
+        // bd.append(METHOD_SPACE);
+        // bd.append("public " + NonFunctionalRequirementRule.class.getName() + " nfr = new "
+        // + NonFunctionalRequirementRule.class.getName() + "();\n\n");
     }
 
     private void generateResetClasses(String testClassName, StringBuilder bd) {
@@ -332,8 +341,9 @@ public class Scaffolding {
 
     /**
      * Here we need to filter out all classes that cannot/should not be loaded,
-     * like for example tmp tests generated by EvoSuite
+     * like for example tmp tests generated by EvoSuite.
      *
+     * @param allInstrumentedClasses list of all instrumented classes
      * @return a new instantiated list
      */
     private List<String> getClassesToInit(List<String> allInstrumentedClasses) {
@@ -411,8 +421,9 @@ public class Scaffolding {
 
     private void generateAfter(StringBuilder bd, boolean wasSecurityException) {
 
-        if (Properties.NO_RUNTIME_DEPENDENCY)
+        if (Properties.NO_RUNTIME_DEPENDENCY) {
             return;
+        }
 
         /*
          * Likely always at least ThreadStopper
@@ -477,8 +488,9 @@ public class Scaffolding {
 
     private void generateBefore(StringBuilder bd, boolean wasSecurityException, List<ExecutionResult> results) {
 
-        if (Properties.NO_RUNTIME_DEPENDENCY)
+        if (Properties.NO_RUNTIME_DEPENDENCY) {
             return;
+        }
 
         /*
          * Most likely, should always have at least ThreadStopper
@@ -576,7 +588,8 @@ public class Scaffolding {
 
     private void generateAfterClass(StringBuilder bd, boolean wasSecurityException, List<ExecutionResult> results) {
 
-        if (Properties.RESET_STATIC_FIELDS || wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results)) {
+        if (Properties.RESET_STATIC_FIELDS || wasSecurityException
+                || TestSuiteWriterUtils.shouldResetProperties(results)) {
             bd.append(METHOD_SPACE);
             bd.append("@").append(getAdapter().afterAll().getSimpleName()).append("\n");
             bd.append(METHOD_SPACE);
@@ -626,11 +639,12 @@ public class Scaffolding {
             Set<String> readProperties = TestSuiteWriterUtils.mergeProperties(results);
             for (String prop : readProperties) {
                 String currentValue = java.lang.System.getProperty(prop);
-                String escaped_prop = StringEscapeUtils.escapeJava(prop);
+                String escapedProp = StringEscapeUtils.escapeJava(prop);
                 if (currentValue != null) {
-                    String escaped_currentValue = StringEscapeUtils.escapeJava(currentValue);
+                    String escapedCurrentValue = StringEscapeUtils.escapeJava(currentValue);
                     bd.append(BLOCK_SPACE);
-                    bd.append("java.lang.System.setProperty(\"").append(escaped_prop).append("\", \"").append(escaped_currentValue).append("\"); \n");
+                    bd.append("java.lang.System.setProperty(\"").append(escapedProp)
+                            .append("\", \"").append(escapedCurrentValue).append("\"); \n");
                 } else {
                     /*
                      * In theory, we do not need to clear properties, as that is
@@ -671,18 +685,21 @@ public class Scaffolding {
         // \n");
 
         bd.append(BLOCK_SPACE);
-        bd.append(RuntimeSettings.class.getName()).append(".className = \"").append(Properties.TARGET_CLASS).append("\"; \n");
+        bd.append(RuntimeSettings.class.getName()).append(".className = \"")
+                .append(Properties.TARGET_CLASS).append("\"; \n");
 
         bd.append(BLOCK_SPACE);
         bd.append(GuiSupport.class.getName()).append(".initialize(); \n");
 
         if (Properties.REPLACE_CALLS) {
             bd.append(BLOCK_SPACE);
-            bd.append(RuntimeSettings.class.getName()).append(".maxNumberOfThreads = ").append(Properties.MAX_STARTED_THREADS).append("; \n");
+            bd.append(RuntimeSettings.class.getName()).append(".maxNumberOfThreads = ")
+                    .append(Properties.MAX_STARTED_THREADS).append("; \n");
         }
 
         bd.append(BLOCK_SPACE);
-        bd.append(RuntimeSettings.class.getName()).append(".maxNumberOfIterationsPerLoop = ").append(Properties.MAX_LOOP_ITERATIONS).append("; \n");
+        bd.append(RuntimeSettings.class.getName()).append(".maxNumberOfIterationsPerLoop = ");
+        bd.append(Properties.MAX_LOOP_ITERATIONS).append("; \n");
 
         if (Properties.REPLACE_SYSTEM_IN) {
             bd.append(BLOCK_SPACE);
@@ -697,7 +714,9 @@ public class Scaffolding {
         if (Properties.RESET_STATIC_FIELDS || wasSecurityException) {
             // need to setup the Sandbox mode
             bd.append(BLOCK_SPACE);
-            bd.append(RuntimeSettings.class.getName()).append(".sandboxMode = ").append(Sandbox.SandboxMode.class.getCanonicalName()).append(".").append(Properties.SANDBOX_MODE).append("; \n");
+            bd.append(RuntimeSettings.class.getName()).append(".sandboxMode = ")
+                    .append(Sandbox.SandboxMode.class.getCanonicalName()).append(".")
+                    .append(Properties.SANDBOX_MODE).append("; \n");
 
             bd.append(BLOCK_SPACE);
             bd.append(Sandbox.class.getName()).append(".initializeSecurityManagerForSUT(); \n");

--- a/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriter.java
+++ b/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriter.java
@@ -21,10 +21,8 @@
 package org.evosuite.junit.writer;
 
 import org.evosuite.Properties;
-import org.evosuite.Properties.Criterion;
 import org.evosuite.Properties.OutputGranularity;
 import org.evosuite.TimeController;
-import org.evosuite.coverage.dataflow.DefUseCoverageTestFitness;
 import org.evosuite.junit.UnitTestAdapter;
 import org.evosuite.junit.naming.methods.CoverageGoalTestNameGenerationStrategy;
 import org.evosuite.junit.naming.methods.NumberedTestNameGenerationStrategy;
@@ -39,7 +37,6 @@ import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testcase.execution.CodeUnderTestException;
 import org.evosuite.testcase.execution.ExecutionResult;
 import org.evosuite.testcase.execution.TestCaseExecutor;
-import org.evosuite.utils.ArrayUtil;
 import org.evosuite.utils.FileIOUtils;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.runner.RunWith;
@@ -64,15 +61,16 @@ import static org.evosuite.junit.writer.TestSuiteWriterUtils.*;
  * <li> Java API
  * <li> Junit
  * <li> org.evosuite.runtime.*
+ * </ul>
  *
  * @author Gordon Fraser
  */
 public class TestSuiteWriter implements Opcodes {
 
     /**
-     * Constant <code>logger</code>
+     * Constant <code>logger</code>.
      */
-    private final static Logger logger = LoggerFactory.getLogger(TestSuiteWriter.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestSuiteWriter.class);
 
     public static final String NOT_GENERATED_TEST_NAME = "notGeneratedAnyTest";
 
@@ -86,7 +84,7 @@ public class TestSuiteWriter implements Opcodes {
 
     private final TestCodeVisitor visitor = new TestCodeVisitor();
 
-    private final static String NEWLINE = java.lang.System.getProperty("line.separator");
+    private static final String NEWLINE = java.lang.System.getProperty("line.separator");
 
     private TestNameGenerationStrategy nameGenerator = null;
 
@@ -127,9 +125,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * <p>
-     * insertTest
-     * </p>
+     * Insert test.
      *
      * @param test    a {@link org.evosuite.testcase.TestCase} object.
      * @param comment a {@link java.lang.String} object.
@@ -138,30 +134,30 @@ public class TestSuiteWriter implements Opcodes {
     public int insertTest(TestCase test, String comment) {
         int id = insertTest(test);
         if (testComment.containsKey(id)) {
-            if (!testComment.get(id).contains(comment))
+            if (!testComment.get(id).contains(comment)) {
                 testComment.put(id, testComment.get(id) + NEWLINE + METHOD_SPACE + "//"
                         + comment);
-        } else
+            }
+        } else {
             testComment.put(id, comment);
+        }
         return id;
     }
 
     /**
-     * <p>
-     * insertTests
-     * </p>
+     * Insert tests.
+     * Insert all tests.
      *
      * @param tests a {@link java.util.List} object.
      */
     public void insertTests(List<TestCase> tests) {
-        for (TestCase test : tests)
+        for (TestCase test : tests) {
             insertTest(test);
+        }
     }
 
     /**
-     * <p>
-     * insertTests
-     * </p>
+     * Insert all tests.
      *
      * @param tests a {@link java.util.List} object.
      */
@@ -170,7 +166,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * Get all test cases
+     * Get all test cases.
      *
      * @return a {@link java.util.List} object.
      */
@@ -179,12 +175,13 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * Create JUnit test suite for class
+     * Create JUnit test suite for class.
      *
      * @param name      Name of the class
      * @param directory Output directory
      */
-    public List<File> writeTestSuite(String name, String directory, List<ExecutionResult> cachedResults) throws IllegalArgumentException {
+    public List<File> writeTestSuite(String name, String directory, List<ExecutionResult> cachedResults)
+            throws IllegalArgumentException {
 
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Empty test class name");
@@ -193,7 +190,8 @@ public class TestSuiteWriter implements Opcodes {
             /*
              * This is VERY important, as otherwise tests can get ignored by "mvn test"
              */
-            throw new IllegalArgumentException("Test classes should have name ending with 'Test'. Invalid input name: " + name);
+            throw new IllegalArgumentException(
+                    "Test classes should have name ending with 'Test'. Invalid input name: " + name);
         }
 
         List<File> generated = new ArrayList<>();
@@ -202,7 +200,8 @@ public class TestSuiteWriter implements Opcodes {
 
         // Execute all tests
         executor.newObservers();
-        LoopCounter.getInstance().setActive(true); //be sure it is active here, as JUnit checks might have left it to false
+        //be sure it is active here, as JUnit checks might have left it to false
+        LoopCounter.getInstance().setActive(true);
 
         List<ExecutionResult> results = new ArrayList<>();
         for (TestCase test : testCases) {
@@ -274,9 +273,9 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * To avoid having completely empty test classes, a no-op test is created
+     * To avoid having completely empty test classes, a no-op test is created.
      *
-     * @return
+     * @return code for empty test
      */
     private String getEmptyTest() {
         StringBuilder bd = new StringBuilder();
@@ -301,20 +300,23 @@ public class TestSuiteWriter implements Opcodes {
 
     private void removeAssertionsAfterException(List<ExecutionResult> results) {
         for (ExecutionResult result : results) {
-            if (result.noThrownExceptions())
+            if (result.noThrownExceptions()) {
                 continue;
+            }
             int exceptionPosition = result.getFirstPositionOfThrownException();
             // TODO: Not clear how that can happen...
-            if (result.test.size() > exceptionPosition)
+            if (result.test.size() > exceptionPosition) {
                 result.test.getStatement(exceptionPosition).removeAssertions();
+            }
         }
     }
 
 
     /**
-     * Create JUnit file for given class name
+     * Create JUnit file for given class name.
      *
      * @param name Name of the class file
+     * @param results Execution results
      * @return String representation of JUnit test file
      */
     private String getUnitTestsAllInSameFile(String name, List<ExecutionResult> results) {
@@ -346,7 +348,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * Create JUnit file for given class name
+     * Create JUnit file for given class name.
      *
      * @param name   Name of the class file
      * @param testId a int.
@@ -361,7 +363,8 @@ public class TestSuiteWriter implements Opcodes {
         builder.append(getHeader(name + "_" + testId, name, results));
 
         if (!Properties.TEST_SCAFFOLDING) {
-            builder.append(new Scaffolding().getBeforeAndAfterMethods(name + "_" + testId, wasSecurityException, results));
+            builder.append(new Scaffolding().getBeforeAndAfterMethods(name + "_" + testId, wasSecurityException,
+                    results));
         }
 
         builder.append(testToString(testId, testId, results.get(testId)));
@@ -371,9 +374,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * <p>
-     * runTest
-     * </p>
+     * Run test.
      *
      * @param test a {@link org.evosuite.testcase.TestCase} object.
      * @return a {@link org.evosuite.testcase.execution.ExecutionResult} object.
@@ -399,7 +400,7 @@ public class TestSuiteWriter implements Opcodes {
 
 
     /**
-     * Determine packages that need to be imported in the JUnit file
+     * Determine packages that need to be imported in the JUnit file.
      *
      * @param results a {@link java.util.List} object.
      * @return a {@link java.lang.String} object.
@@ -417,8 +418,9 @@ public class TestSuiteWriter implements Opcodes {
             result.test.accept(visitor);
             imports.addAll(visitor.getImports());
             accessedClasses.addAll(result.test.getAccessedClasses());
-            if (!hasException)
+            if (!hasException) {
                 hasException = !result.noThrownExceptions();
+            }
         }
         visitor.clearExceptions();
 
@@ -450,28 +452,34 @@ public class TestSuiteWriter implements Opcodes {
 
         Set<String> importNames = new HashSet<>();
         for (Class<?> imp : imports) {
-            while (imp.isArray())
+            while (imp.isArray()) {
                 imp = imp.getComponentType();
-            if (imp.isPrimitive())
+            }
+            if (imp.isPrimitive()) {
                 continue;
+            }
             if (imp.getName().startsWith("java.lang")) {
                 String name = imp.getName().replace("java.lang.", "");
-                if (!name.contains("."))
+                if (!name.contains(".")) {
                     continue;
+                }
             }
-            if (!imp.getName().contains("."))
+            if (!imp.getName().contains(".")) {
                 continue;
+            }
             // TODO: Check for anonymous type?
-            if (imp.getName().contains("$"))
+            if (imp.getName().contains("$")) {
                 importNames.add(imp.getName().replace("$", "."));
-            else
+            } else {
                 importNames.add(imp.getName());
+            }
         }
 
         for (Class<?> klass : EnvironmentDataList.getListOfClasses()) {
             //TODO: not paramount, but best if could check if actually used in the test suite
-            if (accessedClasses.contains(klass))
+            if (accessedClasses.contains(klass)) {
                 importNames.add(klass.getCanonicalName());
+            }
         }
 
         if (wasSecurityException) {
@@ -507,14 +515,14 @@ public class TestSuiteWriter implements Opcodes {
 
 
     /**
-     * JUnit file header
+     * JUnit file header.
      *
-     * @param test_name        a {@link java.lang.String} object.
-     * @param scaffolding_name a {@link java.lang.String} object.
+     * @param testName        a {@link java.lang.String} object.
+     * @param scaffoldingName a {@link java.lang.String} object.
      * @param results          a {@link java.util.List} object.
      * @return a {@link java.lang.String} object.
      */
-    protected String getHeader(String test_name, String scaffolding_name, List<ExecutionResult> results) {
+    protected String getHeader(String testName, String scaffoldingName, List<ExecutionResult> results) {
         StringBuilder builder = new StringBuilder();
         builder.append("/*");
         builder.append(NEWLINE);
@@ -541,17 +549,18 @@ public class TestSuiteWriter implements Opcodes {
             builder.append(getRunner());
         }
 
-        builder.append(adapter.getClassDefinition(test_name));
+        builder.append(adapter.getClassDefinition(testName));
 
         if (Properties.TEST_SCAFFOLDING && !Properties.NO_RUNTIME_DEPENDENCY) {
-            builder.append(" extends ").append(Scaffolding.getFileName(scaffolding_name));
+            builder.append(" extends ").append(Scaffolding.getFileName(scaffoldingName));
         }
 
         builder.append(" {");
         builder.append(NEWLINE);
         if (Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT5) {
             builder.append("@RegisterExtension").append(NEWLINE);
-            builder.append(METHOD_SPACE).append("static EvoRunnerJUnit5 runner = new EvoRunnerJUnit5(").append(test_name).append(".class);").append(NEWLINE);
+            builder.append(METHOD_SPACE).append("static EvoRunnerJUnit5 runner = new EvoRunnerJUnit5(")
+                    .append(testName).append(".class);").append(NEWLINE);
         }
         return builder.toString();
     }
@@ -601,7 +610,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * JUnit file footer
+     * JUnit file footer.
      *
      * @return a {@link java.lang.String} object.
      */
@@ -611,8 +620,9 @@ public class TestSuiteWriter implements Opcodes {
 
 
     /**
-     * Convert one test case to a Java method
+     * Convert one test case to a Java method.
      *
+     * @param number Number of the test case
      * @param id     Index of the test case
      * @param result a {@link org.evosuite.testcase.execution.ExecutionResult} object.
      * @return String representation of test case
@@ -653,7 +663,7 @@ public class TestSuiteWriter implements Opcodes {
         builder.append(NEWLINE);
 
         // ---------   start with the body -------------------------
-        String CODE_SPACE = INNER_BLOCK_SPACE;
+        String codeSpace = INNER_BLOCK_SPACE;
 
         // No code after an exception should be printed as it would break compilability
         TestCase test = testCases.get(id);
@@ -682,12 +692,12 @@ public class TestSuiteWriter implements Opcodes {
                 builder.append("try {");
                 builder.append(NEWLINE);
             }
-            CODE_SPACE = INNER_INNER_INNER_BLOCK_SPACE;
+            codeSpace = INNER_INNER_INNER_BLOCK_SPACE;
         }
 
         for (String line : adapter.getTestString(id, test,
                 result.getCopyOfExceptionMapping(), visitor).split("\\r?\\n")) {
-            builder.append(CODE_SPACE);
+            builder.append(codeSpace);
             builder.append(line);
             builder.append(NEWLINE);
         }
@@ -713,7 +723,8 @@ public class TestSuiteWriter implements Opcodes {
             builder.append("});"); //closing submit
             builder.append(NEWLINE);
 
-            long time = Properties.TIMEOUT + 1000; // we add one second just to be sure, that to avoid issues with test cases taking exactly TIMEOUT ms
+            // we add one second just to be sure, that to avoid issues with test cases taking exactly TIMEOUT ms
+            long time = Properties.TIMEOUT + 1000;
             builder.append(BLOCK_SPACE);
             builder.append("future.get(" + time + ", TimeUnit.MILLISECONDS);");
             builder.append(NEWLINE);
@@ -732,7 +743,7 @@ public class TestSuiteWriter implements Opcodes {
     }
 
     /**
-     * When writing out the JUnit test file, each test can have a text comment
+     * When writing out the JUnit test file, each test can have a text comment.
      *
      * @param num Index of test case
      * @return Comment for test case
@@ -741,8 +752,9 @@ public class TestSuiteWriter implements Opcodes {
 
         if (testComment.containsKey(num)) {
             String comment = testComment.get(num);
-            if (!comment.endsWith("\n"))
+            if (!comment.endsWith("\n")) {
                 comment = comment + NEWLINE;
+            }
             return comment;
         }
 
@@ -758,8 +770,9 @@ public class TestSuiteWriter implements Opcodes {
             builder.append(NEWLINE);
             builder.append("   * ");
             builder.append(coveredGoals.size() + " covered goal");
-            if (coveredGoals.size() != 1)
+            if (coveredGoals.size() != 1) {
                 builder.append("s");
+            }
             builder.append(":");
             int nr = 1;
             for (TestFitnessFunction goal : coveredGoals) {
@@ -783,7 +796,8 @@ public class TestSuiteWriter implements Opcodes {
             for (int i = 0; i < testCases.size(); i++) {
                 TestCase test = testCases.get(i);
                 String generatedName = nameGenerator.getName(test);
-                String testName = (generatedName != null) ? generatedName : TestSuiteWriterUtils.getNameOfTest(testCases, i);
+                String testName = (generatedName != null) ? generatedName
+                        : TestSuiteWriterUtils.getNameOfTest(testCases, i);
                 Set<TestFitnessFunction> coveredGoals = test.getCoveredGoals();
                 for (TestFitnessFunction goal : coveredGoals) {
                     builder.append(testName + "," + goal.toString() + NEWLINE);

--- a/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriterUtils.java
+++ b/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriterUtils.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Set of utility functions for generation of JUnit files
+ * Set of utility functions for generation of JUnit files.
  *
  * @author arcuri
  */
@@ -52,14 +52,14 @@ public class TestSuiteWriterUtils {
     public static final String INNER_INNER_BLOCK_SPACE = "        ";
     public static final String INNER_INNER_INNER_BLOCK_SPACE = "          ";
 
-    protected final static Logger logger = LoggerFactory.getLogger(TestSuiteWriterUtils.class);
+    protected static final Logger logger = LoggerFactory.getLogger(TestSuiteWriterUtils.class);
 
 
     /**
      * Check the configuration settings to see if we are doing any instrumentation.
-     * If so, we ll need to use the Java Agent in the generated tests
+     * If so, we ll need to use the Java Agent in the generated tests.
      *
-     * @return
+     * @return true if instrumentation is needed
      */
     public static boolean needToUseAgent() {
         return Properties.REPLACE_CALLS || Properties.VIRTUAL_FS
@@ -146,7 +146,7 @@ public class TestSuiteWriterUtils {
     }
 
     /**
-     * Create subdirectory for package in test directory
+     * Create subdirectory for package in test directory.
      *
      * @param directory a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.
@@ -161,18 +161,19 @@ public class TestSuiteWriterUtils {
     }
 
     public static UnitTestAdapter getAdapter() {
-        if (Properties.TEST_FORMAT == OutputFormat.JUNIT3)
+        if (Properties.TEST_FORMAT == OutputFormat.JUNIT3) {
             return new JUnit3TestAdapter();
-        else if (Properties.TEST_FORMAT == OutputFormat.JUNIT4)
+        } else if (Properties.TEST_FORMAT == OutputFormat.JUNIT4) {
             return new JUnit4TestAdapter();
-        else if (Properties.TEST_FORMAT == OutputFormat.JUNIT5)
+        } else if (Properties.TEST_FORMAT == OutputFormat.JUNIT5) {
             return new JUnit5TestAdapter();
-        else
+        } else {
             throw new RuntimeException("Unknown output format: " + Properties.TEST_FORMAT);
+        }
     }
 
     /**
-     * Create subdirectory for package in test directory
+     * Create subdirectory for package in test directory.
      *
      * @param directory a {@link java.lang.String} object.
      * @return a {@link java.lang.String} object.


### PR DESCRIPTION
This PR addresses Checkstyle violations in the `org.evosuite.junit` package within the `client` module.

The primary focus was to resolve formatting and style issues such as:
- Line length violations (> 120 characters)
- Missing braces for control structures (`if`, `for`, `else`)
- Javadoc formatting (missing periods, empty at-clauses)
- Operator wrapping
- Whitespace and indentation corrections

Specific changes were made to `JUnitAnalyzer.java` and `CoverageGoalTestNameGenerationStrategy.java` to bring them into compliance with the project's Checkstyle configuration.

Note: Initial attempts to refactor `CoverageGoalTestNameGenerationStrategy.java` caused regression failures in test name generation. Those functional changes were reverted, and only style/formatting fixes were reapplied to ensure no regressions. The `JUnitAnalyzerTest.testSandboxIssue` failure was present before these changes and is unrelated to this PR.

---
*PR created automatically by Jules for task [8090113650452958728](https://jules.google.com/task/8090113650452958728) started by @gofraser*