### PR TITLE
Apply Checkstyle to org.evosuite.statistics in master

### DIFF
--- a/master/src/main/java/org/evosuite/statistics/SearchStatistics.java
+++ b/master/src/main/java/org/evosuite/statistics/SearchStatistics.java
@@ -64,39 +64,39 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     private static final long serialVersionUID = -1859683466333302151L;
 
     /**
-     * Singleton instance
+     * Singleton instance.
      */
     private static final Map<String, SearchStatistics> instances = new LinkedHashMap<>();
 
     private static final Logger logger = LoggerFactory.getLogger(SearchStatistics.class);
 
     /**
-     * Map of client id to best individual received from that client so far
+     * Map of client id to best individual received from that client so far.
      */
     private TestSuiteChromosome bestIndividual = null;
 
     /**
-     * Backend used to output the data
+     * Backend used to output the data.
      */
     private StatisticsBackend backend = null;
 
     /**
-     * Output variables and their values
+     * Output variables and their values.
      */
     private final Map<String, OutputVariable<?>> outputVariables = new TreeMap<>();
 
     /**
-     * Variable factories to extract output variables from chromosomes
+     * Variable factories to extract output variables from chromosomes.
      */
     private final Map<String, ChromosomeOutputVariableFactory<?>> variableFactories = new TreeMap<>();
 
     /**
-     * Variable factories to extract sequence variables
+     * Variable factories to extract sequence variables.
      */
     private final Map<String, SequenceOutputVariableFactory<?>> sequenceOutputVariableFactories = new TreeMap<>();
 
     /**
-     * Keep track of how far EvoSuite progressed
+     * Keep track of how far EvoSuite progressed.
      */
     private ClientState currentState = ClientState.INITIALIZATION;
 
@@ -114,37 +114,67 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
         initFactories();
 
         setOutputVariable(RuntimeVariable.Random_Seed, Randomness.getSeed());
-        sequenceOutputVariableFactories.put(RuntimeVariable.CoverageTimeline.name(), new CoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.FitnessTimeline.name(), new FitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.SizeTimeline.name(), new SizeSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.LengthTimeline.name(), new LengthSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.TotalExceptionsTimeline.name(), DirectSequenceOutputVariableFactory.getInteger(RuntimeVariable.TotalExceptionsTimeline));
-        sequenceOutputVariableFactories.put(RuntimeVariable.IBranchGoalsTimeline.name(), new IBranchGoalsSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.CoverageTimeline.name(),
+                new CoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.FitnessTimeline.name(),
+                new FitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.SizeTimeline.name(),
+                new SizeSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.LengthTimeline.name(),
+                new LengthSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.TotalExceptionsTimeline.name(),
+                DirectSequenceOutputVariableFactory.getInteger(RuntimeVariable.TotalExceptionsTimeline));
+        sequenceOutputVariableFactories.put(RuntimeVariable.IBranchGoalsTimeline.name(),
+                new IBranchGoalsSequenceOutputVariableFactory());
 
