### PR TITLE
Apply Checkstyle to org.evosuite.runtime.util

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/util/ByteDataInputStream.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/ByteDataInputStream.java
@@ -26,9 +26,9 @@ import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Class used to create an input stream for a byte array
- * <p>
- * Created by Andrea Arcuri on 22/05/15.
+ * Class used to create an input stream for a byte array.
+ *
+ * <p>Created by Andrea Arcuri on 22/05/15.
  */
 public class ByteDataInputStream extends InputStream {
 

--- a/runtime/src/main/java/org/evosuite/runtime/util/ComputeClassWriter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/ComputeClassWriter.java
@@ -22,8 +22,6 @@ package org.evosuite.runtime.util;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,10 +33,6 @@ import java.io.InputStream;
  * @author Eric Bruneton
  */
 public class ComputeClassWriter extends ClassWriter {
-
-    private final Logger logger = LoggerFactory.getLogger(ComputeClassWriter.class);
-
-    private final ClassLoader l = getClass().getClassLoader();
 
     public ComputeClassWriter(final int flags) {
         super(flags);
@@ -117,12 +111,12 @@ public class ComputeClassWriter extends ClassWriter {
      * @param type the internal name of a class or interface.
      * @param info the ClassReader corresponding to 'type'.
      * @return a StringBuilder containing the ancestor classes of 'type',
-     * separated by ';'. The returned string has the following format:
-     * ";type1;type2 ... ;typeN", where type1 is 'type', and typeN is a
-     * direct subclass of Object. If 'type' is Object, the returned
-     * string is empty.
+     *     separated by ';'. The returned string has the following format:
+     *     ";type1;type2 ... ;typeN", where type1 is 'type', and typeN is a
+     *     direct subclass of Object. If 'type' is Object, the returned
+     *     string is empty.
      * @throws IOException if the bytecode of 'type' or of some of its ancestor class
-     *                     cannot be loaded.
+     *     cannot be loaded.
      */
     private StringBuilder typeAncestors(String type, ClassReader info)
             throws IOException {
@@ -175,8 +169,9 @@ public class ComputeClassWriter extends ClassWriter {
      */
     private ClassReader typeInfo(final String type) throws IOException, NullPointerException {
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(type + ".class")) {
-            if (is == null)
+            if (is == null) {
                 throw new NullPointerException("Class not found " + type);
+            }
             return new ClassReader(is);
         }
     }

--- a/runtime/src/main/java/org/evosuite/runtime/util/Inputs.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/Inputs.java
@@ -25,10 +25,10 @@ package org.evosuite.runtime.util;
 public class Inputs {
 
     /**
-     * Check for NPE but using IAE with proper error message
+     * Check for NPE but using IAE with proper error message.
      *
-     * @param inputs
-     * @throws IllegalArgumentException
+     * @param inputs the objects to check for null
+     * @throws IllegalArgumentException if any input is null
      */
     public static void checkNull(Object... inputs) throws IllegalArgumentException {
         if (inputs == null) {

--- a/runtime/src/main/java/org/evosuite/runtime/util/JOptionPaneInputs.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JOptionPaneInputs.java
@@ -31,7 +31,7 @@ import java.util.LinkedList;
 public class JOptionPaneInputs {
 
     /**
-     * The type of GUI action that is fed to the JOptionPane mock
+     * The type of GUI action that is fed to the JOptionPane mock.
      *
      * @author galeotti
      */
@@ -53,7 +53,7 @@ public class JOptionPaneInputs {
 
     private static JOptionPaneInputs instance = null;
 
-    public synchronized static JOptionPaneInputs getInstance() {
+    public static synchronized JOptionPaneInputs getInstance() {
         if (instance == null) {
             instance = new JOptionPaneInputs();
         }
@@ -61,14 +61,14 @@ public class JOptionPaneInputs {
     }
 
     /**
-     * Resets the singleton
+     * Resets the singleton.
      */
-    public synchronized static void resetSingleton() {
+    public static synchronized void resetSingleton() {
         instance = null;
     }
 
     /**
-     * This method should clean all the input queues before test case execution
+     * This method should clean all the input queues before test case execution.
      */
     public void initForTestCase() {
         this.stringInputs.clear();
@@ -124,7 +124,7 @@ public class JOptionPaneInputs {
      * Dequeues a string from the string input queue. If no string is in the
      * queue, an IllegalStateException is signaled.
      *
-     * @return
+     * @return the dequeued string
      */
     public String dequeueStringInput() {
         if (stringInputs.isEmpty()) {
@@ -146,7 +146,7 @@ public class JOptionPaneInputs {
     private boolean hasOptionDialogs = false;
 
     /**
-     * Report that the SUT has issued a call to a JOptionPane dialog
+     * Report that the SUT has issued a call to a JOptionPane dialog.
      *
      * @param dialogType the type of the JOptionPane dialog
      */
@@ -179,10 +179,10 @@ public class JOptionPaneInputs {
     }
 
     /**
-     * Returns if the SUT has issued a call to the corresponding dialog
+     * Returns if the SUT has issued a call to the corresponding dialog.
      *
-     * @param dialogType
-     * @return
+     * @param dialogType the type of the dialog
+     * @return true if the dialog has been called
      */
     public boolean hasDialog(GUIAction dialogType) {
         switch (dialogType) {
@@ -207,18 +207,18 @@ public class JOptionPaneInputs {
     }
 
     /**
-     * This method report if any JOptionPane dialog call was issued by the SUT
+     * This method report if any JOptionPane dialog call was issued by the SUT.
      *
-     * @return
+     * @return true if any dialog has been called
      */
     public boolean hasAnyDialog() {
         return hasStringDialogs || hasYesCancelDialogs || hasYesNoCancelDialogs || hasYesNoDialogs || hasOptionDialogs;
     }
 
     /**
-     * The string queue has a string
+     * The string queue has a string.
      *
-     * @return
+     * @return true if string input is present
      */
     public boolean containsStringInput() {
         return !stringInputs.isEmpty();

--- a/runtime/src/main/java/org/evosuite/runtime/util/JarPathing.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JarPathing.java
@@ -94,10 +94,12 @@ public class JarPathing {
                 File file = new File(token.replace("%20", " "));
                 if (!file.exists()) {
                     //this should never happen, unless bug in EvoSuite
-                    throw new IllegalStateException("Pathing jar " + pathingJar + " refers to non-existing entry " + token);
+                    throw new IllegalStateException("Pathing jar " + pathingJar
+                            + " refers to non-existing entry " + token);
                 }
                 if (isPathingJar(file.getAbsolutePath())) {
-                    throw new IllegalArgumentException("Pathing jar " + pathingJar + " contains the pathing jar " + file.getAbsolutePath());
+                    throw new IllegalArgumentException("Pathing jar " + pathingJar
+                            + " contains the pathing jar " + file.getAbsolutePath());
                 }
                 list.add(file.getAbsolutePath());
             }
@@ -113,10 +115,10 @@ public class JarPathing {
     /**
      * Create a jar file in the tmp directory having the given {@code classpath}  in the
      * manifest, and return the path to such jar. This is done to avoid issues in
-     * Windows where cannot have too long classpaths
+     * Windows where cannot have too long classpaths.
      *
-     * @param classpath
-     * @return
+     * @param classpath the classpath to be used
+     * @return the path to the created jar file
      */
     public static String createJarPathing(String classpath) {
 
@@ -143,11 +145,11 @@ public class JarPathing {
                     continue;
                 }
 
-				/*
-					as the path separator in the manifest is just spaces " ", we need
-					to escape the paths to URL to avoid issues in Windows where path might
-					have spaces...
-				 */
+                /*
+                    as the path separator in the manifest is just spaces " ", we need
+                    to escape the paths to URL to avoid issues in Windows where path might
+                    have spaces...
+                 */
 
                 element = element.replace("\\", "/");
                 element = element.replace(" ", "%20");

--- a/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  * <p>
@@ -23,12 +23,12 @@ import java.io.File;
 import java.util.Optional;
 
 /**
- * Created by wildfly.ua@gmail.com for EvoSuite project (https://github.com/EvoSuite/evosuite)
+ * Created by wildfly.ua@gmail.com for EvoSuite project (https://github.com/EvoSuite/evosuite).
  */
 public class JavaExecCmdUtil {
 
     /**
-     * Utility class, no public constructors
+     * Utility class, no public constructors.
      */
     private JavaExecCmdUtil() {
     }
@@ -40,9 +40,9 @@ public class JavaExecCmdUtil {
      * master<->client communication will have no results.
      *
      * @param isFullOriginalJavaExecRequired - original behavior switch: "java" or JAVA_CMD from
-     * (@link org.evosuite.EvoSuite#JAVA_CMD)
-     * @return current runtime java executable path based on $JAVA_HOME environment variable
-     * @apiNote under maven java.home property is ${JAVA_HOME}/jre/bin/java
+     *     (@link org.evosuite.EvoSuite#JAVA_CMD)
+     * @return current runtime java executable path based on $JAVA_HOME environment variable.
+     * @apiNote under maven java.home property is ${JAVA_HOME}/jre/bin/java.
      */
     public static String getJavaBinExecutablePath(final boolean isFullOriginalJavaExecRequired) {
         final String sep = System.getProperty("file.separator");
@@ -50,11 +50,11 @@ public class JavaExecCmdUtil {
 
         return getJavaHomeEnv()
                 .map(javaHomeEnvVar -> {
-                     String exeSuffix = getOsName()
-                               .filter(osName -> osName.toLowerCase().contains("windows"))
-                               .map(osName -> ".exe")
-                               .orElse("");
-                     return new File(javaHomeEnvVar + sep + "bin" + sep + "java" + exeSuffix);
+                    String exeSuffix = getOsName()
+                            .filter(osName -> osName.toLowerCase().contains("windows"))
+                            .map(osName -> ".exe")
+                            .orElse("");
+                    return new File(javaHomeEnvVar + sep + "bin" + sep + "java" + exeSuffix);
                 })
                 .filter(File::exists)
                 .map(File::getPath)
@@ -62,7 +62,10 @@ public class JavaExecCmdUtil {
     }
 
     /**
+     * Helper method to get java bin executable path.
+     *
      * @see #getJavaBinExecutablePath(boolean)
+     * @return the path to the java executable
      */
     public static String getJavaBinExecutablePath() {
         return getJavaBinExecutablePath(false);

--- a/runtime/src/main/java/org/evosuite/runtime/util/SystemInUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/SystemInUtil.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This singleton class is used to handle calls to System.in by
- * replacing them with a smart stub
+ * replacing them with a smart stub.
  *
  * @author arcuri
  */
@@ -39,7 +39,7 @@ public class SystemInUtil extends InputStream {
 
     /**
      * Need to keep reference to original {@code System.in} for
-     * when we reset this singleton
+     * when we reset this singleton.
      */
     private static final InputStream defaultIn = System.in;
 
@@ -48,24 +48,24 @@ public class SystemInUtil extends InputStream {
     private static final SystemInUtil singleton = new SystemInUtil();
 
     /**
-     * Has System.in ever be used by the SUT?
+     * Has System.in ever be used by the SUT.
      */
     private volatile boolean beingUsed;
 
     /**
-     * The data that will be taken from System.in
+     * The data that will be taken from System.in.
      */
     private volatile List<Byte> data;
 
     /**
-     * the position in the stream
+     * The position in the stream.
      */
     private volatile AtomicInteger counter;
 
 
     /**
      * This is needed to simulate blocking calls when there is
-     * no input
+     * no input.
      */
     private static final Object monitor = new Object();
 
@@ -74,7 +74,7 @@ public class SystemInUtil extends InputStream {
     //--------------------------------
 
     /**
-     * Hidden constructor
+     * Hidden constructor.
      */
     protected SystemInUtil() {
         super();
@@ -85,7 +85,7 @@ public class SystemInUtil extends InputStream {
     }
 
     /**
-     * Reset the static state be re-instantiate the singleton
+     * Reset the static state be re-instantiate the singleton.
      */
     public static synchronized void resetSingleton() {
         singleton.beingUsed = false;
@@ -96,7 +96,7 @@ public class SystemInUtil extends InputStream {
     }
 
     /**
-     * Setup mocked/stubbed System.in for the test case
+     * Setup mocked/stubbed System.in for the test case.
      */
     public void initForTestCase() {
         data = new ArrayList<>();
@@ -167,13 +167,13 @@ public class SystemInUtil extends InputStream {
                  * in the following test case statements), let's just simulate an exception.
                  */
                 throw new IOException("Simulated exception in System.in");
-				/*
-				try {
-					monitor.wait();
-				} catch (InterruptedException e) {
-					return -1; // simulate end of stream
-				}
-				*/
+                /*
+                try {
+                    monitor.wait();
+                } catch (InterruptedException e) {
+                    return -1; // simulate end of stream
+                }
+                */
             }
 
             int i = counter.getAndIncrement();
@@ -190,9 +190,9 @@ public class SystemInUtil extends InputStream {
     }
 
     /**
-     * Has there be any call to System.in.read()?
+     * Has there be any call to System.in.read().
      *
-     * @return
+     * @return true if System.in has been read from
      */
     public boolean hasBeenUsed() {
         return beingUsed;


### PR DESCRIPTION
Applied Checkstyle fixes to `org.evosuite.runtime.util` package.
- `ByteDataInputStream.java`: Fixed Javadoc paragraph tags.
- `SystemInUtil.java`: Fixed Javadoc summaries, tabs, and indentation.
- `JavaExecCmdUtil.java`: Fixed license header, Javadoc summaries, indentation.
- `JOptionPaneInputs.java`: Fixed Javadoc summaries, modifier order, missing descriptions.
- `ComputeClassWriter.java`: Removed unused fields/imports, fixed Javadoc indentation, added braces.
- `JarPathing.java`: Fixed line length, missing descriptions, tabs.
- `Inputs.java`: Fixed Javadoc summary, missing descriptions.


---
*PR created automatically by Jules for task [15837177341257181828](https://jules.google.com/task/15837177341257181828) started by @gofraser*