### PR TITLE
Apply Checkstyle fixes to org.evosuite.runtime.sandbox package

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/PermissionStatistics.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/PermissionStatistics.java
@@ -32,14 +32,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * PermissionStatistics class.
  * </p>
  *
- *
- *
  * <p>
  * FIXME: This class seem directly used by the SUT, when its methods check the
  * security manager. This can lead to concurrency issues when the SUT is
  * multi-threaded. Some re-factoring might be needed, but that would need some
  * discussions first regarding its use/goals
- * <p>
+ * </p>
  *
  * @author Gordon Fraser
  */
@@ -88,7 +86,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getRecentFileReadPermissions
+     * getRecentFileReadPermissions.
      * </p>
      *
      * @return an array of {@link java.lang.String} objects.
@@ -99,7 +97,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * resetRecentStatistic
+     * resetRecentStatistic.
      * </p>
      */
     public void resetRecentStatistic() {
@@ -109,17 +107,18 @@ public class PermissionStatistics {
     private void rememberRecentReadFilePermissions(Permission permission) {
         try {
             FilePermission fp = (FilePermission) permission;
-            if (!fp.getActions().equals("read"))
+            if (!fp.getActions().equals("read")) {
                 return;
+            }
             recentAccess.add(fp.getName());
         } catch (Exception e) {
-            return;
+            // ignored
         }
     }
 
     /**
      * <p>
-     * permissionAllowed
+     * permissionAllowed.
      * </p>
      *
      * @param permission a {@link java.security.Permission} object.
@@ -140,8 +139,9 @@ public class PermissionStatistics {
     }
 
     private int getCurrentCount(Class<?> permissionClass) {
-        if (!deniedClassCount.containsKey(permissionClass))
+        if (!deniedClassCount.containsKey(permissionClass)) {
             deniedClassCount.put(permissionClass, 0);
+        }
 
         return deniedClassCount.get(permissionClass);
     }
@@ -165,7 +165,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * permissionDenied
+     * permissionDenied.
      * </p>
      *
      * @param permission a {@link java.security.Permission} object.
@@ -191,7 +191,7 @@ public class PermissionStatistics {
     }
 
     /**
-     * Retrieve the number of times a particular permission was denied
+     * Retrieve the number of times a particular permission was denied.
      *
      * @param permission a {@link java.security.Permission} object.
      * @return a int.
@@ -209,7 +209,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumAllPermission
+     * getNumAllPermission.
      * </p>
      *
      * @return a int.
@@ -220,7 +220,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumSecurityPermission
+     * getNumSecurityPermission.
      * </p>
      *
      * @return a int.
@@ -231,7 +231,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumUnresolvedPermission
+     * getNumUnresolvedPermission.
      * </p>
      *
      * @return a int.
@@ -242,7 +242,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumAWTPermission
+     * getNumAWTPermission.
      * </p>
      *
      * @return a int.
@@ -253,7 +253,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumFilePermission
+     * getNumFilePermission.
      * </p>
      *
      * @return a int.
@@ -264,7 +264,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumSerializablePermission
+     * getNumSerializablePermission.
      * </p>
      *
      * @return a int.
@@ -275,7 +275,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumReflectPermission
+     * getNumReflectPermission.
      * </p>
      *
      * @return a int.
@@ -286,7 +286,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumRuntimePermission
+     * getNumRuntimePermission.
      * </p>
      *
      * @return a int.
@@ -297,7 +297,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumNetPermission
+     * getNumNetPermission.
      * </p>
      *
      * @return a int.
@@ -308,7 +308,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumSocketPermission
+     * getNumSocketPermission.
      * </p>
      *
      * @return a int.
@@ -319,7 +319,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumSQLPermission
+     * getNumSQLPermission.
      * </p>
      *
      * @return a int.
@@ -330,7 +330,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumPropertyPermission
+     * getNumPropertyPermission.
      * </p>
      *
      * @return a int.
@@ -341,7 +341,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumLoggingPermission
+     * getNumLoggingPermission.
      * </p>
      *
      * @return a int.
@@ -352,7 +352,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumSSLPermission
+     * getNumSSLPermission.
      * </p>
      *
      * @return a int.
@@ -363,7 +363,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumAuthPermission
+     * getNumAuthPermission.
      * </p>
      *
      * @return a int.
@@ -377,7 +377,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumAudioPermission
+     * getNumAudioPermission.
      * </p>
      *
      * @return a int.
@@ -388,7 +388,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * getNumOtherPermission
+     * getNumOtherPermission.
      * </p>
      *
      * @return a int.
@@ -404,15 +404,16 @@ public class PermissionStatistics {
                 + getNumAuthPermission() + getNumAudioPermission();
 
         int total = 0;
-        for (int i : deniedClassCount.values())
+        for (int i : deniedClassCount.values()) {
             total += i;
+        }
 
         return total - sum;
     }
 
     /**
      * <p>
-     * hasDeniedPermissions
+     * hasDeniedPermissions.
      * </p>
      *
      * @return a boolean.
@@ -423,7 +424,7 @@ public class PermissionStatistics {
 
     /**
      * <p>
-     * printStatistics
+     * printStatistics.
      * </p>
      */
     public void printStatistics(Logger inputLog) {
@@ -461,7 +462,7 @@ public class PermissionStatistics {
     }
 
     /**
-     * This is needed due to caching
+     * This is needed due to caching.
      */
     private void forcePermissionInit() {
         getNumAllPermission();
@@ -494,7 +495,8 @@ public class PermissionStatistics {
      * @param numThreads a int.
      */
     public void countThreads(int numThreads) {
-        if (threadGroupToMonitor != null && Thread.currentThread().getThreadGroup().getName().equals(threadGroupToMonitor)) {
+        if (threadGroupToMonitor != null
+                && Thread.currentThread().getThreadGroup().getName().equals(threadGroupToMonitor)) {
             maxThreads = Math.max(maxThreads, numThreads);
         }
     }

--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/Sandbox.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/Sandbox.java
@@ -52,8 +52,8 @@ public class Sandbox {
             System.setSecurityManager(current);
         } catch (UnsupportedOperationException e) {
             supported = false;
-            logger.warn("Security Manager is not supported in this JVM (Java 24+). " +
-                    "Sandbox functionality will be disabled.");
+            logger.warn("Security Manager is not supported in this JVM (Java 24+). "
+                    + "Sandbox functionality will be disabled.");
         } catch (SecurityException e) {
             // Security Manager is supported but we don't have permission to change it
             // This is fine - we'll handle it when we actually try to apply our manager
@@ -63,6 +63,7 @@ public class Sandbox {
 
     /**
      * Returns whether Security Manager is supported in this JVM.
+     *
      * @return true if Security Manager can be used, false otherwise (Java 24+)
      */
     public static boolean isSecurityManagerSupported() {
@@ -79,6 +80,7 @@ public class Sandbox {
      * Problem is, that we do compile and run the JUnit test cases (eg
      * to see if they compile with no problems, if their assertions
      * are stable, etc), and those test cases do init/reset the sandbox
+     * </p>
      */
     private static volatile int counter;
 
@@ -89,7 +91,7 @@ public class Sandbox {
     }
 
     /**
-     * Create and initialize security manager for SUT
+     * Create and initialize security manager for SUT.
      */
     public static synchronized void initializeSecurityManagerForSUT(Set<Thread> privileged) {
         if (!SECURITY_MANAGER_SUPPORTED) {
@@ -119,20 +121,23 @@ public class Sandbox {
     }
 
     /**
-     * Create and initialize security manager for SUT
+     * Create and initialize security manager for SUT.
      */
     public static synchronized void initializeSecurityManagerForSUT() {
         initializeSecurityManagerForSUT(null);
     }
 
     public static void addPrivilegedThread(Thread t) {
-        if (manager != null)
+        if (manager != null) {
             manager.addPrivilegedThread(t);
+        }
     }
 
     /**
+     * Reset default security manager.
+     *
      * @return a set of the threads that were marked as privileged. This is useful
-     * if then we want to reactivate the security manager with the same priviliged threads.
+     *     if then we want to reactivate the security manager with the same priviliged threads.
      */
     public static synchronized Set<Thread> resetDefaultSecurityManager() {
 


### PR DESCRIPTION
Applied checkstyle fixes to `MSecurityManager.java`, `PermissionStatistics.java`, and `Sandbox.java` in the `org.evosuite.runtime.sandbox` package. The changes resolve all reported violations from the `maven-checkstyle-plugin` related to Javadoc formatting, code style (braces, line length, operator wrapping), and indentation. No logic was altered. Tests were run, and existing failures were confirmed to be environment-related (deprecation of SecurityManager) and unrelated to these style changes.

---
*PR created automatically by Jules for task [3557873594338033203](https://jules.google.com/task/3557873594338033203) started by @gofraser*