-        sequenceOutputVariableFactories.put(RuntimeVariable.BranchCoverageTimeline.name(), new BranchCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyBranchFitnessTimeline.name(), new OnlyBranchFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyBranchCoverageTimeline.name(), new OnlyBranchCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.CBranchFitnessTimeline.name(), new CBranchFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.CBranchCoverageTimeline.name(), new CBranchCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodTraceFitnessTimeline.name(), new MethodTraceFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodTraceCoverageTimeline.name(), new MethodTraceCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodFitnessTimeline.name(), new MethodFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodCoverageTimeline.name(), new MethodCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodNoExceptionFitnessTimeline.name(), new MethodNoExceptionFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.MethodNoExceptionCoverageTimeline.name(), new MethodNoExceptionCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.RhoScoreTimeline.name(), new RhoFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.AmbiguityScoreTimeline.name(), new AmbiguityFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.LineFitnessTimeline.name(), new LineFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.LineCoverageTimeline.name(), new LineCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OutputFitnessTimeline.name(), new OutputFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OutputCoverageTimeline.name(), new OutputCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.InputFitnessTimeline.name(), new InputFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.InputCoverageTimeline.name(), new InputCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.ExceptionFitnessTimeline.name(), new ExceptionFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.ExceptionCoverageTimeline.name(), new ExceptionCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.WeakMutationCoverageTimeline.name(), new WeakMutationCoverageSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyMutationFitnessTimeline.name(), new OnlyMutationFitnessSequenceOutputVariableFactory());
-        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyMutationCoverageTimeline.name(), new OnlyMutationCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.BranchCoverageTimeline.name(),
+                new BranchCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyBranchFitnessTimeline.name(),
+                new OnlyBranchFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyBranchCoverageTimeline.name(),
+                new OnlyBranchCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.CBranchFitnessTimeline.name(),
+                new CBranchFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.CBranchCoverageTimeline.name(),
+                new CBranchCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodTraceFitnessTimeline.name(),
+                new MethodTraceFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodTraceCoverageTimeline.name(),
+                new MethodTraceCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodFitnessTimeline.name(),
+                new MethodFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodCoverageTimeline.name(),
+                new MethodCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodNoExceptionFitnessTimeline.name(),
+                new MethodNoExceptionFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.MethodNoExceptionCoverageTimeline.name(),
+                new MethodNoExceptionCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.RhoScoreTimeline.name(),
+                new RhoFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.AmbiguityScoreTimeline.name(),
+                new AmbiguityFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.LineFitnessTimeline.name(),
+                new LineFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.LineCoverageTimeline.name(),
+                new LineCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OutputFitnessTimeline.name(),
+                new OutputFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OutputCoverageTimeline.name(),
+                new OutputCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.InputFitnessTimeline.name(),
+                new InputFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.InputCoverageTimeline.name(),
+                new InputCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.ExceptionFitnessTimeline.name(),
+                new ExceptionFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.ExceptionCoverageTimeline.name(),
+                new ExceptionCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.WeakMutationCoverageTimeline.name(),
+                new WeakMutationCoverageSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyMutationFitnessTimeline.name(),
+                new OnlyMutationFitnessSequenceOutputVariableFactory());
+        sequenceOutputVariableFactories.put(RuntimeVariable.OnlyMutationCoverageTimeline.name(),
+                new OnlyMutationCoverageSequenceOutputVariableFactory());
         sequenceOutputVariableFactories.put(RuntimeVariable.DiversityTimeline.name(),
                 DirectSequenceOutputVariableFactory.getDouble(RuntimeVariable.DiversityTimeline));
 
@@ -155,8 +185,9 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
                 DirectSequenceOutputVariableFactory.getInteger(RuntimeVariable.FeaturesFound));
 
         // sequenceOutputVariableFactories.put("Generation_History", new GenerationSequenceOutputVariableFactory());
