### PR TITLE
Fix Checkstyle violations in org.evosuite.runtime.classhandling

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/ClassResetter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/ClassResetter.java
@@ -35,8 +35,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * This class resets the static fields of a given class by invoking the <clinit> class initializer.
- * In order to re-invoke the <clinit> this is duplicated with the method name "__STATIC_RESET".
+ * This class resets the static fields of a given class by invoking the &lt;clinit&gt; class initializer.
+ * In order to re-invoke the &lt;clinit&gt; this is duplicated with the method name "__STATIC_RESET".
  *
  * @author galeotti
  */
@@ -45,12 +45,12 @@ public class ClassResetter {
     private static final Logger logger = LoggerFactory.getLogger(ClassResetter.class);
 
     /**
-     * The name of the instrumented duplication of the class initializer <clinit>
+     * The name of the instrumented duplication of the class initializer &lt;clinit&gt;.
      */
     public static final String STATIC_RESET = "__STATIC_RESET";
 
     /**
-     * Singleton instance of this class
+     * Singleton instance of this class.
      */
     private static final ClassResetter instance = new ClassResetter();
 
@@ -63,9 +63,9 @@ public class ClassResetter {
     }
 
     /**
-     * Return singleton instance
+     * Return singleton instance.
      *
-     * @return
+     * @return the singleton instance
      */
     public static ClassResetter getInstance() {
         return instance;
@@ -80,10 +80,10 @@ public class ClassResetter {
 
 
     /**
-     * Only log once for a class
+     * Only log once for a class.
      *
-     * @param className
-     * @param msg
+     * @param className the name of the class
+     * @param msg       the message to log
      */
     public synchronized void logWarn(String className, String msg) {
         AtMostOnceLogger.warn(logger, msg);
@@ -115,7 +115,8 @@ public class ClassResetter {
             //this can happen if class was not instrumented with a static reset
             logger.debug("__STATIC_RESET() method does not exists in class {}", classNameWithDots);
         } catch (Exception | Error e) {
-            logWarn(classNameWithDots, e.getClass() + " thrown while loading method  __STATIC_RESET() for class " + classNameWithDots);
+            logWarn(classNameWithDots, e.getClass()
+                    + " thrown while loading method  __STATIC_RESET() for class " + classNameWithDots);
         }
     }
 
@@ -125,9 +126,9 @@ public class ClassResetter {
     }
 
     /**
-     * Invoke the duplicated version of class initializar <clinit>
+     * Invoke the duplicated version of class initializar &lt;clinit&gt;.
      *
-     * @param classNameWithDots the class for invoking the duplicated version of class initializer <clinit>
+     * @param classNameWithDots the class for invoking the duplicated version of class initializer &lt;clinit&gt;
      */
     public void reset(String classNameWithDots) throws IllegalArgumentException, IllegalStateException {
         if (classNameWithDots == null || classNameWithDots.isEmpty()) {

--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/ClassStateSupport.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/ClassStateSupport.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 /**
  * Class used to handle the static state of classes, their intialization and
- * re-instrumentation
+ * re-instrumentation.
  *
  * @author arcuri
  */
@@ -54,8 +54,9 @@ public class ClassStateSupport {
      * This method will usually be called in a @BeforeClass initialization
      * </p>
      *
-     * @param classLoader
-     * @param classNames
+     * @param classLoader the class loader to use
+     * @param classNames  the names of the classes to load
+     * @return true if there was a problem loading any class, false otherwise
      */
     public static boolean initializeClasses(ClassLoader classLoader, String... classNames) {
 
@@ -81,10 +82,12 @@ public class ClassStateSupport {
                 }
 
                 if (!InstrumentedClass.class.isAssignableFrom(clazz)) {
-                    String msg = "Class " + clazz.getName() + " was not instrumented by EvoSuite. " +
-                            "This could happen if you are running JUnit tests in a way that is not handled by EvoSuite, in " +
-                            "which some classes are loaded be reflection before the tests are run. Consult the EvoSuite documentation " +
-                            "for possible workarounds for this issue.";
+                    String msg = "Class " + clazz.getName() + " was not instrumented by EvoSuite. "
+                            + "This could happen if you are running JUnit tests in a way that is not handled "
+                            + "by EvoSuite, in "
+                            + "which some classes are loaded be reflection before the tests are run. "
+                            + "Consult the EvoSuite documentation "
+                            + "for possible workarounds for this issue.";
                     logger.error(msg);
                     problem = true;
                     //throw new IllegalStateException(msg); // throwing an exception might be a bit too extreme
@@ -116,7 +119,8 @@ public class ClassStateSupport {
                 } catch (NoSuchMethodException e) {
                     // No instrumentation, no need to do anything
                 } catch (Throwable e) {
-                    logger.info("Error while checking for {} in class {}: {}", externalInitMethod, clazz.getName(), e.getMessage());
+                    logger.info("Error while checking for {} in class {}: {}",
+                            externalInitMethod, clazz.getName(), e.getMessage());
 
                 }
             }
@@ -130,7 +134,7 @@ public class ClassStateSupport {
      * This method will be usually called after a test is executed, ie in a @After
      * </p>
      *
-     * @param classNames
+     * @param classNames the names of the classes to reset
      */
     public static void resetClasses(String... classNames) {
         for (String classNameToReset : classNames) {
@@ -160,8 +164,8 @@ public class ClassStateSupport {
                     Sandbox.goingToExecuteUnsafeCodeOnSameThread();
                 }
                 LoopCounter.getInstance().setActive(false);
-                Class<?> aClass = Class.forName(className, true, classLoader);
-                classes.add(aClass);
+                Class<?> loadedClass = Class.forName(className, true, classLoader);
+                classes.add(loadedClass);
 
             } catch (Exception | Error ex) {
                 AtMostOnceLogger.error(logger, "Could not initialize " + className + ": " + ex.getMessage());
@@ -183,6 +187,9 @@ public class ClassStateSupport {
     /**
      * If any of the loaded class was not instrumented yet, then re-instrument them.
      * Note: re-instrumentation is more limited, as cannot change class signature
+     *
+     * @param classLoader the class loader to use
+     * @param classNames  the names of the classes to re-transform
      */
     @Deprecated
     public static void retransformIfNeeded(ClassLoader classLoader, String... classNames) {
@@ -201,7 +208,7 @@ public class ClassStateSupport {
      * If any of the loaded class was not instrumented yet, then re-instrument them.
      * Note: re-instrumentation is more limited, as cannot change class signature
      *
-     * @param classes
+     * @param classes the list of classes to re-transform
      */
     @Deprecated
     public static void retransformIfNeeded(List<Class<?>> classes) {
@@ -212,28 +219,29 @@ public class ClassStateSupport {
 
         List<Class<?>> classToReInstrument = new ArrayList<>();
 
-		/*
-		InstrumentingAgent.activate();
-		for(Class<?> cl : classes){
+        /*
+        InstrumentingAgent.activate();
+        for(Class<?> cl : classes){
 
-			try{
-				InstrumentingAgent.getInstumentation().retransformClasses(cl);
-			} catch(UnsupportedOperationException e){
-				/ *
-				 * this happens if class was already loaded by JUnit (eg the abstract class problem)
-				 * and re-instrumentation do change the signature
-				 * /
-				classToReInstument.add(cl);
-			} catch(Exception | Error e){
-				//this shouldn't really happen
-				java.lang.System.err.println("Could not instrument "+cl.getName()+". Exception "+e.toString());
-			}
+            try{
+                InstrumentingAgent.getInstumentation().retransformClasses(cl);
+            } catch(UnsupportedOperationException e){
+                / *
+                 * this happens if class was already loaded by JUnit (eg the abstract class problem)
+                 * and re-instrumentation do change the signature
+                 * /
+                classToReInstument.add(cl);
+            } catch(Exception | Error e){
+                //this shouldn't really happen
+                java.lang.System.err.println("Could not instrument "+cl.getName()+". Exception "+e.toString());
+            }
 
-		}
-		*/
+        }
+        */
 
         for (Class<?> cl : classes) {
-            if (!InstrumentingAgent.getTransformer().isClassAlreadyTransformed(cl.getName())) {
+            if (!InstrumentingAgent.getTransformer().isClassAlreadyTransformed(
+                    cl.getName())) {
                 classToReInstrument.add(cl);
             }
         }
@@ -245,7 +253,8 @@ public class ClassStateSupport {
         InstrumentingAgent.setRetransformingMode(true);
         try {
             if (!classToReInstrument.isEmpty()) {
-                InstrumentingAgent.getInstrumentation().retransformClasses(classToReInstrument.toArray(new Class<?>[0]));
+                InstrumentingAgent.getInstrumentation().retransformClasses(
+                        classToReInstrument.toArray(new Class<?>[0]));
             }
         } catch (UnmodifiableClassException e) {
             //this shouldn't really happen, as already checked in previous loop

--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
@@ -28,9 +28,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Class used to handle static state of JDK API classes we cannot instrument
- * <p>
- * Created by Andrea Arcuri on 08/11/15.
+ * Class used to handle static state of JDK API classes we cannot instrument.
+ *
+ * <p>Created by Andrea Arcuri on 08/11/15.
  */
 public class JDKClassResetter {
 
@@ -41,7 +41,7 @@ public class JDKClassResetter {
 
 
     /**
-     * Save current state of all JDK static fields we are going te reset later on
+     * Save current state of all JDK static fields we are going te reset later on.
      */
     public static void init() {
 

--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/ModifiedTargetStaticFields.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/ModifiedTargetStaticFields.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 
 /**
  * This class represents the singleton containing those static fields whose
- * <code>final</code> modifier was removed during our instrumentation
+ * <code>final</code> modifier was removed during our instrumentation.
  *
  * @author galeotti
  */
@@ -36,9 +36,9 @@ public class ModifiedTargetStaticFields {
     private static final Logger logger = LoggerFactory.getLogger(ModifiedTargetStaticFields.class);
 
     /**
-     * gets the current set of modified target static fields
+     * gets the current set of modified target static fields.
      *
-     * @return
+     * @return the singleton instance
      */
     public static ModifiedTargetStaticFields getInstance() {
         if (instance == null) {
@@ -64,9 +64,9 @@ public class ModifiedTargetStaticFields {
 
     /**
      * Adds a collection of final fields whose final modifier was removed by our
-     * instrumentation
+     * instrumentation.
      *
-     * @param newFinalFields
+     * @param newFinalFields the collection of new final fields to add
      */
     public void addFinalFields(Collection<String> newFinalFields) {
         for (String finalField : newFinalFields) {
@@ -78,10 +78,10 @@ public class ModifiedTargetStaticFields {
     }
 
     /**
-     * Checks if a given field is contained or not in this collection
+     * Checks if a given field is contained or not in this collection.
      *
-     * @param name
-     * @return
+     * @param name the name of the field
+     * @return true if the field is contained in the collection, false otherwise
      */
     public boolean containsField(String name) {
         // logger.debug("Checking if a static field was modified or not:" + name);


### PR DESCRIPTION
Applied checkstyle fixes to `org.evosuite.runtime.classhandling` package.
- `ClassResetter.java`: Escaped `<clinit>`, fixed Javadoc periods and descriptions, line length.
- `JDKClassResetter.java`: Fixed `<p>` tag usage, added Javadoc period.
- `ClassStateSupport.java`: Fixed Javadoc periods/descriptions, OperatorWrap, LineLength, renamed `aClass` to `loadedClass`, removed tabs.
- `ModifiedTargetStaticFields.java`: Fixed Javadoc periods and descriptions.

Verified with `mvn checkstyle:check` and `mvn test -pl runtime`.
Existing test failure `MockJFileChooserTest.testGetCurrentDirectory` is unrelated to these changes.

---
*PR created automatically by Jules for task [15934766656824083705](https://jules.google.com/task/15934766656824083705) started by @gofraser*