### PR TITLE
Fix Checkstyle JavadocParagraph violations in runtime annotations

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteAssertionOnly.java
+++ b/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteAssertionOnly.java
@@ -24,8 +24,8 @@ import java.lang.annotation.*;
 /**
  * Specify that the tagged method can only be used during assertion generation.
  * It must be pure.
- * <p>
- * Created by Andrea Arcuri on 22/05/15.
+ *
+ * <p>Created by Andrea Arcuri on 22/05/15.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteClassExclude.java
+++ b/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteClassExclude.java
@@ -26,8 +26,8 @@ import java.lang.annotation.*;
  * they are manually tagged. Note: if a class is not going to be used, it would simply
  * not be added to the TestCluster. Using this annotation is useful when one wants to use
  * the class, but the majority of its methods should be excluded.
- * <p>
- * Created by Andrea Arcuri on 22/05/15.
+ *
+ * <p>Created by Andrea Arcuri on 22/05/15.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteExclude.java
+++ b/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteExclude.java
@@ -26,8 +26,7 @@ import java.lang.annotation.*;
  * Annotation used on methods that the user wants to exclude from the search, ie generate no test
  * case using such methods.
  *
- * <p>
- * This is also useful internally inside EvoSuite for example on mock objects (eg no point in calling
+ * <p>This is also useful internally inside EvoSuite for example on mock objects (eg no point in calling
  * a sleep() on thread in a test case).
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteInclude.java
+++ b/runtime/src/main/java/org/evosuite/runtime/annotation/EvoSuiteInclude.java
@@ -24,8 +24,8 @@ import java.lang.annotation.*;
 /**
  * Manually specify that the tagged method can be used in the generated test cases.
  * Note: this is only needed when the class is tagged with {@link EvoSuiteClassExclude}
- * <p>
- * Created by Andrea Arcuri on 22/05/15.
+ *
+ * <p>Created by Andrea Arcuri on 22/05/15.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})


### PR DESCRIPTION
Applied checkstyle fixes to `org.evosuite.runtime.annotation` package in the `runtime` module. 
Specifically addressed `JavadocParagraph` warnings by ensuring `<p>` tags are preceded by an empty line and not followed by a newline.
Verified with `mvn checkstyle:check` and `mvn compile`.

---
*PR created automatically by Jules for task [1509718997388124175](https://jules.google.com/task/1509718997388124175) started by @gofraser*