-        if (MasterServices.getInstance().getMasterNode() != null)
+        if (MasterServices.getInstance().getMasterNode() != null) {
             MasterServices.getInstance().getMasterNode().addListener(this);
+        }
     }
 
     public static SearchStatistics getInstance() {
@@ -187,8 +218,9 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
      * @param individual best individual of current generation
      */
     public void currentIndividual(Chromosome<?> individual) {
-        if (backend == null)
+        if (backend == null) {
             return;
+        }
 
         if (!(individual instanceof TestSuiteChromosome)) {
             AtMostOnceLogger.warn(logger, "searchStatistics expected a TestSuiteChromosome");
@@ -206,26 +238,28 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Set an output variable to a value directly
+     * Set an output variable to a value directly.
      *
-     * @param variable
-     * @param value
+     * @param variable the variable to set
+     * @param value the value to set
      */
     public void setOutputVariable(RuntimeVariable variable, Object value) {
         setOutputVariable(new OutputVariable<>(variable.toString(), value));
     }
 
     public void setOutputVariable(OutputVariable<?> variable) {
-        /**
+        /*
          * if the output variable is contained in sequenceOutputVariableFactories,
          * then it must be a DirectSequenceOutputVariableFactory, hence we set its
          * value so that it can be used to produce the next timeline variable.
          */
         if (sequenceOutputVariableFactories.containsKey(variable.getName())) {
-            DirectSequenceOutputVariableFactory<?> v = (DirectSequenceOutputVariableFactory<?>) sequenceOutputVariableFactories.get(variable.getName());
+            DirectSequenceOutputVariableFactory<?> v = (DirectSequenceOutputVariableFactory<?>)
+                    sequenceOutputVariableFactories.get(variable.getName());
             v.setValue(variable.getValue());
-        } else
+        } else {
             outputVariables.put(variable.getName(), variable);
+        }
     }
 
     public void addTestGenerationResult(List<TestGenerationResult> result) {
@@ -241,9 +275,9 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Retrieve list of possible variables
+     * Retrieve list of possible variables.
      *
-     * @return
+     * @return list of variable names
      */
     private List<String> getAllOutputVariableNames() {
 
@@ -258,24 +292,24 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
 
         List<String> variableNames = new ArrayList<>(Arrays.asList(essentials));
 
-        /** Fix for DSE as we want to save the output vars in this case */
+        /* Fix for DSE as we want to save the output vars in this case */
         if (Properties.isDSEStrategySelected()) {
             variableNames.addAll(DSEStatistics.dseRuntimeVariables);
         }
 
-		/* cannot use what we received, as due to possible bugs/errors those might not be constant
-		variableNames.addAll(outputVariables.keySet());
-		variableNames.addAll(variableFactories.keySet());
-		variableNames.addAll(sequenceOutputVariableFactories.keySet());
-		*/
+        /* cannot use what we received, as due to possible bugs/errors those might not be constant
+        variableNames.addAll(outputVariables.keySet());
+        variableNames.addAll(variableFactories.keySet());
+        variableNames.addAll(sequenceOutputVariableFactories.keySet());
+        */
         return variableNames;
     }
 
     /**
      * Retrieve list of output variables that the user will get to see.
-     * If output_variables is not set, then all variables will be returned
+     * If output_variables is not set, then all variables will be returned.
      *
-     * @return
+     * @return collection of variable names
      */
     private Collection<String> getOutputVariableNames() {
         List<String> variableNames = new ArrayList<>();
@@ -290,7 +324,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Shorthand for getOutputVariables(individual, false)
+     * Shorthand for getOutputVariables(individual, false).
      */
     private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual) {
         return getOutputVariables(individual, false);
@@ -300,11 +334,11 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
      * Extract output variables from input <code>individual</code>.
      * Add also all the other needed search-level variables.
      *
-     * @param individual
-     * @param skip_missing whether or not to skip missing output variables
+     * @param individual the individual
+     * @param skipMissing whether or not to skip missing output variables
      * @return <code>null</code> if some data is missing
      */
-    private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual, boolean skip_missing) {
+    private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual, boolean skipMissing) {
         Map<String, OutputVariable<?>> variables = new LinkedHashMap<>();
 
         for (String variableName : getOutputVariableNames()) {
@@ -325,7 +359,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
                 for (OutputVariable<?> var : sequenceOutputVariableFactories.get(variableName).getOutputVariables()) {
                     variables.put(var.getName(), var);
                 }
-            } else if (skip_missing) {
+            } else if (skipMissing) {
                 // if variable doesn't exist, return an empty value instead
                 variables.put(variableName, new OutputVariable<>(variableName, ""));
             } else {
@@ -338,16 +372,18 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Write result to disk using selected backend
+     * Write result to disk using selected backend.
      *
      * @return true if the writing was successful
      */
     public boolean writeStatistics() {
         logger.info("Writing statistics");
-        if (backend == null)
+        if (backend == null) {
             return false;
+        }
 
-        outputVariables.put(RuntimeVariable.Total_Time.name(), new OutputVariable<Object>(RuntimeVariable.Total_Time.name(), System.currentTimeMillis() - startTime));
+        outputVariables.put(RuntimeVariable.Total_Time.name(),
+                new OutputVariable<Object>(RuntimeVariable.Total_Time.name(), System.currentTimeMillis() - startTime));
 
         if (bestIndividual == null) {
             logger.error("No statistics has been saved because EvoSuite failed to generate any test case");
@@ -362,6 +398,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
+                // ignored
             }
 
             boolean couldBeFine = MasterServices.getInstance().getMasterNode().getCurrentState().stream()
@@ -377,6 +414,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException e) {
+                        // ignored
                     }
 
                     //retry
@@ -406,7 +444,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Write result to disk using selected backend
+     * Write result to disk using selected backend.
      *
      * @return true if the writing was successful
      */
@@ -417,7 +455,8 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
             return false;
         }
 
-        outputVariables.put(RuntimeVariable.Total_Time.name(), new OutputVariable<Object>(RuntimeVariable.Total_Time.name(), System.currentTimeMillis() - startTime));
+        outputVariables.put(RuntimeVariable.Total_Time.name(),
+                new OutputVariable<Object>(RuntimeVariable.Total_Time.name(), System.currentTimeMillis() - startTime));
 
         TestSuiteChromosome individual = new TestSuiteChromosome();
         Map<String, OutputVariable<?>> map = getOutputVariables(individual);
@@ -437,7 +476,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Process status update event received from client
+     * Process status update event received from client.
      */
     @Override
     public void receiveEvent(ClientStateInformation information) {
@@ -449,7 +488,8 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
                     factory.setStartTime(searchStartTime);
                 }
             }
-            OutputVariable<Long> time = new OutputVariable<>("Time_" + currentState.getName(), System.currentTimeMillis() - currentStateStarted);
+            OutputVariable<Long> time = new OutputVariable<>("Time_" + currentState.getName(),
+                    System.currentTimeMillis() - currentStateStarted);
             outputVariables.put(time.getName(), time);
             currentState = information.getState();
             currentStateStarted = System.currentTimeMillis();
@@ -458,7 +498,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Create default factories
+     * Create default factories.
      */
     private void initFactories() {
         variableFactories.put(RuntimeVariable.Length.name(), new ChromosomeLengthOutputVariableFactory());
@@ -468,7 +508,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Total length of a test suite
+     * Total length of a test suite.
      */
     private static class ChromosomeLengthOutputVariableFactory extends ChromosomeOutputVariableFactory<Integer> {
         public ChromosomeLengthOutputVariableFactory() {
@@ -482,7 +522,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Number of tests in a test suite
+     * Number of tests in a test suite.
      */
     private static class ChromosomeSizeOutputVariableFactory extends ChromosomeOutputVariableFactory<Integer> {
         public ChromosomeSizeOutputVariableFactory() {
@@ -496,7 +536,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Fitness value of a test suite
+     * Fitness value of a test suite.
      */
     private static class ChromosomeFitnessOutputVariableFactory extends ChromosomeOutputVariableFactory<Double> {
         public ChromosomeFitnessOutputVariableFactory() {
@@ -510,7 +550,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Coverage value of a test suite
+     * Coverage value of a test suite.
      */
     private static class ChromosomeCoverageOutputVariableFactory extends ChromosomeOutputVariableFactory<Double> {
         public ChromosomeCoverageOutputVariableFactory() {
@@ -524,7 +564,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Sequence variable for fitness values
+     * Sequence variable for fitness values.
      */
     private static class FitnessSequenceOutputVariableFactory extends DoubleSequenceOutputVariableFactory {
 
@@ -539,7 +579,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Sequence variable for coverage values
+     * Sequence variable for coverage values.
      */
     private static class CoverageSequenceOutputVariableFactory extends DoubleSequenceOutputVariableFactory {
 
@@ -554,7 +594,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Sequence variable for number of tests
+     * Sequence variable for number of tests.
      */
     private static class SizeSequenceOutputVariableFactory extends IntegerSequenceOutputVariableFactory {
 
@@ -569,7 +609,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Sequence variable for total length of tests
+     * Sequence variable for total length of tests.
      */
     private static class LengthSequenceOutputVariableFactory extends IntegerSequenceOutputVariableFactory {
 
@@ -584,7 +624,7 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
     }
 
     /**
-     * Sequence variable for coverage values
+     * Sequence variable for coverage values.
      */
     private static class IBranchGoalsSequenceOutputVariableFactory extends IntegerSequenceOutputVariableFactory {
 
@@ -706,7 +746,8 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
         }
     }
 
-    private static class MethodNoExceptionFitnessSequenceOutputVariableFactory extends DoubleSequenceOutputVariableFactory {
+    private static class MethodNoExceptionFitnessSequenceOutputVariableFactory
+            extends DoubleSequenceOutputVariableFactory {
 
         public MethodNoExceptionFitnessSequenceOutputVariableFactory() {
             super(RuntimeVariable.MethodNoExceptionFitnessTimeline);
@@ -718,7 +759,8 @@ public class SearchStatistics implements Listener<ClientStateInformation> {
         }
     }
 
-    private static class MethodNoExceptionCoverageSequenceOutputVariableFactory extends DoubleSequenceOutputVariableFactory {
+    private static class MethodNoExceptionCoverageSequenceOutputVariableFactory
+            extends DoubleSequenceOutputVariableFactory {
 
         public MethodNoExceptionCoverageSequenceOutputVariableFactory() {
             super(RuntimeVariable.MethodNoExceptionCoverageTimeline);

--- a/master/src/main/java/org/evosuite/statistics/backend/CSVStatisticsBackend.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/CSVStatisticsBackend.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * This statistics backend writes all (selected) output variables to a CSV file
+ * This statistics backend writes all (selected) output variables to a CSV file.
  *
  * @author gordon
  */
@@ -43,10 +43,10 @@ public class CSVStatisticsBackend implements StatisticsBackend {
     private static final Logger logger = LoggerFactory.getLogger(CSVStatisticsBackend.class);
 
     /**
-     * Retrieve header with variable names
+     * Retrieve header with variable names.
      *
-     * @param data
-     * @return
+     * @param data map of output variables
+     * @return CSV header string
      */
     private String getCSVHeader(Map<String, OutputVariable<?>> data) {
         StringBuilder r = new StringBuilder();
@@ -54,18 +54,19 @@ public class CSVStatisticsBackend implements StatisticsBackend {
         while (it.hasNext()) {
             Entry<String, OutputVariable<?>> e = it.next();
             r.append(e.getKey());
-            if (it.hasNext())
+            if (it.hasNext()) {
                 r.append(",");
+            }
         }
         return r.toString();
     }
 
 
     /**
-     * Retrieve one line of data
+     * Retrieve one line of data.
      *
-     * @param data
-     * @return
+     * @param data map of output variables
+     * @return CSV data string
      */
     private String getCSVData(Map<String, OutputVariable<?>> data) {
         StringBuilder r = new StringBuilder();
@@ -73,17 +74,18 @@ public class CSVStatisticsBackend implements StatisticsBackend {
         while (it.hasNext()) {
             Entry<String, OutputVariable<?>> e = it.next();
             r.append(e.getValue().getValue());
-            if (it.hasNext())
+            if (it.hasNext()) {
                 r.append(",");
+            }
         }
         return r.toString();
     }
 
     /**
      * Return the folder of where reports should be generated.
-     * If the folder does not exist, try to create it
+     * If the folder does not exist, try to create it.
      *
-     * @return
+     * @return report directory
      * @throws RuntimeException if folder does not exist, and we cannot create it
      */
     public static File getReportDir() throws RuntimeException {

--- a/master/src/main/java/org/evosuite/statistics/backend/ConsoleStatisticsBackend.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/ConsoleStatisticsBackend.java
@@ -25,7 +25,7 @@ import org.evosuite.statistics.OutputVariable;
 import java.util.Map;
 
 /**
- * Simple dummy backend that just outputs all output variables to the console
+ * Simple dummy backend that just outputs all output variables to the console.
  *
  * @author gordon
  */

--- a/master/src/main/java/org/evosuite/statistics/backend/DebugStatisticsBackend.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/DebugStatisticsBackend.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Backend to be used only for helping writing test cases
+ * Backend to be used only for helping writing test cases.
  *
  * @author arcuri
  */

--- a/master/src/main/java/org/evosuite/statistics/backend/HTMLStatisticsBackend.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/HTMLStatisticsBackend.java
@@ -82,17 +82,18 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
 
             writeHTMLHeader(report, Properties.PROJECT_PREFIX);
             report.append("<div id=\"header\">\n<div id=\"logo\">");
-			/*
-			if (!Properties.PROJECT_PREFIX.isEmpty()) {
-				report.append("<h1 class=title>EvoSuite: " + Properties.PROJECT_PREFIX
-				        + "</h1>\n");
-			}
-			*/
+            /*
+            if (!Properties.PROJECT_PREFIX.isEmpty()) {
+                report.append("<h1 class=title>EvoSuite: " + Properties.PROJECT_PREFIX
+                        + "</h1>\n");
+            }
+            */
             report.append("\n</div><br></div>");
             try {
                 report.append("Run on "
                         + java.net.InetAddress.getLocalHost().getHostName() + "\n");
             } catch (Exception e) {
+                // ignored
             }
 
             report.append("<div id=\"page\">\n");
@@ -147,9 +148,9 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
 
     /**
      * Return the folder of where reports should be generated.
-     * If the folder does not exist, try to create it
+     * If the folder does not exist, try to create it.
      *
-     * @return
+     * @return the report directory
      * @throws RuntimeException if folder does not exist, and we cannot create it
      */
     public static File getReportDir() throws RuntimeException {
@@ -168,7 +169,7 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
     }
 
     /**
-     * HTML header
+     * HTML header.
      *
      * @param buffer a {@link java.lang.StringBuffer} object.
      * @param title  a {@link java.lang.String} object.
@@ -204,7 +205,7 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
     }
 
     /**
-     * HTML footer
+     * HTML footer.
      *
      * @param buffer a {@link java.lang.StringBuffer} object.
      */
@@ -215,7 +216,7 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
     }
 
     /**
-     * The big table of results
+     * The big table of results.
      *
      * @param buffer a {@link java.lang.StringBuffer} object.
      */
@@ -231,8 +232,9 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
         if (data.containsKey(RuntimeVariable.Total_Time.name())) {
             long duration = (Long) data.get(RuntimeVariable.Total_Time.name()).getValue() / 1000L;
             buffer.append(String.format("%d:%02d:%02d", duration / 3600, (duration % 3600) / 60, (duration % 60)));
-        } else
+        } else {
             buffer.append("UNKNOWN");
+        }
         buffer.append("</td>");
         buffer.append("<td>");
         Double coverage = (Double) getOutputVariableValue(data, RuntimeVariable.Coverage.name());
@@ -251,10 +253,10 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
     }
 
     /**
-     * Write a file for a particular run
+     * Write a file for a particular run.
      *
-     * @param run a {@link org.evosuite.utils.ReportGenerator.StatisticEntry}
-     *            object.
+     * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
+     * @param data a {@link java.util.Map} object.
      * @return a {@link java.lang.String} object.
      */
     @SuppressWarnings("deprecation")
@@ -301,8 +303,9 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
             String code = null;
             if (testChromosome.getLastExecutionResult() != null) {
                 code = test.toCode(testChromosome.getLastExecutionResult().getCopyOfExceptionMapping());
-            } else
+            } else {
                 code = test.toCode();
+            }
 
             for (String line : code.split("\n")) {
                 sb.append(String.format("<span class=\"nocode\"><a name=\"%d\">%3d: </a></span>",
@@ -326,9 +329,10 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
         sb.append("</div>");
         sb.append("<div id=\"post\">\n");
 
-        OutputVariable<?> ov_covered_lines = data.get(RuntimeVariable.Covered_Lines.name());
+        OutputVariable<?> ovCoveredLines = data.get(RuntimeVariable.Covered_Lines.name());
         @SuppressWarnings("unchecked")
-        Set<Integer> coveredLines = (ov_covered_lines != null) ? (Set<Integer>) ov_covered_lines.getValue() : new HashSet<>();
+        Set<Integer> coveredLines = (ovCoveredLines != null) ? (Set<Integer>) ovCoveredLines.getValue()
+                : new HashSet<>();
 
         // Source code
         try {
@@ -345,8 +349,9 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
                     sb.append("<span style=\"background-color: #ffffcc\">");
                     sb.append(StringEscapeUtils.escapeHtml4(line));
                     sb.append("</span>");
-                } else
+                } else {
                     sb.append(StringEscapeUtils.escapeHtml4(line));
+                }
                 sb.append("\n");
                 linecount++;
             }
@@ -379,10 +384,12 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
 
         File[] files = (new File(getReportDir().getAbsolutePath() + "/html")).listFiles(filter);
         if (files != null) {
-            for (File f : files)
+            for (File f : files) {
                 filenames.add(f.getName());
-            while (filenames.contains("report-" + className + "-" + num + ".html"))
+            }
+            while (filenames.contains("report-" + className + "-" + num + ".html")) {
                 num++;
+            }
         }
 
         return num;
@@ -396,13 +403,14 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
 
 
     /**
-     * Write some overall stats
+     * Write some overall stats.
      *
+     * @param suite a {@link org.evosuite.testsuite.TestSuiteChromosome} object.
      * @param buffer a {@link java.lang.StringBuffer} object.
-     * @param entry  a {@link org.evosuite.utils.ReportGenerator.StatisticEntry}
-     *               object.
+     * @param data a {@link java.util.Map} object.
      */
-    protected void writeResultTable(TestSuiteChromosome suite, StringBuffer buffer, Map<String, OutputVariable<?>> data) {
+    protected void writeResultTable(TestSuiteChromosome suite, StringBuffer buffer,
+                                    Map<String, OutputVariable<?>> data) {
 
         //buffer.append("<h2>Statistics</h2>\n");
         buffer.append("<ul>\n");
@@ -417,22 +425,22 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
         buffer.append(suite.size());
         buffer.append(" tests.\n");
 
-		/*
-		long duration_GA = (entry.end_time - entry.start_time) / 1000;
-		long duration_MI = (entry.minimized_time - entry.end_time) / 1000;
-		long duration_TO = (entry.minimized_time - entry.start_time) / 1000;
+        /*
+        long duration_GA = (entry.end_time - entry.start_time) / 1000;
+        long duration_MI = (entry.minimized_time - entry.end_time) / 1000;
+        long duration_TO = (entry.minimized_time - entry.start_time) / 1000;
 
-		buffer.append("<li>Time: "
-		        + String.format("%d:%02d:%02d", duration_TO / 3600,
-		                        (duration_TO % 3600) / 60, (duration_TO % 60)));
+        buffer.append("<li>Time: "
+                + String.format("%d:%02d:%02d", duration_TO / 3600,
+                                (duration_TO % 3600) / 60, (duration_TO % 60)));
 
-		buffer.append("(Search: "
-		        + String.format("%d:%02d:%02d", duration_GA / 3600,
-		                        (duration_GA % 3600) / 60, (duration_GA % 60)) + ", ");
-		buffer.append("minimization: "
-		        + String.format("%d:%02d:%02d", duration_MI / 3600,
-		                        (duration_MI % 3600) / 60, (duration_MI % 60)) + ")\n");
-*/
+        buffer.append("(Search: "
+                + String.format("%d:%02d:%02d", duration_GA / 3600,
+                                (duration_GA % 3600) / 60, (duration_GA % 60)) + ", ");
+        buffer.append("minimization: "
+                + String.format("%d:%02d:%02d", duration_MI / 3600,
+                                (duration_MI % 3600) / 60, (duration_MI % 60)) + ")\n");
+        */
 
         buffer.append("<li>Covered " + getOutputVariableValue(data, RuntimeVariable.Covered_Branches.name()) + "/"
                 + getOutputVariableValue(data, RuntimeVariable.Total_Branches.name()) + " branches, ");
@@ -440,19 +448,20 @@ public class HTMLStatisticsBackend implements StatisticsBackend {
                 + getOutputVariableValue(data, RuntimeVariable.Total_Methods.name()) + " methods, ");
         buffer.append("<li>Covered " + getOutputVariableValue(data, RuntimeVariable.Covered_Goals.name()) + "/"
                 + getOutputVariableValue(data, RuntimeVariable.Total_Goals.name()) + " total goals\n");
-        if (data.containsKey(RuntimeVariable.MutationScore.name()))
+        if (data.containsKey(RuntimeVariable.MutationScore.name())) {
             buffer.append("<li>Mutation score: "
-                    + NumberFormat.getPercentInstance().format(data.get(RuntimeVariable.MutationScore.name()).getValue()) + "\n");
+                    + NumberFormat.getPercentInstance().format(
+                            data.get(RuntimeVariable.MutationScore.name()).getValue()) + "\n");
+        }
 
         buffer.append("</ul>\n");
     }
 
     /**
-     * Write some overall stats
+     * Write some overall stats.
      *
      * @param buffer a {@link java.lang.StringBuffer} object.
-     * @param entry  a {@link org.evosuite.utils.ReportGenerator.StatisticEntry}
-     *               object.
+     * @param data a {@link java.util.Map} object.
      */
     protected void writeParameterTable(StringBuffer buffer, Map<String, OutputVariable<?>> data) {
         buffer.append("<h2 id=parameters>EvoSuite Parameters</h2>\n");

--- a/master/src/main/java/org/evosuite/statistics/backend/StatisticsBackendFactory.java
+++ b/master/src/main/java/org/evosuite/statistics/backend/StatisticsBackendFactory.java
@@ -22,17 +22,17 @@ package org.evosuite.statistics.backend;
 import org.evosuite.Properties;
 
 /**
- * Factory of Statistics Backend
+ * Factory of Statistics Backend.
  *
  * @author Ignacio Lebrero
  */
 public class StatisticsBackendFactory {
 
     /**
-     * Builds the type of Statistics backend required
+     * Builds the type of Statistics backend required.
      *
-     * @param backendType
-     * @return
+     * @param backendType the type of backend
+     * @return the backend instance
      */
     public static StatisticsBackend getStatisticsBackend(Properties.StatisticsBackend backendType) {
         switch (backendType) {


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.statistics` package in the `master` module. This includes fixing line lengths, indentation, braces, Javadoc formatting, and variable naming. Verified that the code compiles and tests pass. No temporary files were included.

---
*PR created automatically by Jules for task [5970691028652391371](https://jules.google.com/task/5970691028652391371) started by @gofraser*