### PR TITLE
Apply Checkstyle to org.evosuite.runtime.agent

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/agent/AgentLoader.java
+++ b/runtime/src/main/java/org/evosuite/runtime/agent/AgentLoader.java
@@ -43,7 +43,7 @@ import java.util.jar.Manifest;
 /**
  * This class is responsible to load the jar with the agent
  * definition (in its manifest) and then hook it to the current
- * running JVM
+ * running JVM.
  *
  * @author arcuri
  */
@@ -53,7 +53,7 @@ public class AgentLoader {
 
     private static volatile boolean alreadyLoaded = false;
 
-    public synchronized static void loadAgent() throws RuntimeException {
+    public static synchronized void loadAgent() throws RuntimeException {
 
         if (alreadyLoaded) {
             return;
@@ -66,7 +66,8 @@ public class AgentLoader {
 
         String jarFilePath = getJarPath();
         if (jarFilePath == null) {
-            throw new RuntimeException("Cannot find either the compilation target folder nor the EvoSuite jar in classpath: " + System.getProperty("java.class.path"));
+            throw new RuntimeException("Cannot find either the compilation target folder nor "
+                    + "the EvoSuite jar in classpath: " + System.getProperty("java.class.path"));
         } else {
             logger.info("Using JavaAgent in " + jarFilePath);
         }
@@ -132,12 +133,12 @@ public class AgentLoader {
     private static boolean isEvoSuiteMainJar(String path) throws IllegalArgumentException {
 
         if (path.endsWith("classes")) {
-			/*
-				we need to treat this specially:
-				eg, Jenkins/Maven on Linux on a module with only tests ended up
-				with not creating "target/classes" (it does on Mac though) but still putting
-				it on the classpath
-			 */
+            /*
+             * we need to treat this specially:
+             * eg, Jenkins/Maven on Linux on a module with only tests ended up
+             * with not creating "target/classes" (it does on Mac though) but still putting
+             * it on the classpath
+             */
             return false;
         }
 
@@ -185,14 +186,16 @@ public class AgentLoader {
 
         if (jarFilePath == null) {
             /*
-             * this could happen in Eclipse or during test execution in Maven, and so search in compilation 'target' folder
+             * this could happen in Eclipse or during test execution in Maven,
+             * and so search in compilation 'target' folder
              */
             jarFilePath = searchInFolder("target");
         }
 
         if (jarFilePath == null) {
             /*
-             * this could happen in Eclipse or during test execution in Maven, and so search in compilation 'target' folder
+             * this could happen in Eclipse or during test execution in Maven,
+             * and so search in compilation 'target' folder
              */
             /*
              * FIXME: what is this???????? Definitively the above comment

--- a/runtime/src/main/java/org/evosuite/runtime/agent/InstrumentingAgent.java
+++ b/runtime/src/main/java/org/evosuite/runtime/agent/InstrumentingAgent.java
@@ -33,8 +33,7 @@ import java.lang.instrument.Instrumentation;
  * During EvoSuite search, EvoSuite does not need an agent,
  * as instrumentation can be done at classloader level.
  *
- * <p>
- * Note: we need JavaAgent in JUnit as the classes could have already
+ * <p>Note: we need JavaAgent in JUnit as the classes could have already
  * been loaded/instrumented, eg as it happens when tools like
  * Emma, Cobertura, Javalanche, etc., are used.
  *
@@ -59,11 +58,11 @@ public class InstrumentingAgent {
     }
 
     /**
-     * This is called by JVM when agent starts
+     * This is called by JVM when agent starts.
      *
-     * @param args
-     * @param inst
-     * @throws Exception
+     * @param args command line arguments
+     * @param inst instrumentation instance
+     * @throws Exception if something goes wrong
      */
     public static void premain(String args, Instrumentation inst) throws Exception {
         logger.info("Executing premain of JavaAgent");
@@ -73,11 +72,11 @@ public class InstrumentingAgent {
     }
 
     /**
-     * This is called by JVM when agent starts
+     * This is called by JVM when agent starts.
      *
-     * @param args
-     * @param inst
-     * @throws Exception
+     * @param args command line arguments
+     * @param inst instrumentation instance
+     * @throws Exception if something goes wrong
      */
     public static void agentmain(String args, Instrumentation inst) throws Exception {
         logger.info("Executing agentmain of JavaAgent");
@@ -95,7 +94,7 @@ public class InstrumentingAgent {
     }
 
     /**
-     * Force the dynamic loading of the agent
+     * Force the dynamic loading of the agent.
      */
     public static void initialize() {
         MockFramework.disable(); //need an explicit "activate" call
@@ -114,7 +113,7 @@ public class InstrumentingAgent {
     /**
      * Once loaded, an agent will always read the byte[]
      * of the loaded classes. Here we tell it if those byte[]
-     * should be instrumented
+     * should be instrumented.
      */
     public static void activate() {
         checkTransformerState();
@@ -124,7 +123,7 @@ public class InstrumentingAgent {
     }
 
     /**
-     * Stop instrumenting classes
+     * Stop instrumenting classes.
      */
     public static void deactivate() {
         checkTransformerState();
@@ -135,9 +134,9 @@ public class InstrumentingAgent {
 
     /**
      * Tells EvoSuite that we are going to re-instrument classes.
-     * In these cases, we cannot change the class signatures
+     * In these cases, we cannot change the class signatures.
      *
-     * @param on
+     * @param on whether to enable retransformation
      */
     public static void setRetransformingMode(boolean on) {
         transformer.setRetransformingMode(on);

--- a/runtime/src/main/java/org/evosuite/runtime/agent/ToolsJarLocator.java
+++ b/runtime/src/main/java/org/evosuite/runtime/agent/ToolsJarLocator.java
@@ -61,28 +61,32 @@ public class ToolsJarLocator {
                 Class<?> clazz = Class.forName(EXAMPLE_CLASS);
                 return clazz.getClassLoader();
             } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Did not manage to automatically find tools.jar. Use -Dtools_jar_location=<path> property");
+                throw new RuntimeException("Did not manage to automatically find tools.jar. "
+                        + "Use -Dtools_jar_location=<path> property");
             }
 
         }
 
-		/*
-			This was a problem, as PowerMock and JMockit ship with their own version of tools.jar taken from OpenJDK
-		 */
-//		try {
-//			Class.forName(EXAMPLE_CLASS,true,ClassLoader.getSystemClassLoader());
-//			logger.info("Tools.jar already on system classloader");
-//			return ClassLoader.getSystemClassLoader(); //if this code is reached, the tools.jar is available on system classpath
-//		} catch (ClassNotFoundException e) {
-//			//OK, it is missing, so lets try to locate it
-//		}
-//		try {
-//			Class.forName(EXAMPLE_CLASS);
-//			logger.info("Tools.jar already on current classloader");
-//			return ToolsJarLocator.class.getClassLoader(); //if this code is reached, the tools.jar is available on classpath
-//		} catch (ClassNotFoundException e) {
-//			//OK, it is missing, so lets try to locate it
-//		}
+        /*
+         * This was a problem, as PowerMock and JMockit ship with their own version of tools.jar
+         * taken from OpenJDK
+         */
+        // try {
+        // Class.forName(EXAMPLE_CLASS,true,ClassLoader.getSystemClassLoader());
+        // logger.info("Tools.jar already on system classloader");
+        // return ClassLoader.getSystemClassLoader();
+        // //if this code is reached, the tools.jar is available on system classpath
+        // } catch (ClassNotFoundException e) {
+        // //OK, it is missing, so lets try to locate it
+        // }
+        // try {
+        // Class.forName(EXAMPLE_CLASS);
+        // logger.info("Tools.jar already on current classloader");
+        // return ToolsJarLocator.class.getClassLoader();
+        // //if this code is reached, the tools.jar is available on classpath
+        // } catch (ClassNotFoundException e) {
+        // //OK, it is missing, so lets try to locate it
+        // }
 
         if (manuallySpecifiedToolLocation != null) {
             //if defined, then use it, and throws exception if it is not valid
@@ -113,12 +117,14 @@ public class ToolsJarLocator {
             }
         }
 
-        throw new RuntimeException("Did not manage to automatically find tools.jar. Use -Dtools_jar_location=<path> property");
+        throw new RuntimeException("Did not manage to automatically find tools.jar. "
+                + "Use -Dtools_jar_location=<path> property");
     }
 
     private ClassLoader considerPathInProperties() {
         if (!manuallySpecifiedToolLocation.endsWith(".jar")) {
-            throw new RuntimeException("Property tools_jar_location does not point to a jar file: " + manuallySpecifiedToolLocation);
+            throw new RuntimeException("Property tools_jar_location does not point to a jar file: "
+                    + manuallySpecifiedToolLocation);
         }
 
         return validateAndGetLoader(manuallySpecifiedToolLocation);

--- a/runtime/src/main/java/org/evosuite/runtime/agent/TransformerForTests.java
+++ b/runtime/src/main/java/org/evosuite/runtime/agent/TransformerForTests.java
@@ -34,7 +34,7 @@ import java.util.Set;
 /**
  * Once the agent is hooked to the current JVM, each time a class is
  * loaded, its byte[] representation will be first given as input
- * to this class, which can modify/instrument it
+ * to this class, which can modify/instrument it.
  *
  * @author arcuri
  */
@@ -63,7 +63,8 @@ public class TransformerForTests implements ClassFileTransformer {
             throws IllegalClassFormatException {
 
         String classWithDots = className.replace('/', '.');
-        if (!active || !RuntimeInstrumentation.checkIfCanInstrument(classWithDots) || classWithDots.startsWith(PackageInfo.getEvoSuitePackage())) {
+        if (!active || !RuntimeInstrumentation.checkIfCanInstrument(classWithDots)
+                || classWithDots.startsWith(PackageInfo.getEvoSuitePackage())) {
             return classfileBuffer;
         } else {
             //ClassResetter.getInstance().setClassLoader(loader);
@@ -80,7 +81,8 @@ public class TransformerForTests implements ClassFileTransformer {
                 return classfileBuffer;
             }
 
-            return instrumenter.transformBytes(loader, className, reader, false); // TODO: Need to set skip instrumentation for test class
+            // TODO: Need to set skip instrumentation for test class
+            return instrumenter.transformBytes(loader, className, reader, false);
         }
     }
 


### PR DESCRIPTION
This PR applies Checkstyle fixes to the `org.evosuite.runtime.agent` package in the `runtime` module.
The changes are purely stylistic and documentation-related, ensuring compliance with the project's coding standards.

Changes:
- `AgentLoader.java`: Fixed modifier order, line lengths, tabs, and Javadoc.
- `InstrumentingAgent.java`: Fixed Javadoc tags (`<p>`, `@param`), summary periods, and file ending.
- `ToolsJarLocator.java`: Fixed line lengths, tabs, and indentation.
- `TransformerForTests.java`: Fixed Javadoc and line lengths.

Ran `mvn checkstyle:check` to verify zero violations.
Ran `mvn test -pl runtime` to ensure no regressions (confirmed `MockJFileChooserTest` failure is unrelated).

---
*PR created automatically by Jules for task [17094505490449541195](https://jules.google.com/task/17094505490449541195) started by @gofraser*