### PR TITLE
Fix Checkstyle violations in org.evosuite.graphs.cfg

### DIFF
--- a/client/src/main/java/org/evosuite/graphs/FloydWarshall.java
+++ b/client/src/main/java/org/evosuite/graphs/FloydWarshall.java
@@ -76,10 +76,12 @@ public class FloydWarshall<V, E> {
         // Floyd-Warshall algorithm
         for (int k = 0; k < n; k++) {
             for (int i = 0; i < n; i++) {
-                if (dist[i][k] == Double.POSITIVE_INFINITY) continue;
+                if (dist[i][k] == Double.POSITIVE_INFINITY) {
+                    continue;
+                }
                 for (int j = 0; j < n; j++) {
                     if (dist[k][j] != Double.POSITIVE_INFINITY) {
-                         dist[i][j] = Math.min(dist[i][j], dist[i][k] + dist[k][j]);
+                        dist[i][j] = Math.min(dist[i][j], dist[i][k] + dist[k][j]);
                     }
                 }
             }

--- a/client/src/main/java/org/evosuite/graphs/GraphPool.java
+++ b/client/src/main/java/org/evosuite/graphs/GraphPool.java
@@ -34,13 +34,13 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Gives access to all Graphs computed during CUT analysis such as CFGs created
- * by the CFGGenerator and BytcodeAnalyzer in the CFGMethodAdapter
- * <p>
- * For each CUT and each of their methods a Raw- and an ActualControlFlowGraph
+ * by the CFGGenerator and BytcodeAnalyzer in the CFGMethodAdapter.
+ *
+ * <p>For each CUT and each of their methods a Raw- and an ActualControlFlowGraph
  * instance are stored within this pool. Additionally a ControlDependenceGraph
  * is computed and stored for each such method.
- * <p>
- * This pool also offers the possibility to generate the ClassCallGraph and
+ *
+ * <p>This pool also offers the possibility to generate the ClassCallGraph and
  * ClassControlFlowGraph for a CUT. They represents the call hierarchy and
  * interaction of different methods within a class.
  *
@@ -55,7 +55,7 @@ public class GraphPool {
     private final ClassLoader classLoader;
 
     /**
-     * Private constructor
+     * Private constructor.
      */
     private GraphPool(ClassLoader classLoader) {
         this.classLoader = classLoader;
@@ -70,12 +70,12 @@ public class GraphPool {
 
     /**
      * Complete control flow graph, contains each bytecode instruction, each
-     * label and line number node Think of the direct Known Subclasses of
+     * label and line number node. Think of the direct Known Subclasses of
      * http://
      * asm.ow2.org/asm33/javadoc/user/org/objectweb/asm/tree/AbstractInsnNode
-     * .html for a complete list of the nodes in this cfg
-     * <p>
-     * Maps from classNames to methodNames to corresponding RawCFGs
+     * .html for a complete list of the nodes in this cfg.
+     *
+     * <p>Maps from classNames to methodNames to corresponding RawCFGs.
      */
     private final Map<String, Map<String, RawControlFlowGraph>> rawCFGs = new ConcurrentHashMap<>();
 
@@ -83,22 +83,22 @@ public class GraphPool {
      * Minimized control flow graph. This graph only contains the first and last
      * node (usually a LABEL and IRETURN), nodes which create branches (all
      * jumps/switches except GOTO) and nodes which were mutated.
-     * <p>
-     * Maps from classNames to methodNames to corresponding ActualCFGs
+     *
+     * <p>Maps from classNames to methodNames to corresponding ActualCFGs.
      */
     private final Map<String, Map<String, ActualControlFlowGraph>> actualCFGs = new ConcurrentHashMap<>();
 
     /**
      * Control Dependence Graphs for each method.
-     * <p>
-     * Maps from classNames to methodNames to corresponding CDGs
+     *
+     * <p>Maps from classNames to methodNames to corresponding CDGs.
      */
     private final Map<String, Map<String, ControlDependenceGraph>> controlDependencies = new ConcurrentHashMap<>();
 
     /**
-     * Cache of all created CCFGs
-     * <p>
-     * Maps from classNames to computed CCFG of that class
+     * Cache of all created CCFGs.
+     *
+     * <p>Maps from classNames to computed CCFG of that class.
      */
     private final Map<String, ClassControlFlowGraph> ccfgs = new ConcurrentHashMap<>();
 
@@ -150,7 +150,7 @@ public class GraphPool {
 
     /**
      * <p>
-     * getActualCFG
+     * getActualCFG.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -160,15 +160,16 @@ public class GraphPool {
     public ActualControlFlowGraph getActualCFG(String className, String methodName) {
 
         Map<String, ActualControlFlowGraph> methods = actualCFGs.get(className);
-        if (methods == null)
+        if (methods == null) {
             return null;
+        }
 
         return methods.get(methodName);
     }
 
     /**
      * <p>
-     * getCDG
+     * getCDG.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -178,8 +179,9 @@ public class GraphPool {
     public ControlDependenceGraph getCDG(String className, String methodName) {
 
         Map<String, ControlDependenceGraph> methods = controlDependencies.get(className);
-        if (methods == null)
+        if (methods == null) {
             return null;
+        }
 
         return methods.get(methodName);
     }
@@ -187,9 +189,7 @@ public class GraphPool {
     // register graphs
 
     /**
-     * <p>
-     * registerRawCFG
-     * </p>
+     * Registers the given RawControlFlowGraph.
      *
      * @param cfg a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
      */
@@ -197,23 +197,24 @@ public class GraphPool {
         String className = cfg.getClassName();
         String methodName = cfg.getMethodName();
 
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalStateException(
                     "expect class and method name of CFGs to be set before entering the GraphPool");
+        }
 
-        Map<String, RawControlFlowGraph> methods = rawCFGs.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
+        Map<String, RawControlFlowGraph> methods =
+                rawCFGs.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
         logger.debug("Added complete CFG for class " + className + " and method "
                 + methodName);
         methods.put(methodName, cfg);
 
-        if (Properties.WRITE_CFG)
+        if (Properties.WRITE_CFG) {
             cfg.toDot();
+        }
     }
 
     /**
-     * <p>
-     * registerActualCFG
-     * </p>
+     * Registers the given ActualControlFlowGraph.
      *
      * @param cfg a {@link org.evosuite.graphs.cfg.ActualControlFlowGraph}
      *            object.
@@ -222,17 +223,20 @@ public class GraphPool {
         String className = cfg.getClassName();
         String methodName = cfg.getMethodName();
 
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalStateException(
                     "expect class and method name of CFGs to be set before entering the GraphPool");
+        }
 
-        Map<String, ActualControlFlowGraph> methods = actualCFGs.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
+        Map<String, ActualControlFlowGraph> methods =
+                actualCFGs.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
         logger.debug("Added CFG for class " + className + " and method " + methodName);
         cfg.finalise();
         methods.put(methodName, cfg);
 
-        if (Properties.WRITE_CFG)
+        if (Properties.WRITE_CFG) {
             cfg.toDot();
+        }
 
         if (DependencyAnalysis.shouldInstrument(cfg.getClassName(), cfg.getMethodName())) {
             createAndRegisterControlDependence(cfg);
@@ -246,15 +250,18 @@ public class GraphPool {
         String className = cd.getClassName();
         String methodName = cd.getMethodName();
 
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalStateException(
                     "expect class and method name of CFGs to be set before entering the GraphPool");
+        }
 
-        Map<String, ControlDependenceGraph> cds = controlDependencies.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
+        Map<String, ControlDependenceGraph> cds =
+                controlDependencies.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
 
         cds.put(methodName, cd);
-        if (Properties.WRITE_CFG)
+        if (Properties.WRITE_CFG) {
             cd.toDot();
+        }
     }
 
     /**
@@ -264,47 +271,48 @@ public class GraphPool {
      * @param className the name of the class of the CCFG as a
      *                  {@link java.lang.String}
      * @return The cached CCFG of type
-     * {@link org.evosuite.graphs.ccfg.ClassControlFlowGraph}
+     *     {@link org.evosuite.graphs.ccfg.ClassControlFlowGraph}
      */
     public ClassControlFlowGraph getCCFG(String className) {
         return ccfgs.computeIfAbsent(className, this::computeCCFG);
     }
 
     public boolean canMakeCCFGForClass(String className) {
-        //		if(!rawCFGs.containsKey(className))
-        //			LoggingUtils.getEvoLogger().info("unable to create CCFG for "+className);
+        // if(!rawCFGs.containsKey(className))
+        // LoggingUtils.getEvoLogger().info("unable to create CCFG for "+className);
         return rawCFGs.containsKey(className);
     }
 
     /**
-     * Computes the CCFG for the given class
-     * <p>
-     * If no CFG is known for the given class, an IllegalArgumentException is
+     * Computes the CCFG for the given class.
+     *
+     * <p>If no CFG is known for the given class, an IllegalArgumentException is
      * thrown
      *
      * @param className a {@link java.lang.String} object.
      * @return a {@link org.evosuite.graphs.ccfg.ClassControlFlowGraph} object.
      */
     private ClassControlFlowGraph computeCCFG(String className) {
-        if (rawCFGs.get(className) == null)
+        if (rawCFGs.get(className) == null) {
             throw new IllegalArgumentException(
                     "can't compute CCFG, don't know CFGs for class " + className);
+        }
 
         ClassCallGraph ccg = new ClassCallGraph(classLoader, className);
-        if (Properties.WRITE_CFG)
+        if (Properties.WRITE_CFG) {
             ccg.toDot();
+        }
 
         ClassControlFlowGraph ccfg = new ClassControlFlowGraph(ccg);
-        if (Properties.WRITE_CFG)
+        if (Properties.WRITE_CFG) {
             ccfg.toDot();
+        }
 
         return ccfg;
     }
 
     /**
-     * <p>
-     * clear
-     * </p>
+     * Clears all graphs.
      */
     public void clear() {
         rawCFGs.clear();
@@ -313,9 +321,7 @@ public class GraphPool {
     }
 
     /**
-     * <p>
-     * clear
-     * </p>
+     * Clears graphs for the given class.
      *
      * @param className a {@link java.lang.String} object.
      */
@@ -326,20 +332,21 @@ public class GraphPool {
     }
 
     /**
-     * <p>
-     * clear
-     * </p>
+     * Clears graphs for the given class and method.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
      */
     public void clear(String className, String methodName) {
-        if (rawCFGs.containsKey(className))
+        if (rawCFGs.containsKey(className)) {
             rawCFGs.get(className).remove(methodName);
-        if (actualCFGs.containsKey(className))
+        }
+        if (actualCFGs.containsKey(className)) {
             actualCFGs.get(className).remove(methodName);
-        if (controlDependencies.containsKey(className))
+        }
+        if (controlDependencies.containsKey(className)) {
             controlDependencies.get(className).remove(methodName);
+        }
     }
 
     public static void clearAll(String className) {

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGCodeEdge.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGCodeEdge.java
@@ -61,16 +61,21 @@ public class CCFGCodeEdge extends CCFGEdge {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGCodeEdge other = (CCFGCodeEdge) obj;
         if (cfgEdge == null) {
             return other.cfgEdge == null;
-        } else return cfgEdge.equals(other.cfgEdge);
+        } else {
+            return cfgEdge.equals(other.cfgEdge);
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGCodeNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGCodeNode.java
@@ -35,7 +35,7 @@ public class CCFGCodeNode extends CCFGNode {
     }
 
     /**
-     * <p>getMethod</p>
+     * <p>getMethod.</p>
      *
      * @return a {@link java.lang.String} object.
      */
@@ -69,16 +69,21 @@ public class CCFGCodeNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGCodeNode other = (CCFGCodeNode) obj;
         if (codeInstruction == null) {
             return other.codeInstruction == null;
-        } else return codeInstruction.equals(other.codeInstruction);
+        } else {
+            return codeInstruction.equals(other.codeInstruction);
+        }
     }
 
     /**
@@ -86,9 +91,10 @@ public class CCFGCodeNode extends CCFGNode {
      */
     @Override
     public String toString() {
-        if (codeInstruction.isMethodCall())
+        if (codeInstruction.isMethodCall()) {
             return codeInstruction.toString() + " in class " + codeInstruction.getCalledMethodsClass();
-        else
+        } else {
             return codeInstruction.toString();
+        }
     }
 }

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGFieldClassCallNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGFieldClassCallNode.java
@@ -32,15 +32,16 @@ public class CCFGFieldClassCallNode extends CCFGCodeNode {
     private final String methodName;
     private final String methodParameters;
 
-
-//	
-
     /**
      * <p>Constructor for CCFGFieldClassCallNode.</p>
      *
      * @param code a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
+     * @param className a {@link java.lang.String} object.
+     * @param methodName a {@link java.lang.String} object.
+     * @param methodParameters a {@link java.lang.String} object.
      */
-    public CCFGFieldClassCallNode(BytecodeInstruction code, String className, String methodName, String methodParameters) {
+    public CCFGFieldClassCallNode(BytecodeInstruction code, String className, String methodName,
+                                  String methodParameters) {
         super(code);
         this.className = className;
         this.methodName = methodName;
@@ -48,6 +49,8 @@ public class CCFGFieldClassCallNode extends CCFGCodeNode {
     }
 
     /**
+     * Returns the class name.
+     *
      * @return the className
      */
     public String getClassName() {
@@ -55,6 +58,8 @@ public class CCFGFieldClassCallNode extends CCFGCodeNode {
     }
 
     /**
+     * Returns the method name with parameters.
+     *
      * @return the methodName
      */
     public String getMethodName() {
@@ -85,26 +90,35 @@ public class CCFGFieldClassCallNode extends CCFGCodeNode {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (!super.equals(obj))
+        }
+        if (!super.equals(obj)) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGFieldClassCallNode other = (CCFGFieldClassCallNode) obj;
         if (className == null) {
-            if (other.className != null)
+            if (other.className != null) {
                 return false;
-        } else if (!className.equals(other.className))
+            }
+        } else if (!className.equals(other.className)) {
             return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null)
+            if (other.methodName != null) {
                 return false;
-        } else if (!methodName.equals(other.methodName))
+            }
+        } else if (!methodName.equals(other.methodName)) {
             return false;
+        }
         if (methodParameters == null) {
             return other.methodParameters == null;
-        } else return methodParameters.equals(other.methodParameters);
+        } else {
+            return methodParameters.equals(other.methodParameters);
+        }
     }
 
 

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGFrameNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGFrameNode.java
@@ -57,15 +57,19 @@ public class CCFGFrameNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGFrameNode other = (CCFGFrameNode) obj;
-        if (type != other.type)
+        if (type != other.type) {
             return false;
+        }
         return true;
     }
 

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodCallEdge.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodCallEdge.java
@@ -30,9 +30,7 @@ public class CCFGMethodCallEdge extends CCFGEdge {
     private final boolean isCallingEdge;
 
     /**
-     * <p>
-     * Constructor for CCFGMethodCallEdge.
-     * </p>
+     * Constructs a CCFGMethodCallEdge.
      *
      * @param callInstruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @param isCallingEdge   a boolean.
@@ -43,7 +41,7 @@ public class CCFGMethodCallEdge extends CCFGEdge {
     }
 
     /**
-     * Marks whether this is a calling edge or a returning edge
+     * Marks whether this is a calling edge or a returning edge.
      *
      * @return a boolean.
      */

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodCallNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodCallNode.java
@@ -38,7 +38,7 @@ public class CCFGMethodCallNode extends CCFGNode {
     }
 
     /**
-     * <p>getMethod</p>
+     * <p>getMethod.</p>
      *
      * @return a {@link java.lang.String} object.
      */
@@ -47,7 +47,7 @@ public class CCFGMethodCallNode extends CCFGNode {
     }
 
     /**
-     * <p>getCalledMethod</p>
+     * <p>getCalledMethod.</p>
      *
      * @return a {@link java.lang.String} object.
      */
@@ -92,21 +92,28 @@ public class CCFGMethodCallNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGMethodCallNode other = (CCFGMethodCallNode) obj;
         if (callInstruction == null) {
-            if (other.callInstruction != null)
+            if (other.callInstruction != null) {
                 return false;
-        } else if (!callInstruction.equals(other.callInstruction))
+            }
+        } else if (!callInstruction.equals(other.callInstruction)) {
             return false;
+        }
         if (returnNode == null) {
             return other.returnNode == null;
-        } else return returnNode.equals(other.returnNode);
+        } else {
+            return returnNode.equals(other.returnNode);
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodEntryNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodEntryNode.java
@@ -72,21 +72,28 @@ public class CCFGMethodEntryNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGMethodEntryNode other = (CCFGMethodEntryNode) obj;
         if (entryInstruction == null) {
-            if (other.entryInstruction != null)
+            if (other.entryInstruction != null) {
                 return false;
-        } else if (!entryInstruction.equals(other.entryInstruction))
+            }
+        } else if (!entryInstruction.equals(other.entryInstruction)) {
             return false;
+        }
         if (method == null) {
             return other.method == null;
-        } else return method.equals(other.method);
+        } else {
+            return method.equals(other.method);
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodExitNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodExitNode.java
@@ -33,14 +33,15 @@ public class CCFGMethodExitNode extends CCFGNode {
     }
 
     /**
-     * <p>isExitOfMethodEntry</p>
+     * <p>isExitOfMethodEntry.</p>
      *
      * @param methodEntry a {@link org.evosuite.graphs.ccfg.CCFGMethodEntryNode} object.
      * @return a boolean.
      */
     public boolean isExitOfMethodEntry(CCFGMethodEntryNode methodEntry) {
-        if (methodEntry == null)
+        if (methodEntry == null) {
             return false;
+        }
         return methodEntry.getMethod().equals(method);
     }
 
@@ -69,16 +70,21 @@ public class CCFGMethodExitNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGMethodExitNode other = (CCFGMethodExitNode) obj;
         if (method == null) {
             return other.method == null;
-        } else return method.equals(other.method);
+        } else {
+            return method.equals(other.method);
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodReturnNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGMethodReturnNode.java
@@ -35,7 +35,7 @@ public class CCFGMethodReturnNode extends CCFGNode {
     }
 
     /**
-     * <p>getMethod</p>
+     * <p>getMethod.</p>
      *
      * @return a {@link java.lang.String} object.
      */
@@ -69,16 +69,21 @@ public class CCFGMethodReturnNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CCFGMethodReturnNode other = (CCFGMethodReturnNode) obj;
         if (callInstruction == null) {
             return other.callInstruction == null;
-        } else return callInstruction.equals(other.callInstruction);
+        } else {
+            return callInstruction.equals(other.callInstruction);
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/ccfg/CCFGNodeAttributeProvider.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/CCFGNodeAttributeProvider.java
@@ -75,14 +75,14 @@ public class CCFGNodeAttributeProvider implements ComponentAttributeProvider<CCF
     private String generateSaturatedColor(Object obj) {
 
         float h = Math.abs(obj.hashCode() / (float) Integer.MAX_VALUE);
-//		return h+",0.75,0.65";
+        // return h+",0.75,0.65";
         return h + ",0.85,0.55";
     }
 
     private String generateBColor(Object obj) {
 
         float h = Math.abs(obj.hashCode() / (float) Integer.MAX_VALUE);
-//		return h+",0.75,0.65";
+        // return h+",0.75,0.65";
         return h + ",0.85,0.95";
     }
 

--- a/client/src/main/java/org/evosuite/graphs/ccfg/ClassControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/ccfg/ClassControlFlowGraph.java
@@ -33,17 +33,17 @@ import java.util.*;
 
 /**
  * This class computes the Class Control Flow Graph (CCFG) of a CUT.
- * <p>
- * Given the ClassCallGraph the CCFG is generated as follows:
- * <p>
- * The RawControlFlowGraph (CFG) of each method in the target class is retrieved
+ *
+ * <p>Given the ClassCallGraph the CCFG is generated as follows:
+ *
+ * <p>The RawControlFlowGraph (CFG) of each method in the target class is retrieved
  * from the GraphPool and imported into this CCFG. BytecodeInstructions are
  * imported as CCFGCodeNodes and ControlFlowEdges as CCFGCodeEdges. Additionally
  * each CFG is enclosed by a CCFGMethodEntryNode and CCFGMethodExitNode with an
  * edge from the entry node to the first instruction in the CFG and an edge from
  * each exit instruction in the CFG to the exit node.
- * <p>
- * After that each method call instruction as defined in
+ *
+ * <p>After that each method call instruction as defined in
  * BytecodeInstruction.isMethodCall() is replaced by two new nodes
  * CCFGMethodCallNode and CCFGMethodReturnNode that are labeled with that call
  * instruction. Each incoming edge to the previous CCFGCodeNode is redirected to
@@ -56,23 +56,23 @@ import java.util.*;
  * methods - as defined by BytecodeInstruction.isStaticMethodCall() - or calls
  * to methods on the same object (this) as defined by
  * BytecodeInstruction.isMethodCallOnSameObject().
- * <p>
- * All this is enclosed by a frame consisting of five CCFGFrameNodes of
+ *
+ * <p>All this is enclosed by a frame consisting of five CCFGFrameNodes of
  * different types. This frame has two dedicated ENTRY and EXIT nodes connected
  * via a third node LOOP. The LOOP node has an outgoing edge to CALL which in
  * turn has an outgoing edge to each CCFGMethodEntryNode of each public method
  * in this graph. Analogously the CCFGMethodExitNode of each public method has
  * an outgoing edge to the CCFGFrameNode RETURN which in turn has an outgoing
  * edge back to LOOP. All these edges are CCFGFrameEdges.
- * <p>
- * The frame simulates the possible calls to the CUT a test can potentially
+ *
+ * <p>The frame simulates the possible calls to the CUT a test can potentially
  * make. After starting (ENTRY->LOOP) a test can make arbitrary calls to public
  * methods (LOOP->CALL) that can in turn call other methods of the class
  * (CCFGMethodCallEdges). After returning from a public method call
  * (RETURN->LOOP) the test can either make more calls to the class (LOOP->CALL)
  * or stop (LOOP->EXIT).
- * <p>
- * The construction of the CCFG is inspired by: Proc. of the Second ACM SIGSOFT
+ *
+ * <p>The construction of the CCFG is inspired by: Proc. of the Second ACM SIGSOFT
  * Symp. on the Foundations of Softw. Eng., December 1994, pages 154-164
  * "Performing Data Flow Testing on Classes" Mary Jean Harrold and Gregg
  * Rothermel, Section 5. The resulting CCFG should be as described in the paper
@@ -131,10 +131,11 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
     // purity analysis
 
     public boolean isPure(String methodName) {
-        if (pureMethods.contains(methodName))
+        if (pureMethods.contains(methodName)) {
             return true;
-        else if (impureMethods.contains(methodName))
+        } else if (impureMethods.contains(methodName)) {
             return false;
+        }
 
         boolean isPure = analyzePurity(methodName);
         if (isPure) {
@@ -203,16 +204,18 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
                 }
             } else {
 
-                //The format that ASM for types and the one used in my data file is different: in particular ASM uses the
-                //Class.getName format for types see http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getName(), while the data
-                //file with the pure methods uses the qualified name.
-                //For instance, in my file is: java.blabla.ClassExample.method(java.util.List,java.lang.Class[])
-                //ASM returns java.blabla.ClassExample.method(Ljava.util.List;[Ljava.lang.Class)V.
-                //The conversion from qualified name to the JVM/ASM format is not so straightforward,
-                //well it's not a very complicate problem but there some corner cases that I have to check.
-                //In the mean time this method convert the ASM/JVM format into the normal one, using an utility
-                //of ASM.
-                //The file with the method list is in src/resources, it SHOULD be accurate but not perfect, some methods are missing for sure.
+                // The format that ASM for types and the one used in my data file is different: in particular
+                // ASM uses the Class.getName format for types see
+                // http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getName(), while the data
+                // file with the pure methods uses the qualified name.
+                // For instance, in my file is: java.blabla.ClassExample.method(java.util.List,java.lang.Class[])
+                // ASM returns java.blabla.ClassExample.method(Ljava.util.List;[Ljava.lang.Class)V.
+                // The conversion from qualified name to the JVM/ASM format is not so straightforward,
+                // well it's not a very complicate problem but there some corner cases that I have to check.
+                // In the mean time this method convert the ASM/JVM format into the normal one, using an utility
+                // of ASM.
+                // The file with the method list is in src/resources, it SHOULD be accurate but not perfect,
+                // some methods are missing for sure.
 
                 if (toAnalyze.startsWith("java.")) {
 
@@ -224,7 +227,8 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
                         }
                         newParams.deleteCharAt(0);
                     }
-                    toAnalyze = fieldCall.getClassName() + "." + fieldCall.getOnlyMethodName() + "(" + newParams + ")";
+                    toAnalyze = fieldCall.getClassName() + "." + fieldCall.getOnlyMethodName()
+                            + "(" + newParams + ")";
 
                     return JdkPureMethodsList.instance.checkPurity(toAnalyze);
                 }
@@ -235,19 +239,21 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
             CCFGCodeNode codeNode = (CCFGCodeNode) currentNode;
             // it this node alters the state of this object this method is
             // impure
-            if (codeNode.getCodeInstruction().isFieldDefinition())
+            if (codeNode.getCodeInstruction().isFieldDefinition()) {
                 return false;
+            }
             // otherwise proceed
         } else if (currentNode instanceof CCFGMethodExitNode) {
             CCFGMethodExitNode methodExit = (CCFGMethodExitNode) currentNode;
             // if we encounter the end of the analyzed method and have not
             // detected
             // impurity yet then the method is pure
-            if (methodExit.getMethod().equals(analyzedMethod))
+            if (methodExit.getMethod().equals(analyzedMethod)) {
                 return true;
-            else
+            } else {
                 throw new IllegalStateException(
                         "MethodExitNodes from methods other then the currently analyzed one should not be reached");
+            }
         } else if (currentNode instanceof CCFGMethodCallNode) {
             CCFGMethodCallNode callNode = (CCFGMethodCallNode) currentNode;
             // avoid loops in analysis
@@ -256,22 +262,25 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
                 // if another method of this class is called check that
                 // method
                 // it the called method is impure then this method is impure
-                if (!isPure(callNode.getCalledMethod()))
+                if (!isPure(callNode.getCalledMethod())) {
                     return false;
+                }
             }
             // otherwise proceed after the method call has taken place
             nextNode = callNode.getReturnNode();
         } else if (currentNode instanceof CCFGMethodEntryNode) {
             // do nothing special
-        } else
+        } else {
             throw new IllegalStateException(
                     "purity analysis should not reach this kind of CCFGNode: "
                             + currentNode.getClass().toString());
+        }
 
         Set<CCFGNode> children = getChildren(nextNode);
         for (CCFGNode child : children) {
-            if (!analyzePurity(analyzedMethod, child, handled))
+            if (!analyzePurity(analyzedMethod, child, handled)) {
                 return false;
+            }
         }
 
         // no child was impure so this method is pure
@@ -282,15 +291,17 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
 
 
     public boolean isPublicMethod(String method) {
-        if (method == null)
+        if (method == null) {
             return false;
+        }
         CCFGMethodEntryNode entry = getMethodEntryOf(method);
         return isPublicMethod(entry);
     }
 
     public boolean isPublicMethod(CCFGMethodEntryNode node) {
-        if (node == null)
+        if (node == null) {
             return false;
+        }
         return publicMethods.contains(node);
     }
 
@@ -300,17 +311,19 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
     public CCFGMethodEntryNode getMethodEntryNodeForClassCallNode(
             ClassCallNode ccgNode) {
         CCFGMethodEntryNode r = methodEntries.get(ccgNode.getMethod());
-        if (r == null)
+        if (r == null) {
             throw new IllegalStateException(
                     "expect the CCFG to contain a CCFGMethodEntryNode for each node in the corresponding CCG "
                             + ccgNode.getMethod());
+        }
         return r;
     }
 
     private CCFGMethodEntryNode getMethodEntryOf(String method) {
         CCFGMethodEntryNode r = methodEntries.get(method);
-        if (r == null)
+        if (r == null) {
             throw new IllegalArgumentException("unknown method: " + method);
+        }
         return r;
 
     }
@@ -321,30 +334,32 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
 
     /**
      * <p>
-     * getMethodExitOf
+     * getMethodExitOf.
      * </p>
      *
      * @param methodEntry a {@link org.evosuite.graphs.ccfg.CCFGMethodEntryNode} object.
      * @return a {@link org.evosuite.graphs.ccfg.CCFGMethodExitNode} object.
      */
     public CCFGMethodExitNode getMethodExitOf(CCFGMethodEntryNode methodEntry) {
-        if (methodEntry == null)
+        if (methodEntry == null) {
             return null;
+        }
 
         return methodExits.get(methodEntry.getMethod());
     }
 
     /**
      * <p>
-     * getMethodEntryOf
+     * getMethodEntryOf.
      * </p>
      *
      * @param methodExit a {@link org.evosuite.graphs.ccfg.CCFGMethodExitNode} object.
      * @return a {@link org.evosuite.graphs.ccfg.CCFGMethodEntryNode} object.
      */
     public CCFGMethodEntryNode getMethodEntryOf(CCFGMethodExitNode methodExit) {
-        if (methodExit == null)
+        if (methodExit == null) {
             return null;
+        }
 
         return methodEntries.get(methodExit.getMethod());
     }
@@ -410,9 +425,10 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
         // redirect edges from the original CodeNode to the new nodes
         CCFGNode origCallNode = tempMap.get(cfg).get(call);
         if (!redirectEdges(origCallNode, callNode, returnNode)
-                || !graph.removeVertex(origCallNode))
+                || !graph.removeVertex(origCallNode)) {
             throw new IllegalStateException(
                     "internal error while connecting cfgs during CCFG construction");
+        }
     }
 
     private Map<BytecodeInstruction, CCFGCodeNode> importCFG(
@@ -431,10 +447,10 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
     /**
      * import CFGs nodes. If the node is a method call to a method of a field
      * class, a new CCFGFieldClassCallNode is created. Otherwise, a normal
-     * CCFGCodeNode is created
+     * CCFGCodeNode is created.
      *
-     * @param cfg
-     * @param temp
+     * @param cfg a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
+     * @param temp a {@link java.util.Map} object.
      */
     private void importCFGNodes(RawControlFlowGraph cfg,
                                 Map<BytecodeInstruction, CCFGCodeNode> temp) {
@@ -444,7 +460,8 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
             CCFGCodeNode node;
             if (code.isMethodCallOfField()) {
                 node = new CCFGFieldClassCallNode(code,
-                        code.getCalledMethodsClass(), code.getCalledMethodName(), code.getMethodCallDescriptor());
+                        code.getCalledMethodsClass(), code.getCalledMethodName(),
+                        code.getMethodCallDescriptor());
             } else {
                 node = new CCFGCodeNode(code);
             }
@@ -458,8 +475,9 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
 
         // add ControlFlowEdges as CCFGCodeEdges
         for (ControlFlowEdge e : cfg.edgeSet()) {
-            if (e.isExceptionEdge())
+            if (e.isExceptionEdge()) {
                 continue;
+            }
             CCFGCodeNode src = temp.get(cfg.getEdgeSource(e));
             CCFGCodeNode target = temp.get(cfg.getEdgeTarget(e));
             addEdge(src, target, new CCFGCodeEdge(e));
@@ -526,7 +544,7 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
 
     /**
      * <p>
-     * getFrameNode
+     * getFrameNode.
      * </p>
      *
      * @param type a
@@ -562,7 +580,7 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
 
     /**
      * Makes .dot output pretty by visualizing different types of nodes and
-     * edges with different forms and colors
+     * edges with different forms and colors.
      */
     private void nicenDotOutput() {
         registerVertexAttributeProvider(new CCFGNodeAttributeProvider());
@@ -586,6 +604,8 @@ public class ClassControlFlowGraph extends EvoSuiteGraph<CCFGNode, CCFGEdge> {
     }
 
     /**
+     * Returns the underlying ClassCallGraph.
+     *
      * @return the ccg
      */
     public ClassCallGraph getCcg() {

--- a/client/src/main/java/org/evosuite/graphs/ccg/ClassCallEdge.java
+++ b/client/src/main/java/org/evosuite/graphs/ccg/ClassCallEdge.java
@@ -31,7 +31,7 @@ public class ClassCallEdge extends DefaultEdge {
     private final BytecodeInstruction callInstruction;
 
     /**
-     * <p>Constructor for ClassCallEdge.</p>
+     * Constructor for ClassCallEdge.
      *
      * @param callInstruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      */
@@ -61,10 +61,12 @@ public class ClassCallEdge extends DefaultEdge {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null || getClass() != obj.getClass())
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
+        }
         ClassCallEdge other = (ClassCallEdge) obj;
         return Objects.equals(callInstruction, other.callInstruction);
     }

--- a/client/src/main/java/org/evosuite/graphs/ccg/ClassCallGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/ccg/ClassCallGraph.java
@@ -31,11 +31,11 @@ import java.util.TreeMap;
 
 /**
  * Represents the method call structure of a class in a graph.
- * <p>
- * The graph contains a node for each of the classes methods with edges going
+ *
+ * <p>The graph contains a node for each of the classes methods with edges going
  * from a method node to each of its called methods.
- * <p>
- * Edges are labeled with the BytecodeInstruction of the corresponding call.
+ *
+ * <p>Edges are labeled with the BytecodeInstruction of the corresponding call.
  *
  * @author Andre Mis
  */
@@ -48,6 +48,8 @@ public class ClassCallGraph extends EvoSuiteGraph<ClassCallNode, ClassCallEdge> 
     private final Map<String, ClassCallNode> methodToNodeMap = new HashMap<>();
 
     /**
+     * Returns the class loader.
+     *
      * @return the classLoader
      */
     public ClassLoader getClassLoader() {
@@ -55,9 +57,7 @@ public class ClassCallGraph extends EvoSuiteGraph<ClassCallNode, ClassCallEdge> 
     }
 
     /**
-     * <p>
      * Constructor for ClassCallGraph.
-     * </p>
      *
      * @param className a {@link java.lang.String} object.
      */
@@ -73,9 +73,10 @@ public class ClassCallGraph extends EvoSuiteGraph<ClassCallNode, ClassCallEdge> 
     private void compute() {
         Map<String, RawControlFlowGraph> cfgs = GraphPool.getInstance(classLoader).getRawCFGs(className);
 
-        if (cfgs == null)
+        if (cfgs == null) {
             throw new IllegalStateException(
                     "Did not find CFGs for class " + className + " to compute the CCG of");
+        }
 
         // Use TreeMap for deterministic iteration order
         Map<String, RawControlFlowGraph> sortedCfgs = new TreeMap<>(cfgs);
@@ -105,9 +106,7 @@ public class ClassCallGraph extends EvoSuiteGraph<ClassCallNode, ClassCallEdge> 
     }
 
     /**
-     * <p>
-     * getNodeByMethodName
-     * </p>
+     * Returns the node for the given method name.
      *
      * @param methodName a {@link java.lang.String} object.
      * @return a {@link org.evosuite.graphs.ccg.ClassCallNode} object.
@@ -117,9 +116,7 @@ public class ClassCallGraph extends EvoSuiteGraph<ClassCallNode, ClassCallEdge> 
     }
 
     /**
-     * <p>
      * Getter for the field <code>className</code>.
-     * </p>
      *
      * @return a {@link java.lang.String} object.
      */

--- a/client/src/main/java/org/evosuite/graphs/ccg/ClassCallNode.java
+++ b/client/src/main/java/org/evosuite/graphs/ccg/ClassCallNode.java
@@ -37,7 +37,7 @@ public class ClassCallNode extends CCFGNode {
     }
 
     /**
-     * <p>Constructor for ClassCallNode.</p>
+     * Constructor for ClassCallNode.
      *
      * @param method a {@link java.lang.String} object.
      */
@@ -58,10 +58,12 @@ public class ClassCallNode extends CCFGNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null || getClass() != obj.getClass())
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
+        }
         ClassCallNode other = (ClassCallNode) obj;
         return Objects.equals(method, other.method);
     }

--- a/client/src/main/java/org/evosuite/graphs/cdg/ControlDependenceGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cdg/ControlDependenceGraph.java
@@ -38,7 +38,7 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
     private final String methodName;
 
     /**
-     * <p>Constructor for ControlDependenceGraph.</p>
+     * Constructor for ControlDependenceGraph.
      *
      * @param cfg a {@link org.evosuite.graphs.cfg.ActualControlFlowGraph} object.
      */
@@ -64,7 +64,7 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
     }
 
     /**
-     * <p>getControlDependenceDepth</p>
+     * Returns the depth of the control dependence.
      *
      * @param dependence a {@link org.evosuite.graphs.cfg.ControlDependency} object.
      * @return a int.
@@ -74,14 +74,15 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         for (BasicBlock root : determineEntryPoints()) {
             int distance = getDistance(root,
                     dependence.getBranch().getInstruction().getBasicBlock());
-            if (distance < min)
+            if (distance < min) {
                 min = distance;
+            }
         }
         return min;
     }
 
     /**
-     * <p>getAlternativeBlocks</p>
+     * Returns the alternative blocks for the given control dependency.
      *
      * @param dependency a {@link org.evosuite.graphs.cfg.ControlDependency} object.
      * @return a {@link java.util.Set} object.
@@ -94,8 +95,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         for (ControlFlowEdge e : outgoingEdgesOf(block)) {
             // ControlDependency can be null on edges that are not control dependent (e.g. unconditional)
             if (e.getControlDependency() == null
-                    || e.getControlDependency().equals(dependency))
+                    || e.getControlDependency().equals(dependency)) {
                 continue;
+            }
             BasicBlock next = getEdgeTarget(e);
             blocks.add(next);
             getReachableBasicBlocks(blocks, next);
@@ -116,8 +118,8 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
     /**
      * Returns a Set containing all Branches the given BasicBlock is control
      * dependent on.
-     * <p>
-     * This is for each incoming ControlFlowEdge of the given block within this
+     *
+     * <p>This is for each incoming ControlFlowEdge of the given block within this
      * CDG, the branch instruction of that edge will be added to the returned
      * set.
      *
@@ -125,17 +127,21 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
      * @return a {@link java.util.Set} object.
      */
     public Set<ControlDependency> getControlDependentBranches(BasicBlock insBlock) {
-        if (insBlock == null)
+        if (insBlock == null) {
             throw new IllegalArgumentException("null not accepted");
-        if (!containsVertex(insBlock))
+        }
+        if (!containsVertex(insBlock)) {
             throw new IllegalArgumentException("unknown block: " + insBlock.getName());
+        }
 
-        if (insBlock.hasControlDependenciesSet())
+        if (insBlock.hasControlDependenciesSet()) {
             return insBlock.getControlDependencies();
+        }
 
         Set<ControlDependency> direct = retrieveControlDependencies(insBlock, new LinkedHashSet<>());
-        if (direct.isEmpty())
+        if (direct.isEmpty()) {
             return direct;
+        }
 
         // Expand with transitive control dependencies (e.g., nested branches).
         Set<ControlDependency> expanded = new LinkedHashSet<>(direct);
@@ -151,8 +157,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
     private void expandTransitiveDependencies(Set<ControlDependency> out,
                                               BasicBlock start,
                                               Set<BasicBlock> visited) {
-        if (start == null || !visited.add(start))
+        if (start == null || !visited.add(start)) {
             return;
+        }
 
         Set<ControlDependency> deps = retrieveControlDependencies(start, new LinkedHashSet<>());
         for (ControlDependency cd : deps) {
@@ -170,8 +177,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         Set<ControlDependency> r = new LinkedHashSet<>();
 
         for (ControlFlowEdge e : incomingEdgesOf(insBlock)) {
-            if (handled.contains(e))
+            if (handled.contains(e)) {
                 continue;
+            }
             handled.add(e);
 
             ControlDependency cd = e.getControlDependency();
@@ -190,7 +198,7 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
     }
 
     /**
-     * <p>getControlDependentBranchIds</p>
+     * Returns the IDs of the control dependent branches.
      *
      * @param ins a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @return a {@link java.util.Set} object.
@@ -202,17 +210,19 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         Set<Integer> r = new LinkedHashSet<>();
 
         for (ControlDependency cd : dependentBranches) {
-            if (cd == null)
+            if (cd == null) {
                 throw new IllegalStateException(
                         "expect set returned by getControlDependentBranches() not to contain null");
+            }
 
             r.add(cd.getBranch().getActualBranchId());
         }
 
         // to indicate this is only dependent on root branch,
         // meaning entering the method
-        if (isRootDependent(ins))
+        if (isRootDependent(ins)) {
             r.add(-1);
+        }
 
         return r;
     }
@@ -223,10 +233,10 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
      * Determines whether the given BytecodeInstruction is directly control
      * dependent on the given Branch. It's BasicBlock is control dependent on
      * the given Branch.
-     * <p>
-     * If b is null, it is assumed to be the root branch.
-     * <p>
-     * If the given instruction is not known to this CDG an
+     *
+     * <p>If b is null, it is assumed to be the root branch.
+     *
+     * <p>If the given instruction is not known to this CDG an
      * IllegalArgumentException is thrown.
      *
      * @param ins a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -234,8 +244,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
      * @return a boolean.
      */
     public boolean isDirectlyControlDependentOn(BytecodeInstruction ins, Branch b) {
-        if (ins == null)
+        if (ins == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         BasicBlock insBlock = ins.getBasicBlock();
 
@@ -247,10 +258,10 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
      * the given Branch. Meaning within this CDG there is an incoming
      * ControlFlowEdge to this instructions BasicBlock holding the given Branch
      * as it's branchInstruction.
-     * <p>
-     * If b is null, it is assumed to be the root branch.
-     * <p>
-     * If the given instruction is not known to this CDG an
+     *
+     * <p>If b is null, it is assumed to be the root branch.
+     *
+     * <p>If the given instruction is not known to this CDG an
      * IllegalArgumentException is thrown.
      *
      * @param insBlock a {@link org.evosuite.graphs.cfg.BasicBlock} object.
@@ -274,27 +285,32 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         }
 
         boolean isRootDependent = isRootDependent(insBlock);
-        if (b == null)
+        if (b == null) {
             return isRootDependent;
-        if (isRootDependent && b != null)
+        }
+        if (isRootDependent && b != null) {
             return false;
+        }
 
         for (ControlFlowEdge e : incomming) {
             Branch current = e.getBranchInstruction();
 
             if (e.isExceptionEdge()) {
-                if (current != null)
+                if (current != null) {
                     throw new IllegalStateException(
                             "expect exception edges to have no BranchInstruction set");
-                else
+                } else {
                     continue;
+                }
             }
 
-            if (current == null)
+            if (current == null) {
                 continue;
+            }
 
-            if (current.equals(b))
+            if (current.equals(b)) {
                 return true;
+            }
         }
 
         return false;
@@ -302,9 +318,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
 
     /**
      * Checks whether the given instruction is dependent on the root branch of
-     * it's method
-     * <p>
-     * This is the case if the BasicBlock of the given instruction is directly
+     * it's method.
+     *
+     * <p>This is the case if the BasicBlock of the given instruction is directly
      * adjacent to the EntryBlock
      *
      * @param ins a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -317,27 +333,31 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
 
     /**
      * Checks whether the given basicBlock is dependent on the root branch of
-     * it's method
-     * <p>
-     * This is the case if the BasicBlock of the given instruction is directly
+     * it's method.
+     *
+     * <p>This is the case if the BasicBlock of the given instruction is directly
      * adjacent to the EntryBlock
      *
      * @param insBlock a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @return a boolean.
      */
     public boolean isRootDependent(BasicBlock insBlock) {
-        if (isAdjacentToEntryBlock(insBlock))
+        if (isAdjacentToEntryBlock(insBlock)) {
             return true;
+        }
 
         for (ControlFlowEdge in : incomingEdgesOf(insBlock)) {
-            if (in.hasControlDependency())
+            if (in.hasControlDependency()) {
                 continue;
+            }
             BasicBlock inBlock = getEdgeSource(in);
-            if (inBlock.equals(insBlock))
+            if (inBlock.equals(insBlock)) {
                 continue;
+            }
 
-            if (isRootDependent(inBlock))
+            if (isRootDependent(inBlock)) {
                 return true;
+            }
         }
 
         return false;
@@ -346,20 +366,23 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
 
     /**
      * Returns true if the given BasicBlock has an incoming edge from this CDG's
-     * EntryBlock or is itself the EntryBlock
+     * EntryBlock or is itself the EntryBlock.
      *
      * @param insBlock a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @return a boolean.
      */
     public boolean isAdjacentToEntryBlock(BasicBlock insBlock) {
 
-        if (insBlock.isEntryBlock())
+        if (insBlock.isEntryBlock()) {
             return true;
+        }
 
         Set<BasicBlock> parents = getParents(insBlock);
-        for (BasicBlock parent : parents)
-            if (parent.isEntryBlock())
+        for (BasicBlock parent : parents) {
+            if (parent.isEntryBlock()) {
                 return true;
+            }
+        }
 
         return false;
     }
@@ -377,13 +400,16 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
 
         // Remove exit blocks from CDG as they don't have control dependencies
         Set<BasicBlock> toRemove = new LinkedHashSet<>();
-        for (BasicBlock b : vertexSet())
-            if (b.isExitBlock())
+        for (BasicBlock b : vertexSet()) {
+            if (b.isExitBlock()) {
                 toRemove.add(b);
+            }
+        }
 
         for (BasicBlock b : toRemove) {
-            if (!graph.removeVertex(b))
+            if (!graph.removeVertex(b)) {
                 throw new IllegalStateException("internal error building up CDG: failed to remove exit block");
+            }
         }
     }
 
@@ -393,7 +419,9 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
         DominatorTree<BasicBlock> dt = new DominatorTree<>(rcfg);
 
         for (BasicBlock b : rcfg.vertexSet()) {
-            if (b.isExitBlock()) continue;
+            if (b.isExitBlock()) {
+                continue;
+            }
 
             logger.debug("DFs for: " + b.getName());
             for (BasicBlock cd : dt.getDominatingFrontiers(b)) {
@@ -407,7 +435,8 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
 
                     Set<ControlFlowEdge> candidates = cfg.outgoingEdgesOf(cd);
                     if (candidates.size() < 2) {
-                        logger.warn("Expected branch node " + cd + " to have multiple outgoing edges, but found " + candidates.size());
+                        logger.warn("Expected branch node " + cd + " to have multiple outgoing edges, but found "
+                                + candidates.size());
                     }
 
                     boolean leadToB = false;
@@ -431,17 +460,20 @@ public class ControlDependenceGraph extends EvoSuiteGraph<BasicBlock, ControlFlo
                             orig = e;
                         }
                     }
-                    if (skip)
+                    if (skip) {
                         continue;
+                    }
 
                     if (!leadToB) {
-                        logger.warn("Unexpected: node " + cd + " determined as control dependency for " + b + " but no path found.");
+                        logger.warn("Unexpected: node " + cd + " determined as control dependency for " + b
+                                + " but no path found.");
                     }
                 }
 
                 if (orig != null) {
-                    if (!addEdge(cd, b, new ControlFlowEdge(orig)))
+                    if (!addEdge(cd, b, new ControlFlowEdge(orig))) {
                         throw new IllegalStateException("internal error while adding CD edge");
+                    }
 
                     logger.debug("  " + cd.getName());
                 } else {

--- a/client/src/main/java/org/evosuite/graphs/cdg/DominatorNode.java
+++ b/client/src/main/java/org/evosuite/graphs/cdg/DominatorNode.java
@@ -23,16 +23,16 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * This class serves as a convenience data structure within {@link DominatorTree}
- * <p>
- * For every node within a CFG for which the immediateDominators are to be
+ * This class serves as a convenience data structure within {@link DominatorTree}.
+ *
+ * <p>For every node within a CFG for which the immediateDominators are to be
  * computed this class holds auxiliary information needed during the computation
- * inside the DominatorTree
- * <p>
- * After that computation instances of this class hold the connection between
- * CFG nodes and their immediateDominators
- * <p>
- * Look at {@link DominatorTree} for more detailed information
+ * inside the DominatorTree.
+ *
+ * <p>After that computation instances of this class hold the connection between
+ * CFG nodes and their immediateDominators.
+ *
+ * <p>Look at {@link DominatorTree} for more detailed information.
  *
  * @author Andre Mis
  */
@@ -40,10 +40,14 @@ class DominatorNode<V> {
 
     final V node;
 
-    /** DFS number */
-    int n = 0;
+    /**
+     * DFS number.
+     */
+    int dfsNum = 0;
 
-    /** parent of node within spanning tree of DFS inside {@link DominatorTree} */
+    /**
+     * parent of node within spanning tree of DFS inside {@link DominatorTree}.
+     */
     DominatorNode<V> parent;
 
     // computed dominators
@@ -51,7 +55,7 @@ class DominatorNode<V> {
     DominatorNode<V> immediateDominator;
 
     // auxiliary field needed for dominator computation
-    /** Set of nodes for which this node is the semi-dominator */
+    /** Set of nodes for which this node is the semi-dominator. */
     Set<DominatorNode<V>> bucket = new LinkedHashSet<>();
 
     // data structure needed to represented forest produced during cfg.DominatorTree computation
@@ -71,8 +75,9 @@ class DominatorNode<V> {
     }
 
     DominatorNode<V> eval() {
-        if (ancestor == null)
+        if (ancestor == null) {
             return this;
+        }
 
         compress();
 
@@ -80,21 +85,24 @@ class DominatorNode<V> {
     }
 
     void compress() {
-        if (ancestor == null)
+        if (ancestor == null) {
             throw new IllegalStateException("may only be called when ancestor is set");
+        }
 
         if (ancestor.ancestor != null) {
             ancestor.compress();
-            if (ancestor.label.semiDominator.n < label.semiDominator.n)
+            if (ancestor.label.semiDominator.dfsNum < label.semiDominator.dfsNum) {
                 label = ancestor.label;
+            }
 
             ancestor = ancestor.ancestor;
         }
     }
 
     DominatorNode<V> getFromBucket() {
-        for (DominatorNode<V> r : bucket)
+        for (DominatorNode<V> r : bucket) {
             return r;
+        }
 
         return null;
     }
@@ -106,7 +114,7 @@ class DominatorNode<V> {
      */
     public boolean isRootNode() {
         // DFS traversal assigns 1 to the root.
-        return n == 1;
+        return dfsNum == 1;
     }
 
     /**
@@ -114,6 +122,6 @@ class DominatorNode<V> {
      */
     @Override
     public String toString() {
-        return "DTNode " + n + " - " + node;
+        return "DTNode " + dfsNum + " - " + node;
     }
 }

--- a/client/src/main/java/org/evosuite/graphs/cfg/ASMWrapper.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ASMWrapper.java
@@ -21,7 +21,17 @@ package org.evosuite.graphs.cfg;
 
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FrameNode;
+import org.objectweb.asm.tree.IincInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
 import org.objectweb.asm.util.Printer;
 
 // TODO: the following methods about control dependence are flawed right now:
@@ -34,23 +44,23 @@ import org.objectweb.asm.util.Printer;
 // - look at BranchCoverageGoal and Branch for more information
 
 /**
- * Wrapper class for the underlying byteCode instruction library ASM
- * <p>
- * Gives access to a lot of methods that interpret the raw information in
- * AbstractInsnNode to usable chunks of information, inside EvoSuite
- * <p>
- * This class is supposed to hide the ASM library from the rest of EvoSuite as
- * much as possible
- * <p>
- * After initialization, all information about byteCode instructions should be
+ * Wrapper class for the underlying byteCode instruction library ASM.
+ *
+ * <p>Gives access to a lot of methods that interpret the raw information in
+ * AbstractInsnNode to usable chunks of information, inside EvoSuite.
+ *
+ * <p>This class is supposed to hide the ASM library from the rest of EvoSuite as
+ * much as possible.
+ *
+ * <p>After initialization, all information about byteCode instructions should be
  * accessible via the BytecodeInstruction-, DefUse- and BranchPool. Each of
  * those has data structures holding all BytecodeInstruction, DefUse and Branch
  * objects respectively created during initialization.
- * <p>
- * BytecodeInstruction directly extends ASMWrapper and is the first way to
+ *
+ * <p>BytecodeInstruction directly extends ASMWrapper and is the first way to
  * instantiate an ASMWrapper. Branch and DefUse extend BytecodeInstruction,
  * where DefUse is abstract and Branch is not ("concrete"?) DefUse is further
- * extended by Definition and Use
+ * extended by Definition and Use.
  *
  * @author Andre Mis
  */
@@ -62,7 +72,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getASMNode
+     * getASMNode.
      * </p>
      *
      * @return a {@link org.objectweb.asm.tree.AbstractInsnNode} object.
@@ -73,32 +83,35 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getInstructionType
+     * getInstructionType.
      * </p>
      *
      * @return a {@link java.lang.String} object.
      */
     public String getInstructionType() {
 
-        if (asmNode.getOpcode() >= 0 && asmNode.getOpcode() < Printer.OPCODES.length)
+        if (asmNode.getOpcode() >= 0 && asmNode.getOpcode() < Printer.OPCODES.length) {
             return Printer.OPCODES[asmNode.getOpcode()];
+        }
 
-        if (isLineNumber())
+        if (isLineNumber()) {
             return "LINE " + this.getLineNumber();
+        }
 
         return getType();
     }
 
     public String getMethodCallDescriptor() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return null;
+        }
         MethodInsnNode meth = (MethodInsnNode) asmNode;
         return meth.desc;
     }
 
     /**
      * <p>
-     * getType
+     * getType.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -106,15 +119,16 @@ public abstract class ASMWrapper {
     public String getType() {
         // TODO explain
         String type = "";
-        if (asmNode.getType() >= 0 && asmNode.getType() < Printer.TYPES.length)
+        if (asmNode.getType() >= 0 && asmNode.getType() < Printer.TYPES.length) {
             type = Printer.TYPES[asmNode.getType()];
+        }
 
         return type;
     }
 
     /**
      * <p>
-     * getInstructionId
+     * getInstructionId.
      * </p>
      *
      * @return a int.
@@ -123,7 +137,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getMethodName
+     * getMethodName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -132,7 +146,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getClassName
+     * getClassName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -147,7 +161,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isActualBranch
+     * isActualBranch.
      * </p>
      *
      * @return a boolean.
@@ -158,7 +172,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isSwitch
+     * isSwitch.
      * </p>
      *
      * @return a boolean.
@@ -169,7 +183,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * canReturnFromMethod
+     * canReturnFromMethod.
      * </p>
      *
      * @return a boolean.
@@ -180,7 +194,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isReturn
+     * isReturn.
      * </p>
      *
      * @return a boolean.
@@ -201,7 +215,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isThrow
+     * isThrow.
      * </p>
      *
      * @return a boolean.
@@ -213,7 +227,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isTableSwitch
+     * isTableSwitch.
      * </p>
      *
      * @return a boolean.
@@ -224,7 +238,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isLookupSwitch
+     * isLookupSwitch.
      * </p>
      *
      * @return a boolean.
@@ -235,7 +249,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isBranchLabel
+     * isBranchLabel.
      * </p>
      *
      * @return a boolean.
@@ -247,7 +261,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isJump
+     * isJump.
      * </p>
      *
      * @return a boolean.
@@ -258,11 +272,10 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isInvokeStatic
+     * isInvokeStatic.
      * </p>
      *
-     * @return a boolean representing whether the instruction is a static method
-     * call.
+     * @return a boolean representing whether the instruction is a static method call.
      */
     public boolean isInvokeStatic() {
         if (asmNode instanceof MethodInsnNode) {
@@ -273,7 +286,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isGoto
+     * isGoto.
      * </p>
      *
      * @return a boolean.
@@ -287,7 +300,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isBranch
+     * isBranch.
      * </p>
      *
      * @return a boolean.
@@ -303,7 +316,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isIfNull
+     * isIfNull.
      * </p>
      *
      * @return a boolean.
@@ -317,7 +330,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFrame
+     * isFrame.
      * </p>
      *
      * @return a boolean.
@@ -328,7 +341,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isMethodCall
+     * isMethodCall.
      * </p>
      *
      * @return a boolean.
@@ -339,47 +352,50 @@ public abstract class ASMWrapper {
 
     /**
      * Returns the conjunction of the name and method descriptor of the method
-     * called by this instruction
+     * called by this instruction.
      *
      * @return a {@link java.lang.String} object.
      */
     public String getCalledMethod() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return null;
+        }
         MethodInsnNode meth = (MethodInsnNode) asmNode;
         return meth.name + meth.desc;
     }
 
     /**
      * Returns the conjunction of the name of the method called by this
-     * instruction
+     * instruction.
      *
      * @return a {@link java.lang.String} object.
      */
     public String getCalledMethodName() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return null;
+        }
         MethodInsnNode meth = (MethodInsnNode) asmNode;
         return meth.name;
     }
 
     /**
      * Returns true if and only if the class of the method called by this
-     * instruction is the same as the given className
+     * instruction is the same as the given className.
      *
      * @param className a {@link java.lang.String} object.
      * @return a boolean.
      */
     public boolean isMethodCallForClass(String className) {
         if (isMethodCall()) {
-            // System.out.println("in isMethodCallForClass of "+toString()+" for arg "+className+" calledMethodsClass: "+getCalledMethodsClass()+" calledMethod "+getCalledMethod());
+            // System.out.println("in isMethodCallForClass of "+toString()+" for arg "+className+" calledMethodsClass: "
+            // +getCalledMethodsClass()+" calledMethod "+getCalledMethod());
             return getCalledMethodsClass().equals(className);
         }
         return false;
     }
 
     /**
-     * Returns the class of the method called by this instruction
+     * Returns the class of the method called by this instruction.
      *
      * @return a {@link java.lang.String} object.
      */
@@ -392,7 +408,7 @@ public abstract class ASMWrapper {
     }
 
     /**
-     * Returns the number of arguments of the method called by this instruction
+     * Returns the number of arguments of the method called by this instruction.
      *
      * @return a int.
      */
@@ -413,7 +429,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isLoadConstant
+     * isLoadConstant.
      * </p>
      *
      * @return a boolean.
@@ -424,7 +440,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isConstant
+     * isConstant.
      * </p>
      *
      * @return a boolean.
@@ -458,7 +474,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isDefUse
+     * isDefUse.
      * </p>
      *
      * @return a boolean.
@@ -469,7 +485,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFieldDU
+     * isFieldDU.
      * </p>
      *
      * @return a boolean.
@@ -484,7 +500,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isLocalDU
+     * isLocalDU.
      * </p>
      *
      * @return a boolean.
@@ -495,7 +511,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isDefinition
+     * isDefinition.
      * </p>
      *
      * @return a boolean.
@@ -506,7 +522,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isUse
+     * isUse.
      * </p>
      *
      * @return a boolean.
@@ -521,7 +537,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFieldDefinition
+     * isFieldDefinition.
      * </p>
      *
      * @return a boolean.
@@ -534,7 +550,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFieldDefinition
+     * isFieldDefinition.
      * </p>
      *
      * @return a boolean.
@@ -546,7 +562,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFieldUse
+     * isFieldUse.
      * </p>
      *
      * @return a boolean.
@@ -558,7 +574,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isFieldUse
+     * isFieldUse.
      * </p>
      *
      * @return a boolean.
@@ -570,7 +586,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isStaticDefUse
+     * isStaticDefUse.
      * </p>
      *
      * @return a boolean.
@@ -584,7 +600,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getDUVariableName
+     * getDUVariableName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -607,7 +623,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getFieldName
+     * getFieldName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -620,7 +636,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getFieldName
+     * getFieldName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -633,7 +649,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getFieldName
+     * getFieldName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -646,7 +662,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getLocalVarName
+     * getLocalVarName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -660,23 +676,24 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getLocalVar
+     * getLocalVar.
      * </p>
      *
      * @return a int.
      */
     public int getLocalVariableSlot() {
-        if (asmNode instanceof VarInsnNode)
+        if (asmNode instanceof VarInsnNode) {
             return ((VarInsnNode) asmNode).var;
-        else if (asmNode instanceof IincInsnNode)
+        } else if (asmNode instanceof IincInsnNode) {
             return ((IincInsnNode) asmNode).var;
-        else
+        } else {
             return -1;
+        }
     }
 
     /**
      * <p>
-     * isLocalVarDefinition
+     * isLocalVarDefinition.
      * </p>
      *
      * @return a boolean.
@@ -692,7 +709,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isLocalVarUse
+     * isLocalVarUse.
      * </p>
      *
      * @return a boolean.
@@ -712,11 +729,11 @@ public abstract class ASMWrapper {
 
     /**
      * Determines whether this is the special ALOAD that pushes 'this' onto the
-     * stack
-     * <p>
-     * In non static methods the variable slot 0 holds the reference to "this".
+     * stack.
+     *
+     * <p>In non static methods the variable slot 0 holds the reference to "this".
      * Loading this reference is not seen as a Use for defuse purposes. This
-     * method checks if this is the case
+     * method checks if this is the case.
      *
      * @return a boolean.
      */
@@ -731,36 +748,42 @@ public abstract class ASMWrapper {
     public abstract RawControlFlowGraph getRawCFG();
 
     public boolean isLocalArrayDefinition() {
-        if (!isArrayStoreInstruction())
+        if (!isArrayStoreInstruction()) {
             return false;
+        }
 
         // only local var if arrayref on stack is from local var use
         BytecodeInstruction arrayLoader = getSourceOfArrayReference();
-        if (arrayLoader == null)
+        if (arrayLoader == null) {
             return false;
+        }
 
         return arrayLoader.isLocalVariableUse();
     }
 
     public boolean isFieldArrayDefinition() {
-        if (!isArrayStoreInstruction())
+        if (!isArrayStoreInstruction()) {
             return false;
+        }
 
         // only field var if arrayref on stack is from field var use
         BytecodeInstruction arrayLoader = getSourceOfArrayReference();
-        if (arrayLoader == null)
+        if (arrayLoader == null) {
             return false;
+        }
 
         return arrayLoader.isFieldUse();
     }
 
     public boolean isStaticArrayUsage() {
-        if (!isArrayStoreInstruction())
+        if (!isArrayStoreInstruction()) {
             return false;
+        }
 
         BytecodeInstruction arrayLoader = getSourceOfArrayReference();
-        if (arrayLoader == null)
+        if (arrayLoader == null) {
             return false;
+        }
 
         return arrayLoader.isStaticDefUse();
     }
@@ -783,8 +806,9 @@ public abstract class ASMWrapper {
 
     protected String getArrayVariableName() {
         BytecodeInstruction arrayLoader = getSourceOfArrayReference();
-        if (arrayLoader == null)
+        if (arrayLoader == null) {
             return null;
+        }
 
         return arrayLoader.getVariableName();
     }
@@ -793,7 +817,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isDefinitionForVariable
+     * isDefinitionForVariable.
      * </p>
      *
      * @param var a {@link java.lang.String} object.
@@ -805,7 +829,7 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * isInvokeSpecial
+     * isInvokeSpecial.
      * </p>
      *
      * @return a boolean.
@@ -821,8 +845,9 @@ public abstract class ASMWrapper {
      * @return a boolean.
      */
     public boolean isConstructorInvocation() {
-        if (!isInvokeSpecial())
+        if (!isInvokeSpecial()) {
             return false;
+        }
 
         MethodInsnNode invoke = (MethodInsnNode) asmNode;
         // if (!invoke.owner.equals(className.replaceAll("\\.", "/")))
@@ -839,12 +864,14 @@ public abstract class ASMWrapper {
      * @return a boolean.
      */
     public boolean isConstructorInvocation(String className) {
-        if (!isInvokeSpecial())
+        if (!isInvokeSpecial()) {
             return false;
+        }
 
         MethodInsnNode invoke = (MethodInsnNode) asmNode;
-        if (!invoke.owner.equals(className.replaceAll("\\.", "/")))
+        if (!invoke.owner.equals(className.replaceAll("\\.", "/"))) {
             return false;
+        }
 
         return invoke.name.equals("<init>");
     }
@@ -852,9 +879,9 @@ public abstract class ASMWrapper {
     // other classification methods
 
     /**
-     * Determines if this instruction is a line number instruction
-     * <p>
-     * More precisely this method checks if the underlying asmNode is a
+     * Determines if this instruction is a line number instruction.
+     *
+     * <p>More precisely this method checks if the underlying asmNode is a
      * LineNumberNode
      *
      * @return a boolean.
@@ -865,21 +892,22 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * getLineNumber
+     * getLineNumber.
      * </p>
      *
      * @return a int.
      */
     public int getLineNumber() {
-        if (!isLineNumber())
+        if (!isLineNumber()) {
             return -1;
+        }
 
         return ((LineNumberNode) asmNode).line;
     }
 
     /**
      * <p>
-     * isLabel
+     * isLabel.
      * </p>
      *
      * @return a boolean.
@@ -892,18 +920,20 @@ public abstract class ASMWrapper {
 
     /**
      * <p>
-     * sanityCheckAbstractInsnNode
+     * sanityCheckAbstractInsnNode.
      * </p>
      *
      * @param node a {@link org.objectweb.asm.tree.AbstractInsnNode} object.
+     * @return a boolean.
      */
     public boolean sanityCheckAbstractInsnNode(AbstractInsnNode node) {
-        if (node == null)
-            return false; //throw new IllegalArgumentException("null given");
+        if (node == null) {
+            return false; // throw new IllegalArgumentException("null given");
+        }
         return node.equals(this.asmNode);
         //
-        //	throw new IllegalStateException("sanity check failed for "
-        //			+ node.toString() + " on " + getMethodName() + toString());
+        // throw new IllegalStateException("sanity check failed for "
+        // + node.toString() + " on " + getMethodName() + toString());
     }
 
 }

--- a/client/src/main/java/org/evosuite/graphs/cfg/ActualControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ActualControlFlowGraph.java
@@ -27,43 +27,42 @@ import java.util.Set;
 
 /**
  * Supposed to become the new implementation of a control flow graph inside
- * EvoSuite
- * <p>
- * The "actual" CFG does not contain single cfg.BytecodeInstructions as nodes,
- * but contains cfg.BasicBlocks - look at that class for more information
- * <p>
- * Simply put this is a minimized version of the complete/raw CFG the
+ * EvoSuite.
+ *
+ * <p>The "actual" CFG does not contain single cfg.BytecodeInstructions as nodes,
+ * but contains cfg.BasicBlocks - look at that class for more information.
+ *
+ * <p>Simply put this is a minimized version of the complete/raw CFG the
  * cfg.BytecodeAnalyzer and cfg.CFGGenerator produce - which holds a node for
- * every BytecodeInstruction
- * <p>
- * Out of the above described raw CFG the following "pin-points" are extracted:
- * <p>
- * 1) the entryNode (first instruction in the method)
- * <p>
- * 2) all exitNodes (outDegree 0)
- * <p>
- * 3.1) all branches (outDegree>1) 3.2) in a subsequent step all targets of all
+ * every BytecodeInstruction.
+ *
+ * <p>Out of the above described raw CFG the following "pin-points" are extracted:
+ *
+ * <p>1) the entryNode (first instruction in the method)
+ *
+ * <p>2) all exitNodes (outDegree 0)
+ *
+ * <p>3.1) all branches (outDegree>1) 3.2) in a subsequent step all targets of all
  * branches
- * <p>
- * 4.1) all joins (inDegree>1) 4.2) in a subsequent step all sources of all
+ *
+ * <p>4.1) all joins (inDegree>1) 4.2) in a subsequent step all sources of all
  * joins
- * <p>
- * All those "pin-points" are put into a big set (some of the above categories
+ *
+ * <p>All those "pin-points" are put into a big set (some of the above categories
  * may overlap) and for all those single BytecodeInstrucions their corresponding
  * BasicBlock is computed and added to this CFGs vertexSet. After that the raw
  * CFG is asked for the parents of the first instruction of each BasicBlock and
  * the children of that blocks last instruction. Then the edges to their
- * corresponding BasicBlocks are added to this CFG
- * <p>
- * TODO: verify that this method works :D
- * <p>
- * <p>
- * cfg.EvoSuiteGraph is used as the underlying data structure holding the
- * graphical representation of the CFG
- * <p>
- * WORK IN PROGRESS
- * <p>
- * TODO implement
+ * corresponding BasicBlocks are added to this CFG.
+ *
+ * <p>TODO: verify that this method works :D
+ *
+ * <p>cfg.EvoSuiteGraph is used as the underlying data structure holding the
+ * graphical representation of the CFG.
+ *
+ * <p>WORK IN PROGRESS
+ *
+ * <p>TODO implement
  *
  * @author Andre Mis
  */
@@ -81,9 +80,7 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     private Set<BytecodeInstruction> joinSources;
 
     /**
-     * <p>
      * Constructor for ActualControlFlowGraph.
-     * </p>
      *
      * @param rawGraph a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
      */
@@ -113,9 +110,7 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     }
 
     /**
-     * <p>
-     * computeReverseCFG
-     * </p>
+     * <p>computeReverseCFG.</p>
      *
      * @return a {@link org.evosuite.graphs.cfg.ActualControlFlowGraph} object.
      */
@@ -139,89 +134,106 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     }
 
     private void setEntryPoint(BytecodeInstruction entryPoint) {
-        if (entryPoint == null)
+        if (entryPoint == null) {
             throw new IllegalArgumentException("null given");
-        if (!belongsToMethod(entryPoint))
+        }
+        if (!belongsToMethod(entryPoint)) {
             throw new IllegalArgumentException(
                     "entry point does not belong to this CFGs method");
+        }
         this.entryPoint = entryPoint;
     }
 
     private void setExitPoints(Set<BytecodeInstruction> exitPoints) {
-        if (exitPoints == null)
+        if (exitPoints == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.exitPoints = new HashSet<>();
 
         for (BytecodeInstruction exitPoint : exitPoints) {
-            if (!belongsToMethod(exitPoint))
+            if (!belongsToMethod(exitPoint)) {
                 throw new IllegalArgumentException(
                         "exit point does not belong to this CFGs method");
-            if (!exitPoint.canBeExitPoint())
+            }
+            if (!exitPoint.canBeExitPoint()) {
                 throw new IllegalArgumentException(
                         "unexpected exitPoint byteCode instruction type: "
                                 + exitPoint.getInstructionType());
+            }
 
             this.exitPoints.add(exitPoint);
         }
     }
 
     private void setJoins(Set<BytecodeInstruction> joins) {
-        if (joins == null)
+        if (joins == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.joins = new HashSet<>();
 
         for (BytecodeInstruction join : joins) {
-            if (!belongsToMethod(join))
+            if (!belongsToMethod(join)) {
                 throw new IllegalArgumentException(
                         "join does not belong to this CFGs method");
+            }
 
             this.joins.add(join);
         }
     }
 
     private void setJoinSources() {
-        if (joins == null)
+        if (joins == null) {
             throw new IllegalStateException(
                     "expect joins to be set before setting of joinSources");
-        if (rawGraph == null)
+        }
+        if (rawGraph == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.joinSources = new HashSet<>();
 
-        for (BytecodeInstruction join : joins)
-            for (ControlFlowEdge joinEdge : rawGraph.incomingEdgesOf(join))
+        for (BytecodeInstruction join : joins) {
+            for (ControlFlowEdge joinEdge : rawGraph.incomingEdgesOf(join)) {
                 joinSources.add(rawGraph.getEdgeSource(joinEdge));
+            }
+        }
     }
 
     private void setBranches(Set<BytecodeInstruction> branches) {
-        if (branches == null)
+        if (branches == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.branches = new HashSet<>();
 
         for (BytecodeInstruction branch : branches) {
-            if (!belongsToMethod(branch))
+            if (!belongsToMethod(branch)) {
                 throw new IllegalArgumentException(
                         "branch does not belong to this CFGs method");
+            }
 
             this.branches.add(branch);
         }
     }
 
     private void setBranchTargets() {
-        if (branches == null)
+        if (branches == null) {
             throw new IllegalStateException(
                     "expect branches to be set before setting of branchTargets");
-        if (rawGraph == null)
+        }
+        if (rawGraph == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.branchTargets = new HashSet<>();
 
-        for (BytecodeInstruction branch : branches)
-            for (ControlFlowEdge branchEdge : rawGraph.outgoingEdgesOf(branch))
+        for (BytecodeInstruction branch : branches) {
+            for (ControlFlowEdge branchEdge : rawGraph.outgoingEdgesOf(branch)) {
                 branchTargets.add(rawGraph.getEdgeTarget(branchEdge));
+            }
+        }
     }
 
     private Set<BytecodeInstruction> getInitiallyKnownInstructions() {
@@ -267,8 +279,9 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
         Set<BytecodeInstruction> nodes = getInitiallyKnownInstructions();
 
         for (BytecodeInstruction node : nodes) {
-            if (knowsInstruction(node))
+            if (knowsInstruction(node)) {
                 continue;
+            }
 
             BasicBlock nodeBlock = rawGraph.determineBasicBlockFor(node);
             addBlock(nodeBlock);
@@ -290,8 +303,9 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
 
     private void computeIncomingEdgesFor(BasicBlock block) {
 
-        if (isEntryPoint(block))
+        if (isEntryPoint(block)) {
             return;
+        }
 
         BytecodeInstruction blockStart = block.getFirstInstruction();
         Set<ControlFlowEdge> rawIncomings = rawGraph.incomingEdgesOf(blockStart);
@@ -303,8 +317,9 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
 
     private void computeOutgoingEdgesFor(BasicBlock block) {
 
-        if (isExitPoint(block))
+        if (isExitPoint(block)) {
             return;
+        }
 
         BytecodeInstruction blockEnd = block.getLastInstruction();
 
@@ -318,36 +333,36 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     // internal graph handling
 
     /**
-     * <p>
-     * addBlock
-     * </p>
+     * <p>addBlock.</p>
      *
      * @param nodeBlock a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      */
     protected void addBlock(BasicBlock nodeBlock) {
-        if (nodeBlock == null)
+        if (nodeBlock == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         logger.debug("Adding block: " + nodeBlock.getName());
 
-        if (containsVertex(nodeBlock))
+        if (containsVertex(nodeBlock)) {
             throw new IllegalArgumentException("block already added before");
+        }
 
-        if (!addVertex(nodeBlock))
+        if (!addVertex(nodeBlock)) {
             throw new IllegalStateException(
                     "internal error while addind basic block to CFG");
+        }
 
-        if (!containsVertex(nodeBlock))
+        if (!containsVertex(nodeBlock)) {
             throw new IllegalStateException(
                     "expect graph to contain the given block on returning of addBlock()");
+        }
 
         logger.debug(".. succeeded. nodeCount: " + vertexCount());
     }
 
     /**
-     * <p>
-     * addRawEdge
-     * </p>
+     * <p>addRawEdge.</p>
      *
      * @param src      a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @param target   a {@link org.evosuite.graphs.cfg.BasicBlock} object.
@@ -356,17 +371,16 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     protected void addRawEdge(BytecodeInstruction src, BasicBlock target,
                               ControlFlowEdge origEdge) {
         BasicBlock srcBlock = src.getBasicBlock();
-        if (srcBlock == null)
+        if (srcBlock == null) {
             throw new IllegalStateException(
                     "when adding an edge to a CFG it is expected to know both the src- and the target-instruction");
+        }
 
         addRawEdge(srcBlock, target, origEdge);
     }
 
     /**
-     * <p>
-     * addRawEdge
-     * </p>
+     * <p>addRawEdge.</p>
      *
      * @param src      a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @param target   a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -375,25 +389,25 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     protected void addRawEdge(BasicBlock src, BytecodeInstruction target,
                               ControlFlowEdge origEdge) {
         BasicBlock targetBlock = target.getBasicBlock();
-        if (targetBlock == null)
+        if (targetBlock == null) {
             throw new IllegalStateException(
                     "when adding an edge to a CFG it is expected to know both the src- and the target-instruction");
+        }
 
         addRawEdge(src, targetBlock, origEdge);
     }
 
     /**
-     * <p>
-     * addRawEdge
-     * </p>
+     * <p>addRawEdge.</p>
      *
      * @param src      a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @param target   a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @param origEdge a {@link org.evosuite.graphs.cfg.ControlFlowEdge} object.
      */
     protected void addRawEdge(BasicBlock src, BasicBlock target, ControlFlowEdge origEdge) {
-        if (src == null || target == null)
+        if (src == null || target == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         logger.debug("Adding edge from " + src.getName() + " to " + target.getName());
 
@@ -401,29 +415,35 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
             logger.debug("edge already contained in CFG");
             // sanity check
             ControlFlowEdge current = getEdge(src, target);
-            if (current == null)
+            if (current == null) {
                 throw new IllegalStateException(
                         "expect getEdge() not to return null on parameters on which containsEdge() retruned true");
+            }
             if (current.getBranchExpressionValue()
-                    && !origEdge.getBranchExpressionValue())
+                    && !origEdge.getBranchExpressionValue()) {
                 throw new IllegalStateException(
-                        "if this rawEdge was handled before i expect the old edge to have same branchExpressionValue set");
+                        "if this rawEdge was handled before i expect the old edge to have "
+                                + "same branchExpressionValue set");
+            }
             if (current.getBranchInstruction() == null) {
-                if (origEdge.getBranchInstruction() != null)
+                if (origEdge.getBranchInstruction() != null) {
                     throw new IllegalStateException(
                             "if this rawEdge was handled before i expect the old edge to have same branchInstruction set");
+                }
 
             } else if (origEdge.getBranchInstruction() == null
-                    || !current.getBranchInstruction().equals(origEdge.getBranchInstruction()))
+                    || !current.getBranchInstruction().equals(origEdge.getBranchInstruction())) {
                 throw new IllegalStateException(
                         "if this rawEdge was handled before i expect the old edge to have same branchInstruction set");
+            }
 
             return;
         }
 
         ControlFlowEdge e = new ControlFlowEdge(origEdge);
-        if (!super.addEdge(src, target, e))
+        if (!super.addEdge(src, target, e)) {
             throw new IllegalStateException("internal error while adding edge to CFG");
+        }
 
         logger.debug(".. succeeded, edgeCount: " + edgeCount());
     }
@@ -438,17 +458,20 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
      * @return a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      */
     public BasicBlock getBlockOf(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
+        }
 
-        if (instruction.hasBasicBlockSet())
+        if (instruction.hasBasicBlockSet()) {
             return instruction.getBasicBlock();
+        }
 
-        for (BasicBlock block : vertexSet())
+        for (BasicBlock block : vertexSet()) {
             if (block.containsInstruction(instruction)) {
                 instruction.setBasicBlock(block);
                 return block;
             }
+        }
 
         logger.debug("unknown instruction " + instruction);
         return null;
@@ -462,65 +485,74 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
      * @return a boolean.
      */
     public boolean knowsInstruction(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
+        }
 
-        if (instruction.hasBasicBlockSet())
+        if (instruction.hasBasicBlockSet()) {
             return containsVertex(instruction.getBasicBlock());
+        }
 
-        for (BasicBlock block : vertexSet())
-            if (block.containsInstruction(instruction))
+        for (BasicBlock block : vertexSet()) {
+            if (block.containsInstruction(instruction)) {
                 return true;
+            }
+        }
 
         return false;
     }
 
     /**
-     * <p>
-     * getDistance
-     * </p>
+     * <p>getDistance.</p>
      *
      * @param v1 a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @param v2 a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a int.
      */
     public int getDistance(BytecodeInstruction v1, BytecodeInstruction v2) {
-        if (v1 == null || v2 == null)
+        if (v1 == null || v2 == null) {
             throw new IllegalArgumentException("null given");
-        if (!knowsInstruction(v1) || !knowsInstruction(v2))
+        }
+        if (!knowsInstruction(v1) || !knowsInstruction(v2)) {
             throw new IllegalArgumentException("instructions not contained in this CFG");
+        }
 
         BasicBlock b1 = v1.getBasicBlock();
         BasicBlock b2 = v2.getBasicBlock();
 
-        if (b1 == null || b2 == null)
+        if (b1 == null || b2 == null) {
             throw new IllegalStateException(
-                    "expect CFG to contain the BasicBlock for each instruction knowsInstruction() returns true on");
+                    "expect CFG to contain the BasicBlock for each instruction "
+                            + "knowsInstruction() returns "
+                            + "true on");
+        }
 
         return getDistance(b1, b2);
     }
 
     /**
-     * <p>
-     * isDirectSuccessor
-     * </p>
+     * <p>isDirectSuccessor.</p>
      *
      * @param v1 a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @param v2 a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a boolean.
      */
     public boolean isDirectSuccessor(BytecodeInstruction v1, BytecodeInstruction v2) {
-        if (v1 == null || v2 == null)
+        if (v1 == null || v2 == null) {
             throw new IllegalArgumentException("null given");
-        if (!knowsInstruction(v1) || !knowsInstruction(v2))
+        }
+        if (!knowsInstruction(v1) || !knowsInstruction(v2)) {
             throw new IllegalArgumentException("instructions not contained in this CFG");
+        }
 
         BasicBlock b1 = v1.getBasicBlock();
         BasicBlock b2 = v2.getBasicBlock();
 
-        if (b1 == null || b2 == null)
+        if (b1 == null || b2 == null) {
             throw new IllegalStateException(
-                    "expect CFG to contain the BasicBlock for each instruction knowsInstruction() returns true on");
+                    "expect CFG to contain the BasicBlock for each instruction "
+                            + "knowsInstruction() returns true on");
+        }
 
         return isDirectSuccessor(b1, b2);
     }
@@ -528,16 +560,15 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     // retrieve information about the CFG
 
     /**
-     * <p>
-     * isEntryPoint
-     * </p>
+     * <p>isEntryPoint.</p>
      *
      * @param block a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @return a boolean.
      */
     public boolean isEntryPoint(BasicBlock block) {
-        if (block == null)
+        if (block == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         // // sanity check
         // if (!block.getFirstInstruction().equals(entryPoint)) {
@@ -550,69 +581,69 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     }
 
     /**
-     * <p>
-     * isExitPoint
-     * </p>
+     * <p>isExitPoint.</p>
      *
      * @param block a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      * @return a boolean.
      */
     public boolean isExitPoint(BasicBlock block) {
-        if (block == null)
+        if (block == null) {
             throw new IllegalArgumentException("null given");
+        }
 
-        for (BytecodeInstruction exitPoint : exitPoints)
+        for (BytecodeInstruction exitPoint : exitPoints) {
             if (block.containsInstruction(exitPoint)) {
-                //				// sanity check
-                //				if (!block.getLastInstruction().equals(exitPoint))
-                //					throw new IllegalStateException(
-                //							"expect exitPoints of a method to be the last instruction from an exitBlock of that method");
+                //                // sanity check
+                //                if (!block.getLastInstruction().equals(exitPoint))
+                //                    throw new IllegalStateException(
+                //                            "expect exitPoints of a method to be the last instruction from an exitBlock of that method");
                 return true;
             }
+        }
 
         return false;
     }
 
     /**
-     * <p>
-     * belongsToMethod
-     * </p>
+     * <p>belongsToMethod.</p>
      *
      * @param instruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a boolean.
      */
     public boolean belongsToMethod(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
+        }
 
-        if (!className.equals(instruction.getClassName()))
+        if (!className.equals(instruction.getClassName())) {
             return false;
+        }
         return methodName.equals(instruction.getMethodName());
     }
 
     // sanity checks
 
     /**
-     * <p>
-     * checkSanity
-     * </p>
+     * <p>checkSanity.</p>
      */
     public void checkSanity() {
 
         logger.debug("checking sanity of CFG for " + methodName);
 
-        if (isEmpty())
+        if (isEmpty()) {
             throw new IllegalStateException("a CFG must contain at least one element");
+        }
 
         for (BytecodeInstruction initInstruction : getInitiallyKnownInstructions()) {
-            if (!knowsInstruction(initInstruction))
+            if (!knowsInstruction(initInstruction)) {
                 throw new IllegalStateException(
                         "expect CFG to contain all initially known instructions");
+            }
         }
 
         logger.debug(".. all initInstructions contained");
 
-        //		checkNodeSanity();
+        //        checkNodeSanity();
 
         checkInstructionsContainedOnceConstraint();
 
@@ -622,19 +653,24 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     private void checkInstructionsContainedOnceConstraint() {
 
         for (BytecodeInstruction ins : rawGraph.vertexSet()) {
-            if (!knowsInstruction(ins))
+            if (!knowsInstruction(ins)) {
                 throw new IllegalStateException(
                         "expect all instructions ins underlying RawCFG to be known by Actual CFG");
+            }
 
             BasicBlock insBlock = ins.getBasicBlock();
-            if (insBlock == null)
+            if (insBlock == null) {
                 throw new IllegalStateException(
-                        "expect ActualCFG.getBlockOf() to return non-null BasicBlocks for all instructions it knows");
+                        "expect ActualCFG.getBlockOf() to return non-null BasicBlocks "
+                                + "for all instructions it "
+                                + "knows");
+            }
 
             for (BasicBlock block : vertexSet()) {
-                if (!block.equals(insBlock) && block.containsInstruction(ins))
+                if (!block.equals(insBlock) && block.containsInstruction(ins)) {
                     throw new IllegalStateException(
                             "expect ActualCFG to contain exactly one BasicBlock for each original bytecode instruction, not more!");
+                }
             }
         }
 
@@ -657,44 +693,53 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     void checkEntryExitPointConstraint(BasicBlock node) {
         // exit point constraint
         int out = outDegreeOf(node);
-        if (!isExitPoint(node) && out == 0)
+        if (!isExitPoint(node) && out == 0) {
             throw new IllegalStateException(
                     "expect nodes without outgoing edges to be exitBlocks: "
                             + node.toString());
+        }
         // entry point constraint
         int in = inDegreeOf(node);
-        if (!isEntryPoint(node) && in == 0)
+        if (!isEntryPoint(node) && in == 0) {
             throw new IllegalStateException(
                     "expect nodes without incoming edges to be the entryBlock: "
                             + node.toString());
+        }
     }
 
     void checkSingleCFGNodeConstraint(BasicBlock node) {
         int in = inDegreeOf(node);
         int out = outDegreeOf(node);
-        if (in + out == 0 && vertexCount() != 1)
+        if (in + out == 0 && vertexCount() != 1) {
             throw new IllegalStateException(
                     "node with neither child nor parent only allowed if CFG consists of a single block: "
                             + node.toString());
+        }
 
-        if (vertexCount() == 1 && !(isEntryPoint(node) && isExitPoint(node)))
+        if (vertexCount() == 1 && !(isEntryPoint(node) && isExitPoint(node))) {
             throw new IllegalStateException(
-                    "if a CFG consists of a single basic block that block must be both entry and exitBlock: "
+                    "if a CFG consists of a single basic block that block must be both "
+                            + "entry and exitBlock: "
                             + node.toString());
+        }
     }
 
     void checkNodeMinimalityConstraint(BasicBlock node) {
 
         if (hasNPartentsMChildren(node, 1, 1)) {
-            for (BasicBlock child : getChildren(node))
-                if (hasNPartentsMChildren(child, 1, 1))
+            for (BasicBlock child : getChildren(node)) {
+                if (hasNPartentsMChildren(child, 1, 1)) {
                     throw new IllegalStateException(
                             "whenever a node has exactly one child and one parent, it is expected that the same is true for either of those");
+                }
+            }
 
-            for (BasicBlock parent : getParents(node))
-                if (hasNPartentsMChildren(parent, 1, 1))
+            for (BasicBlock parent : getParents(node)) {
+                if (hasNPartentsMChildren(parent, 1, 1)) {
                     throw new IllegalStateException(
                             "whenever a node has exactly one child and one parent, it is expected that the same is true for either of those");
+                }
+            }
         }
     }
 
@@ -705,12 +750,15 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
      */
     @Override
     public boolean containsInstruction(BytecodeInstruction v) {
-        if (v == null)
+        if (v == null) {
             return false;
+        }
 
-        for (BasicBlock block : vertexSet())
-            if (block.containsInstruction(v))
+        for (BasicBlock block : vertexSet()) {
+            if (block.containsInstruction(v)) {
                 return true;
+            }
+        }
 
         return false;
     }
@@ -721,12 +769,12 @@ public class ActualControlFlowGraph extends ControlFlowGraph<BasicBlock> {
     @Override
     public BytecodeInstruction getInstruction(int instructionId) {
 
-        BytecodeInstruction searchedFor = BytecodeInstructionPool.getInstance(rawGraph.getClassLoader()).getInstruction(className,
-                methodName,
-                instructionId);
+        BytecodeInstruction searchedFor = BytecodeInstructionPool.getInstance(rawGraph.getClassLoader())
+                .getInstruction(className, methodName, instructionId);
 
-        if (containsInstruction(searchedFor))
+        if (containsInstruction(searchedFor)) {
             return searchedFor;
+        }
 
         return null;
     }

--- a/client/src/main/java/org/evosuite/graphs/cfg/BasicBlock.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BasicBlock.java
@@ -31,30 +31,29 @@ import java.util.stream.Collectors;
 
 /**
  * This class is used to represent basic blocks in the control flow graph.
- * <p>
- * A basic block is a list of instructions for which the following holds:
- * <p>
- * Whenever control flow reaches the first instruction of this blocks list,
+ *
+ * <p>A basic block is a list of instructions for which the following holds:
+ *
+ * <p>Whenever control flow reaches the first instruction of this blocks list,
  * control flow will pass through all the instructions of this list successively
  * and not pass another instruction of the underlying method in the mean time.
  * The first element in this blocks list does not have a parent in the CFG that
  * can be prepended to the list and the same would still hold true Finally the
  * last element in this list does not have a child inside the CFG that could be
  * appended to the list such that the above still holds true
- * <p>
- * In other words: - the first/last element of this blocks list has either 0 or
+ *
+ * <p>In other words: - the first/last element of this blocks list has either 0 or
  * >=2 parents/children in the CFG - every other element in the list has exactly
  * 1 parent and exactly 1 child in the raw CFG
- * <p>
- * <p>
- * Taken from:
- * <p>
- * "Efficiently Computing Static Single Assignment Form and the Control
+ *
+ * <p>Taken from:
+ *
+ * <p>"Efficiently Computing Static Single Assignment Form and the Control
  * Dependence Graph" RON CYTRON, JEANNE FERRANTE, BARRY K. ROSEN, and MARK N.
  * WEGMAN IBM Research Division and F. KENNETH ZADECK Brown University 1991
  *
  * @author Andre Mis
- * @see cfg.ActualControlFlowGraph
+ * @see ActualControlFlowGraph
  */
 public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
@@ -62,7 +61,7 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
     private static final Logger logger = LoggerFactory.getLogger(BasicBlock.class);
 
-    private int id = -1;
+    private int blockId = -1;
     protected ClassLoader classLoader;
     protected String className;
     protected String methodName;
@@ -70,7 +69,7 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
     // experiment: since finding the control dependent branches in the CDG might
     // take a little to long, we might want to remember them
     private Set<ControlDependency> controlDependencies;
-    private Set<Integer> controlDependentBranchIDs;
+    private Set<Integer> controlDependentBranchIds;
 
     protected boolean isAuxiliaryBlock = false;
 
@@ -87,8 +86,9 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
      */
     public BasicBlock(ClassLoader classLoader, String className, String methodName,
                       List<BytecodeInstruction> blockNodes) {
-        if (className == null || methodName == null || blockNodes == null)
+        if (className == null || methodName == null || blockNodes == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.className = className;
         this.methodName = methodName;
@@ -97,34 +97,35 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
         setInstructions(blockNodes);
 
         if (!instructions.isEmpty()) {
-            this.id = instructions.get(0).getInstructionId();
+            this.blockId = instructions.get(0).getInstructionId();
         }
 
         checkSanity();
     }
 
     /**
-     * Used by Entry- and ExitBlocks
+     * Used by Entry- and ExitBlocks.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
      */
     protected BasicBlock(String className, String methodName, int id) {
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.className = className;
         this.methodName = methodName;
         this.isAuxiliaryBlock = true;
-        this.id = id;
+        this.blockId = id;
     }
 
     // CDs
 
     /**
-     * Returns the ControlDependenceGraph of this instructions method
-     * <p>
-     * Convenience method. Redirects the call to GraphPool.getCDG()
+     * Returns the ControlDependenceGraph of this instructions method.
+     *
+     * <p>Convenience method. Redirects the call to GraphPool.getCDG()
      *
      * @return a {@link org.evosuite.graphs.cdg.ControlDependenceGraph} object.
      */
@@ -132,9 +133,10 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
         ControlDependenceGraph myCDG = GraphPool.getInstance(classLoader).getCDG(className,
                 methodName);
-        if (myCDG == null)
+        if (myCDG == null) {
             throw new IllegalStateException(
                     "expect GraphPool to know CDG for every method for which an instruction is known");
+        }
 
         return myCDG;
     }
@@ -143,8 +145,8 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
      * Returns all branchIds of Branches this instruction is directly control
      * dependent on as determined by the ControlDependenceGraph for this
      * instruction's method.
-     * <p>
-     * If this instruction is control dependent on the root branch the id -1
+     *
+     * <p>If this instruction is control dependent on the root branch the id -1
      * will be contained in this set
      *
      * @return a {@link java.util.Set} object.
@@ -153,22 +155,22 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
         ControlDependenceGraph myDependence = getCDG();
 
-        if (controlDependentBranchIDs == null) {
-            controlDependentBranchIDs = myDependence.getControlDependentBranchIds(this);
-            //be sure we can iterate over it deterministically
-            controlDependentBranchIDs =
-                    controlDependentBranchIDs.stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        if (controlDependentBranchIds == null) {
+            controlDependentBranchIds = myDependence.getControlDependentBranchIds(this);
+            // be sure we can iterate over it deterministically
+            controlDependentBranchIds =
+                    controlDependentBranchIds.stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new));
         }
-        return controlDependentBranchIDs;
+        return controlDependentBranchIds;
     }
 
     /**
      * Returns a cfg.Branch object for each branch this instruction is control
      * dependent on as determined by the ControlDependenceGraph. If this
      * instruction is only dependent on the root branch this method returns an
-     * empty set
-     * <p>
-     * If this instruction is a Branch and it is dependent on itself - which can
+     * empty set.
+     *
+     * <p>If this instruction is a Branch and it is dependent on itself - which can
      * happen in loops for example - the returned set WILL contain this. If you
      * do not need the full set in order to avoid loops, call
      * getAllControlDependentBranches instead
@@ -177,15 +179,16 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
      */
     public Set<ControlDependency> getControlDependencies() {
 
-        if (controlDependencies == null)
+        if (controlDependencies == null) {
             controlDependencies = getCDG().getControlDependentBranches(this);
+        }
 
         return controlDependencies;
     }
 
     /**
      * <p>
-     * hasControlDependenciesSet
+     * hasControlDependenciesSet.
      * </p>
      *
      * @return a boolean.
@@ -198,30 +201,37 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
     private void setInstructions(List<BytecodeInstruction> blockNodes) {
         for (BytecodeInstruction instruction : blockNodes) {
-            if (!appendInstruction(instruction))
+            if (!appendInstruction(instruction)) {
                 throw new IllegalStateException(
                         "internal error while addind instruction to basic block list");
+            }
         }
-        if (instructions.isEmpty())
+        if (instructions.isEmpty()) {
             throw new IllegalStateException(
                     "expect each basic block to contain at least one instruction");
+        }
     }
 
     private boolean appendInstruction(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
-        if (!className.equals(instruction.getClassName()))
+        }
+        if (!className.equals(instruction.getClassName())) {
             throw new IllegalArgumentException(
                     "expect elements of a basic block to be inside the same class");
-        if (!methodName.equals(instruction.getMethodName()))
+        }
+        if (!methodName.equals(instruction.getMethodName())) {
             throw new IllegalArgumentException(
                     "expect elements of a basic block to be inside the same class");
-        if (instruction.hasBasicBlockSet())
+        }
+        if (instruction.hasBasicBlockSet()) {
             throw new IllegalArgumentException(
                     "expect to get instruction without BasicBlock already set");
-        if (instructions.contains(instruction))
+        }
+        if (instructions.contains(instruction)) {
             throw new IllegalArgumentException(
                     "a basic block can not contain the same element twice");
+        }
 
         instruction.setBasicBlock(this);
 
@@ -232,22 +242,23 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
     /**
      * <p>
-     * containsInstruction
+     * containsInstruction.
      * </p>
      *
      * @param instruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a boolean.
      */
     public boolean containsInstruction(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         return instructions.contains(instruction);
     }
 
     /**
      * <p>
-     * containsInstruction
+     * containsInstruction.
      * </p>
      *
      * @param insnNode a {@link org.objectweb.asm.tree.AbstractInsnNode} object.
@@ -255,56 +266,61 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
      */
     public boolean containsInstruction(AbstractInsnNode insnNode) {
         for (BytecodeInstruction instruction : instructions) {
-            if (instruction.getASMNode().equals(insnNode))
+            if (instruction.getASMNode().equals(insnNode)) {
                 return true;
+            }
         }
         return false;
     }
 
     /**
      * <p>
-     * getFirstInstruction
+     * getFirstInstruction.
      * </p>
      *
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      */
     public BytecodeInstruction getFirstInstruction() {
-        if (instructions.isEmpty())
+        if (instructions.isEmpty()) {
             return null;
+        }
         return instructions.get(0);
     }
 
     /**
      * <p>
-     * getLastInstruction
+     * getLastInstruction.
      * </p>
      *
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      */
     public BytecodeInstruction getLastInstruction() {
-        if (instructions.isEmpty())
+        if (instructions.isEmpty()) {
             return null;
+        }
         return instructions.get(instructions.size() - 1);
     }
 
     /**
      * <p>
-     * getFirstLine
+     * getFirstLine.
      * </p>
      *
      * @return a int.
      */
     public int getFirstLine() {
-        for (BytecodeInstruction ins : instructions)
-            if (ins.hasLineNumberSet())
+        for (BytecodeInstruction ins : instructions) {
+            if (ins.hasLineNumberSet()) {
                 return ins.getLineNumber();
+            }
+        }
 
         return -1;
     }
 
     /**
      * <p>
-     * getLastLine
+     * getLastLine.
      * </p>
      *
      * @return a int.
@@ -313,22 +329,24 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
         int r = -1;
 
-        for (BytecodeInstruction ins : instructions)
-            if (ins.hasLineNumberSet())
+        for (BytecodeInstruction ins : instructions) {
+            if (ins.hasLineNumberSet()) {
                 r = ins.getLineNumber();
+            }
+        }
 
         return r;
     }
 
     /**
      * <p>
-     * getName
+     * getName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
      */
     public String getName() {
-        return (isAuxiliaryBlock ? "aux" : "") + "BasicBlock " + id;
+        return (isAuxiliaryBlock ? "aux" : "") + "BasicBlock " + blockId;
     }
 
     /**
@@ -355,7 +373,7 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
     /**
      * <p>
-     * explain
+     * explain.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -381,14 +399,16 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
     @Override
     public String toString() {
 
-        String r = "BB" + id;
+        String r = "BB" + blockId;
 
-        if (instructions.size() < 5)
-            for (BytecodeInstruction ins : instructions)
+        if (instructions.size() < 5) {
+            for (BytecodeInstruction ins : instructions) {
                 r = r.trim() + " " + ins.getInstructionType();
-        else
+            }
+        } else {
             r += " " + getFirstInstruction().getInstructionType() + " ... "
                     + getLastInstruction().getInstructionType();
+        }
 
         int startLine = getFirstLine();
         int endLine = getLastLine();
@@ -407,7 +427,7 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
         int result = 1;
         result = prime * result
                 + ((className == null) ? 0 : className.hashCode());
-        result = prime * result + id;
+        result = prime * result + blockId;
         result = prime * result
                 + ((instructions == null) ? 0 : instructions.hashCode());
         result = prime * result + (isAuxiliaryBlock ? 1231 : 1237);
@@ -418,48 +438,55 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (!(obj instanceof BasicBlock))
+        }
+        if (!(obj instanceof BasicBlock)) {
             return false;
+        }
         BasicBlock other = (BasicBlock) obj;
-        if (id != other.id)
+        if (blockId != other.blockId) {
             return false;
+        }
         if (className == null) {
-            if (other.className != null)
+            if (other.className != null) {
                 return false;
-        } else if (!className.equals(other.className))
+            }
+        } else if (!className.equals(other.className)) {
             return false;
+        }
         if (methodName == null) {
-            if (other.methodName != null)
+            if (other.methodName != null) {
                 return false;
-        } else if (!methodName.equals(other.methodName))
+            }
+        } else if (!methodName.equals(other.methodName)) {
             return false;
+        }
         if (instructions == null) {
-            if (other.instructions != null)
+            if (other.instructions != null) {
                 return false;
-        } else if (!instructions.equals(other.instructions))
+            }
+        } else if (!instructions.equals(other.instructions)) {
             return false;
-        if (isEntryBlock() != other.isEntryBlock())
+        }
+        if (isEntryBlock() != other.isEntryBlock()) {
             return false;
+        }
         return isExitBlock() == other.isExitBlock();
     }
 
     /**
-     * <p>
-     * checkSanity
-     * </p>
+     * Checks sanity of this block.
      */
     public void checkSanity() {
         logger.debug("checking sanity of " + this);
     }
 
     /**
-     * <p>
-     * isEntryBlock
-     * </p>
+     * Checks if this block is an entry block.
      *
      * @return a boolean.
      */
@@ -468,9 +495,7 @@ public class BasicBlock implements Serializable, Iterable<BytecodeInstruction> {
     }
 
     /**
-     * <p>
-     * isExitBlock
-     * </p>
+     * Checks if this block is an exit block.
      *
      * @return a boolean.
      */

--- a/client/src/main/java/org/evosuite/graphs/cfg/BytecodeAnalyzer.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BytecodeAnalyzer.java
@@ -26,15 +26,15 @@ import org.objectweb.asm.tree.analysis.Frame;
 import org.objectweb.asm.tree.analysis.SourceInterpreter;
 
 /**
- * This class analyzes the byteCode from a method in the CUT and generates it's
- * CFG using a cfg.CFGGenerator
- * <p>
- * This is done using the ASM library, extending from it's asm.Analyzer and
+ * This class analyzes the byteCode from a method in the CUT and generates its
+ * CFG using a cfg.CFGGenerator.
+ *
+ * <p>This is done using the ASM library, extending from its asm.Analyzer and
  * redirecting the calls to newControlFlowEdge() to an instance of
  * cfg.CFGGenerator which in turn builds up a graph representation of the CFG,
  * which later is used to build a "smaller" CFG containing not
  * BytecodeInstructions but BasicBlocks of BytecodeInstructions which are always
- * executed successively
+ * executed successively.
  *
  * @author Gordon Fraser, Andre Mis
  */
@@ -43,9 +43,7 @@ public class BytecodeAnalyzer extends Analyzer {
     CFGGenerator cfgGenerator;
 
     /**
-     * <p>
      * Constructor for BytecodeAnalyzer.
-     * </p>
      */
     public BytecodeAnalyzer() {
         super(new SourceInterpreter());
@@ -72,8 +70,9 @@ public class BytecodeAnalyzer extends Analyzer {
 
         Frame[] frames = getFrames();
 
-        if (frames.length == 0)
+        if (frames.length == 0) {
             return null;
+        }
 
         return (CFGFrame) getFrames()[0];
     }
@@ -81,14 +80,15 @@ public class BytecodeAnalyzer extends Analyzer {
     /**
      * After running analyze() this method yields the filled CFGGenerator for
      * further processing of the gathered information from analyze() within the
-     * ByteCode representation of EvoSuite
+     * ByteCode representation of EvoSuite.
      *
      * @return a {@link org.evosuite.graphs.cfg.CFGGenerator} object.
      */
     public CFGGenerator retrieveCFGGenerator() {
-        if (cfgGenerator == null)
+        if (cfgGenerator == null) {
             throw new IllegalStateException(
                     "you have to call analyze() first before retrieving the CFGGenerator");
+        }
         return cfgGenerator;
     }
 
@@ -96,19 +96,18 @@ public class BytecodeAnalyzer extends Analyzer {
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Called for each non-exceptional cfg edge
+     *
+     * <p>Called for each non-exceptional cfg edge.
      */
     @Override
     protected void newControlFlowEdge(int src, int dst) {
-
         cfgGenerator.registerControlFlowEdge(src, dst, getFrames(), false);
     }
 
     /**
      * {@inheritDoc}
-     * <p>
-     * We also need to keep track of exceptional edges - they are also branches
+     *
+     * <p>We also need to keep track of exceptional edges - they are also branches.
      */
     @Override
     protected boolean newControlFlowExceptionEdge(int src, int dst) {
@@ -122,8 +121,8 @@ public class BytecodeAnalyzer extends Analyzer {
      * {@inheritDoc}
      */
     @Override
-    protected Frame newFrame(int nLocals, int nStack) {
-        return new CFGFrame(nLocals, nStack);
+    protected Frame newFrame(int numLocals, int numStack) {
+        return new CFGFrame(numLocals, numStack);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstruction.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstruction.java
@@ -34,14 +34,14 @@ import java.io.Serializable;
 import java.util.Set;
 
 /**
- * Internal representation of a BytecodeInstruction
- * <p>
- * Extends ASMWrapper which serves as an interface to the ASM library.
- * <p>
- * Known super classes are DefUse and Branch which yield specific functionality
- * needed to achieve theirs respective coverage criteria
- * <p>
- * Old: Node of the control flow graph
+     * Internal representation of a BytecodeInstruction.
+     *
+     * <p>Extends ASMWrapper which serves as an interface to the ASM library.
+     *
+     * <p>Known super classes are DefUse and Branch which yield specific functionality
+     * needed to achieve theirs respective coverage criteria.
+     *
+     * <p>Old: Node of the control flow graph.
  *
  * @author Gordon Fraser, Andre Mis
  */
@@ -69,7 +69,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     /**
      * Generates a ByteCodeInstruction instance that represents a byteCode
      * instruction as indicated by the given ASMNode in the given method and
-     * class
+     * class.
      *
      * @param className      a {@link java.lang.String} object.
      * @param methodName     a {@link java.lang.String} object.
@@ -80,11 +80,13 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     public BytecodeInstruction(ClassLoader classLoader, String className,
                                String methodName, int instructionId, int bytecodeOffset, AbstractInsnNode asmNode) {
 
-        if (className == null || methodName == null || asmNode == null)
+        if (className == null || methodName == null || asmNode == null) {
             throw new IllegalArgumentException("null given");
-        if (instructionId < 0)
+        }
+        if (instructionId < 0) {
             throw new IllegalArgumentException(
                     "expect instructionId to be positive, not " + instructionId);
+        }
 
         this.instructionId = instructionId;
         this.bytecodeOffset = bytecodeOffset;
@@ -97,7 +99,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     /**
-     * Can represent any byteCode instruction
+     * Can represent any byteCode instruction.
      *
      * @param wrap a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      */
@@ -149,29 +151,32 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
         this(classLoader, className, methodName, instructionId, bytecodeOffset, asmNode);
 
-        if (lineNumber != -1)
+        if (lineNumber != -1) {
             setLineNumber(lineNumber);
+        }
     }
 
     // getter + setter
 
     private void setMethodName(String methodName) {
-        if (methodName == null)
+        if (methodName == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.methodName = methodName;
     }
 
     private void setClassName(String className) {
-        if (className == null)
+        if (className == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.className = className;
     }
 
     /**
      * <p>
-     * setCFGFrame
+     * setCFGFrame.
      * </p>
      *
      * @param frame a {@link org.evosuite.graphs.cfg.CFGFrame} object.
@@ -192,7 +197,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * getBytecodeOffset
+     * getBytecodeOffset.
      * </p>
      *
      * @return a int.
@@ -223,7 +228,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * getName
+     * getName.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -234,22 +239,24 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * Return's the BasicBlock that contain's this instruction in it's CFG.
-     * <p>
-     * If no BasicBlock containing this instruction was created yet, null is
+     *
+     * <p>If no BasicBlock containing this instruction was created yet, null is
      * returned.
      *
      * @return a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      */
     public BasicBlock getBasicBlock() {
-        if (!hasBasicBlockSet())
+        if (!hasBasicBlockSet()) {
             retrieveBasicBlock();
+        }
         return basicBlock;
     }
 
     private void retrieveBasicBlock() {
 
-        if (basicBlock == null)
+        if (basicBlock == null) {
             basicBlock = getActualCFG().getBlockOf(this);
+        }
     }
 
     /**
@@ -259,23 +266,25 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * @param block a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      */
     public void setBasicBlock(BasicBlock block) {
-        if (block == null)
+        if (block == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         if (!block.getClassName().equals(getClassName())
-                || !block.getMethodName().equals(getMethodName()))
+                || !block.getMethodName().equals(getMethodName())) {
             throw new IllegalArgumentException(
                     "expect block to be for the same method and class as this instruction");
-        if (this.basicBlock != null)
+        }
+        if (this.basicBlock != null) {
             throw new IllegalArgumentException(
                     "basicBlock already set! not allowed to overwrite");
+        }
 
         this.basicBlock = block;
     }
 
     /**
-     * Checks whether this instance's basicBlock has already been set by the CFG
-     * or
+     * Check whether this instance's basicBlock has already been set by the CFG.
      *
      * @return a boolean.
      */
@@ -289,8 +298,9 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     @Override
     public int getLineNumber() {
 
-        if (lineNumber == -1 && isLineNumber())
+        if (lineNumber == -1 && isLineNumber()) {
             retrieveLineNumber();
+        }
 
         return lineNumber;
     }
@@ -303,19 +313,23 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * @param lineNumber a int.
      */
     public void setLineNumber(int lineNumber) {
-        if (lineNumber <= 0)
+        if (lineNumber <= 0) {
             throw new IllegalArgumentException(
                     "expect lineNumber value to be positive");
+        }
 
-        if (isLabel())
+        if (isLabel()) {
             return;
+        }
 
         if (isLineNumber()) {
             int asmLine = super.getLineNumber();
             // sanity check
-            if (lineNumber != -1 && asmLine != lineNumber)
+            if (lineNumber != -1 && asmLine != lineNumber) {
                 throw new IllegalStateException(
-                        "linenumber instruction has lineNumber field set to a value different from instruction linenumber");
+                        "linenumber instruction has lineNumber field set to a value different "
+                                + "from instruction linenumber");
+            }
             this.lineNumber = asmLine;
         } else {
             this.lineNumber = lineNumber;
@@ -326,12 +340,12 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * At first, if this instruction constitutes a line number instruction this
      * method tries to retrieve the lineNumber from the underlying asmNode and
      * set the lineNumber field to the value given by the asmNode.
-     * <p>
-     * This can lead to an IllegalStateException, should the lineNumber field
-     * have been set to another value previously
-     * <p>
-     * After that, if the lineNumber field is still not initialized, this method
-     * returns false Otherwise it returns true
+     *
+     * <p>This can lead to an IllegalStateException, should the lineNumber field
+     * have been set to another value previously.
+     *
+     * <p>After that, if the lineNumber field is still not initialized, this method
+     * returns false Otherwise it returns true.
      *
      * @return a boolean.
      */
@@ -343,18 +357,20 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     /**
      * If the underlying ASMNode is a LineNumberNode the lineNumber field of
      * this instance will be set to the lineNumber contained in that
-     * LineNumberNode
-     * <p>
-     * Should the lineNumber field have been set to a value different from that
-     * contained in the asmNode, this method throws an IllegalStateExeption
+     * LineNumberNode.
+     *
+     * <p>Should the lineNumber field have been set to a value different from that
+     * contained in the asmNode, this method throws an IllegalStateExeption.
      */
     private void retrieveLineNumber() {
         if (isLineNumber()) {
             int asmLine = super.getLineNumber();
             // sanity check
-            if (this.lineNumber != -1 && asmLine != this.lineNumber)
+            if (this.lineNumber != -1 && asmLine != this.lineNumber) {
                 throw new IllegalStateException(
-                        "lineNumber field was manually set to a value different from the actual lineNumber contained in LineNumberNode");
+                        "lineNumber field was manually set to a value different from the actual "
+                                + "lineNumber contained in LineNumberNode");
+            }
             this.lineNumber = asmLine;
         }
     }
@@ -362,55 +378,55 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     // --- graph section ---
 
     /**
-     * Returns the ActualControlFlowGraph of this instructions method
-     * <p>
-     * Convenience method. Redirects the call to GraphPool.getActualCFG()
+     * Returns the ActualControlFlowGraph of this instructions method.
+     *
+     * <p>Convenience method. Redirects the call to GraphPool.getActualCFG()
      *
      * @return a {@link org.evosuite.graphs.cfg.ActualControlFlowGraph} object.
      */
     public ActualControlFlowGraph getActualCFG() {
 
-        ActualControlFlowGraph myCFG = GraphPool.getInstance(classLoader).getActualCFG(className,
-                methodName);
-        if (myCFG == null)
+        ActualControlFlowGraph myCFG = GraphPool.getInstance(classLoader).getActualCFG(className, methodName);
+        if (myCFG == null) {
             throw new IllegalStateException(
                     "expect GraphPool to know CFG for every method for which an instruction is known");
+        }
 
         return myCFG;
     }
 
     /**
-     * Returns the RawControlFlowGraph of this instructions method
-     * <p>
-     * Convenience method. Redirects the call to GraphPool.getRawCFG()
+     * Returns the RawControlFlowGraph of this instructions method.
+     *
+     * <p>Convenience method. Redirects the call to GraphPool.getRawCFG()
      *
      * @return a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
      */
     public RawControlFlowGraph getRawCFG() {
 
-        RawControlFlowGraph myCFG = GraphPool.getInstance(classLoader).getRawCFG(className,
-                methodName);
-        if (myCFG == null)
+        RawControlFlowGraph myCFG = GraphPool.getInstance(classLoader).getRawCFG(className, methodName);
+        if (myCFG == null) {
             throw new IllegalStateException(
                     "expect GraphPool to know CFG for every method for which an instruction is known");
+        }
 
         return myCFG;
     }
 
     /**
-     * Returns the ControlDependenceGraph of this instructions method
-     * <p>
-     * Convenience method. Redirects the call to GraphPool.getCDG()
+     * Returns the ControlDependenceGraph of this instructions method.
+     *
+     * <p>Convenience method. Redirects the call to GraphPool.getCDG()
      *
      * @return a {@link org.evosuite.graphs.cdg.ControlDependenceGraph} object.
      */
     public ControlDependenceGraph getCDG() {
 
-        ControlDependenceGraph myCDG = GraphPool.getInstance(classLoader).getCDG(className,
-                methodName);
-        if (myCDG == null)
+        ControlDependenceGraph myCDG = GraphPool.getInstance(classLoader).getCDG(className, methodName);
+        if (myCDG == null) {
             throw new IllegalStateException(
                     "expect GraphPool to know CDG for every method for which an instruction is known");
+        }
 
         return myCDG;
     }
@@ -418,15 +434,15 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     // --- CDG-Section ---
 
     /**
-     * Returns a cfg.Branch object for each branch this instruction is control
+     * Get a cfg.Branch object for each branch this instruction is control
      * dependent on as determined by the ControlDependenceGraph. If this
      * instruction is only dependent on the root branch this method returns an
-     * empty set
-     * <p>
-     * If this instruction is a Branch and it is dependent on itself - which can
+     * empty set.
+     *
+     * <p>If this instruction is a Branch and it is dependent on itself - which can
      * happen in loops for example - the returned set WILL contain this. If you
      * do not need the full set in order to avoid loops, call
-     * getAllControlDependentBranches instead
+     * getAllControlDependentBranches instead.
      *
      * @return a {@link java.util.Set} object.
      */
@@ -440,15 +456,15 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     /**
-     * This method returns a random Branch among all Branches this instruction
-     * is control dependent on
-     * <p>
-     * If this instruction is only dependent on the root branch, this method
-     * returns null
-     * <p>
-     * Since EvoSuite was previously unable to detect multiple control
+     * Get a random Branch among all Branches this instruction
+     * is control dependent on.
+     *
+     * <p>If this instruction is only dependent on the root branch, this method
+     * returns null.
+     *
+     * <p>Since EvoSuite was previously unable to detect multiple control
      * dependencies for one instruction this method serves as a backwards
-     * compatibility bridge
+     * compatibility bridge.
      *
      * @return a {@link org.evosuite.coverage.branch.Branch} object.
      */
@@ -456,19 +472,20 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
         Set<ControlDependency> controlDependentBranches = getControlDependencies();
 
-        for (ControlDependency cd : controlDependentBranches)
+        for (ControlDependency cd : controlDependentBranches) {
             return cd.getBranch();
+        }
 
         return null; // root branch
     }
 
     /**
-     * Returns all branchIds of Branches this instruction is directly control
+     * A set of branchIds of Branches this instruction is directly control
      * dependent on as determined by the ControlDependenceGraph for this
      * instruction's method.
-     * <p>
-     * If this instruction is control dependent on the root branch the id -1
-     * will be contained in this set
+     *
+     * <p>If this instruction is control dependent on the root branch the id -1
+     * will be contained in this set.
      *
      * @return a {@link java.util.Set} object.
      */
@@ -480,7 +497,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     /**
-     * Determines whether or not this instruction is control dependent on the
+     * Return true if this instruction is control dependent on the
      * root branch of it's method by calling getControlDependentBranchIds() to
      * see if the return contains -1.
      *
@@ -493,24 +510,25 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     /**
      * This method returns a random branchId among all branchIds this
      * instruction is control dependent on.
-     * <p>
-     * This method returns -1 if getControlDependentBranch() returns null,
-     * otherwise that Branch's branchId is returned
-     * <p>
-     * Note: The returned branchExpressionValue comes from the same Branch
-     * getControlDependentBranch() and getControlDependentBranchId() return
-     * <p>
-     * Since EvoSuite was previously unable to detect multiple control
+     *
+     * <p>This method returns -1 if getControlDependentBranch() returns null,
+     * otherwise that Branch's branchId is returned.
+     *
+     * <p>Note: The returned branchExpressionValue comes from the same Branch
+     * getControlDependentBranch() and getControlDependentBranchId() return.
+     *
+     * <p>Since EvoSuite was previously unable to detect multiple control
      * dependencies for one instruction this method serves as a backwards
-     * compatibility bridge
+     * compatibility bridge.
      *
      * @return a int.
      */
     public int getControlDependentBranchId() {
 
         Branch b = getControlDependentBranch();
-        if (b == null)
+        if (b == null) {
             return -1;
+        }
 
         return b.getActualBranchId();
     }
@@ -518,16 +536,16 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     /**
      * This method returns the branchExpressionValue from a random Branch among
      * all Branches this instruction is control dependent on.
-     * <p>
-     * This method returns true if getControlDependentBranch() returns null,
-     * otherwise that Branch's branchExpressionValue is returned
-     * <p>
-     * Note: The returned branchExpressionValue comes from the same Branch
-     * getControlDependentBranch() and getControlDependentBranchId() return
-     * <p>
-     * Since EvoSuite was previously unable to detect multiple control
+     *
+     * <p>This method returns true if getControlDependentBranch() returns null,
+     * otherwise that Branch's branchExpressionValue is returned.
+     *
+     * <p>Note: The returned branchExpressionValue comes from the same Branch
+     * getControlDependentBranch() and getControlDependentBranchId() return.
+     *
+     * <p>Since EvoSuite was previously unable to detect multiple control
      * dependencies for one instruction this method serves as a backwards
-     * compatibility bridge
+     * compatibility bridge.
      *
      * @return a boolean.
      */
@@ -539,19 +557,22 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * getBranchExpressionValue
+     * getBranchExpressionValue.
      * </p>
      *
      * @param b a {@link org.evosuite.coverage.branch.Branch} object.
      * @return a boolean.
      */
     public boolean getBranchExpressionValue(Branch b) {
-        if (!isDirectlyControlDependentOn(b))
+        if (!isDirectlyControlDependentOn(b)) {
             throw new IllegalArgumentException(
-                    "this method can only be called for branches that this instruction is directly control dependent on.");
+                    "this method can only be called for branches that this instruction "
+                            + "is directly control dependent on.");
+        }
 
-        if (b == null)
+        if (b == null) {
             return true; // root branch special case
+        }
 
         return getControlDependency(b).getBranchExpressionValue();
     }
@@ -561,48 +582,55 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * on the given Branch. Meaning within this instruction CDG there is an
      * incoming ControlFlowEdge to this instructions BasicBlock holding the
      * given Branch as it's branchInstruction.
-     * <p>
-     * If the given Branch is null, this method checks whether the this
+     *
+     * <p>If the given Branch is null, this method checks whether the this
      * instruction is control dependent on the root branch of it's method.
      *
      * @param branch a {@link org.evosuite.coverage.branch.Branch} object.
      * @return a boolean.
      */
     public boolean isDirectlyControlDependentOn(Branch branch) {
-        if (branch == null)
+        if (branch == null) {
             return getControlDependentBranchIds().contains(-1);
+        }
 
-        for (ControlDependency cd : getControlDependencies())
-            if (cd.getBranch().equals(branch))
+        for (ControlDependency cd : getControlDependencies()) {
+            if (cd.getBranch().equals(branch)) {
                 return true;
+            }
+        }
 
         return false;
     }
 
     /**
      * <p>
-     * getControlDependency
+     * getControlDependency.
      * </p>
      *
      * @param branch a {@link org.evosuite.coverage.branch.Branch} object.
      * @return a {@link org.evosuite.graphs.cfg.ControlDependency} object.
      */
     public ControlDependency getControlDependency(Branch branch) {
-        if (!isDirectlyControlDependentOn(branch))
+        if (!isDirectlyControlDependentOn(branch)) {
             throw new IllegalArgumentException(
                     "instruction not directly control dependent on given branch");
+        }
 
-        for (ControlDependency cd : getControlDependencies())
-            if (cd.getBranch().equals(branch))
+        for (ControlDependency cd : getControlDependencies()) {
+            if (cd.getBranch().equals(branch)) {
                 return cd;
+            }
+        }
 
         throw new IllegalStateException(
-                "expect getControlDependencies() to contain a CD for each branch that isDirectlyControlDependentOn() returns true on");
+                "expect getControlDependencies() to contain a CD for each branch that "
+                        + "isDirectlyControlDependentOn() returns true on");
     }
 
     /**
      * <p>
-     * getCDGDepth
+     * getCDGDepth.
      * </p>
      *
      * @return a int.
@@ -610,12 +638,14 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     public int getCDGDepth() {
         int min = Integer.MAX_VALUE;
         Set<ControlDependency> dependencies = getControlDependencies();
-        if (dependencies.isEmpty())
+        if (dependencies.isEmpty()) {
             min = 1;
+        }
         for (ControlDependency dependency : dependencies) {
             int depth = getCDG().getControlDependenceDepth(dependency);
-            if (depth < min)
+            if (depth < min) {
                 min = depth;
+            }
         }
         return min;
     }
@@ -624,7 +654,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * explain
+     * explain.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -633,9 +663,11 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
         if (isBranch()) {
             if (BranchPool.getInstance(classLoader).isKnownAsBranch(this)) {
                 Branch b = BranchPool.getInstance(classLoader).getBranchForInstruction(this);
-                if (b == null)
+                if (b == null) {
                     throw new IllegalStateException(
-                            "expect BranchPool to be able to return Branches for instructions fullfilling BranchPool.isKnownAsBranch()");
+                            "expect BranchPool to be able to return Branches for instructions "
+                                    + "fullfilling BranchPool.isKnownAsBranch()");
+                }
 
                 return "Branch " + b.getActualBranchId() + " - "
                         + getInstructionType();
@@ -649,7 +681,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * getASMNodeString
+     * getASMNodeString.
      * </p>
      *
      * @return a {@link java.lang.String} object.
@@ -659,53 +691,55 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
         String opcode = getInstructionType();
 
         String stack = "";
-        if (frame == null)
+        if (frame == null) {
             stack = "null";
-        else
+        } else {
             for (int i = 0; i < frame.getStackSize(); i++) {
                 stack += frame.getStack(i) + ",";
             }
+        }
 
         if (asmNode instanceof LabelNode) {
             return "LABEL " + ((LabelNode) asmNode).getLabel().toString();
-        } else if (asmNode instanceof FieldInsnNode)
+        } else if (asmNode instanceof FieldInsnNode) {
             return "Field" + " " + ((FieldInsnNode) asmNode).owner + "."
                     + ((FieldInsnNode) asmNode).name + " Type=" + type
                     + ", Opcode=" + opcode;
-        else if (asmNode instanceof FrameNode)
+        } else if (asmNode instanceof FrameNode) {
             return "Frame" + " " + asmNode.getOpcode() + " Type=" + type
                     + ", Opcode=" + opcode;
-        else if (asmNode instanceof IincInsnNode)
+        } else if (asmNode instanceof IincInsnNode) {
             return "IINC " + ((IincInsnNode) asmNode).var + " Type=" + type
                     + ", Opcode=" + opcode;
-        else if (asmNode instanceof InsnNode)
+        } else if (asmNode instanceof InsnNode) {
             return "" + opcode;
-        else if (asmNode instanceof IntInsnNode)
+        } else if (asmNode instanceof IntInsnNode) {
             return "INT " + ((IntInsnNode) asmNode).operand + " Type=" + type
                     + ", Opcode=" + opcode;
-        else if (asmNode instanceof MethodInsnNode)
-            return opcode + " " + ((MethodInsnNode) asmNode).owner + "." + ((MethodInsnNode) asmNode).name + ((MethodInsnNode) asmNode).desc;
-        else if (asmNode instanceof JumpInsnNode)
+        } else if (asmNode instanceof MethodInsnNode) {
+            return opcode + " " + ((MethodInsnNode) asmNode).owner + "."
+                    + ((MethodInsnNode) asmNode).name + ((MethodInsnNode) asmNode).desc;
+        } else if (asmNode instanceof JumpInsnNode) {
             return "JUMP " + ((JumpInsnNode) asmNode).label.getLabel()
                     + " Type=" + type + ", Opcode=" + opcode + ", Stack: "
                     + stack + " - Line: " + lineNumber;
-        else if (asmNode instanceof LdcInsnNode)
+        } else if (asmNode instanceof LdcInsnNode) {
             return "LDC " + ((LdcInsnNode) asmNode).cst + " Type=" + type; // +
             // ", Opcode=";
             // + opcode; // cst starts with mutationid if
             // this is location of mutation
-        else if (asmNode instanceof LineNumberNode)
+        } else if (asmNode instanceof LineNumberNode) {
             return "LINE " + " " + ((LineNumberNode) asmNode).line;
-        else if (asmNode instanceof LookupSwitchInsnNode)
+        } else if (asmNode instanceof LookupSwitchInsnNode) {
             return "LookupSwitchInsnNode" + " " + asmNode.getOpcode()
                     + " Type=" + type + ", Opcode=" + opcode;
-        else if (asmNode instanceof MultiANewArrayInsnNode)
+        } else if (asmNode instanceof MultiANewArrayInsnNode) {
             return "MULTIANEWARRAY " + " " + asmNode.getOpcode() + " Type="
                     + type + ", Opcode=" + opcode;
-        else if (asmNode instanceof TableSwitchInsnNode)
+        } else if (asmNode instanceof TableSwitchInsnNode) {
             return "TableSwitchInsnNode" + " " + asmNode.getOpcode() + " Type="
                     + type + ", Opcode=" + opcode;
-        else if (asmNode instanceof TypeInsnNode) {
+        } else if (asmNode instanceof TypeInsnNode) {
             switch (asmNode.getOpcode()) {
                 case Opcodes.NEW:
                     return "NEW " + ((TypeInsnNode) asmNode).desc;
@@ -718,18 +752,16 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
                 default:
                     return "Unknown node" + " Type=" + type + ", Opcode=" + opcode;
             }
-        }
-        // return "TYPE " + " " + node.getOpcode() + " Type=" + type
-        // + ", Opcode=" + opcode;
-        else if (asmNode instanceof VarInsnNode)
+        } else if (asmNode instanceof VarInsnNode) {
             return opcode + " " + ((VarInsnNode) asmNode).var;
-        else
+        } else {
             return "Unknown node" + " Type=" + type + ", Opcode=" + opcode;
+        }
     }
 
     /**
      * <p>
-     * printFrameInformation
+     * printFrameInformation.
      * </p>
      */
     public void printFrameInformation() {
@@ -740,7 +772,8 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
             sb.append(" ").append(i).append("(").append(v.insns.size()).append("): ");
             for (Object n : v.insns) {
                 AbstractInsnNode node = (AbstractInsnNode) n;
-                BytecodeInstruction ins = BytecodeInstructionPool.getInstance(classLoader).getInstruction(className,
+                BytecodeInstruction ins = BytecodeInstructionPool.getInstance(classLoader).getInstruction(
+                        className,
                         methodName,
                         node);
                 sb.append(ins.toString()).append(", ");
@@ -755,7 +788,8 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
             sb.append(" ").append(i).append("(").append(v.insns.size()).append("): ");
             for (Object n : v.insns) {
                 AbstractInsnNode node = (AbstractInsnNode) n;
-                BytecodeInstruction ins = BytecodeInstructionPool.getInstance(classLoader).getInstruction(className,
+                BytecodeInstruction ins = BytecodeInstructionPool.getInstance(classLoader).getInstruction(
+                        className,
                         methodName,
                         node);
                 sb.append(ins.toString()).append(", ");
@@ -777,20 +811,21 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
         r += " (" + +bytecodeOffset + ")";
         r += " " + explain();
 
-        if (hasLineNumberSet() && !isLineNumber())
+        if (hasLineNumberSet() && !isLineNumber()) {
             r += " l" + getLineNumber();
+        }
 
         return r;
     }
 
     /**
      * Convenience method:
-     * <p>
-     * If this instruction is known by the BranchPool to be a Branch, you can
+     *
+     * <p>If this instruction is known by the BranchPool to be a Branch, you can
      * call this method in order to retrieve the corresponding Branch object
      * registered within the BranchPool.
-     * <p>
-     * Otherwise this method will return null;
+     *
+     * <p>Otherwise this method will return null;
      *
      * @return a {@link org.evosuite.coverage.branch.Branch} object.
      */
@@ -805,7 +840,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * proceedsOwnConstructorInvocation
+     * proceedsOwnConstructorInvocation.
      * </p>
      *
      * @return a boolean.
@@ -813,18 +848,21 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     public boolean proceedsOwnConstructorInvocation() {
 
         RawControlFlowGraph cfg = getRawCFG();
-        for (BytecodeInstruction other : cfg.vertexSet())
+        for (BytecodeInstruction other : cfg.vertexSet()) {
             if (other.isConstructorInvocation()
-                    && other.isMethodCallOnSameObject())
-                if (getInstructionId() < other.getInstructionId())
+                    && other.isMethodCallOnSameObject()) {
+                if (getInstructionId() < other.getInstructionId()) {
                     return true;
+                }
+            }
+        }
 
         return false;
     }
 
     /**
      * <p>
-     * isWithinConstructor
+     * isWithinConstructor.
      * </p>
      *
      * @return a boolean.
@@ -835,7 +873,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * isLastInstructionInMethod
+     * isLastInstructionInMethod.
      * </p>
      *
      * @return a boolean.
@@ -846,7 +884,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * canBeExitPoint
+     * canBeExitPoint.
      * </p>
      *
      * @return a boolean.
@@ -856,13 +894,14 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     /**
-     * Returns the RawCFG of the method called by this instruction
+     * Returns the RawCFG of the method called by this instruction.
      *
      * @return a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
      */
     public RawControlFlowGraph getCalledCFG() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return null;
+        }
 
         return GraphPool.getInstance(classLoader).getRawCFG(getCalledMethodsClass(),
                 getCalledMethod());
@@ -870,51 +909,56 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * Determines whether this instruction calls a method on its own Object
-     * ('this')
-     * <p>
-     * This is done using the getSourceOfMethodInvocationInstruction() method
+     * ('this').
+     *
+     * <p>This is done using the getSourceOfMethodInvocationInstruction() method
      * and checking if the return of that method loads this using loadsReferenceToThis()
      *
      * @return a boolean.
      */
     public boolean isMethodCallOnSameObject() {
         BytecodeInstruction srcInstruction = getSourceOfMethodInvocationInstruction();
-        if (srcInstruction == null)
+        if (srcInstruction == null) {
             return false;
+        }
         return srcInstruction.loadsReferenceToThis();
     }
 
     /**
-     * Determines whether this instruction calls a method on a field variable
-     * <p>
-     * This is done using the getSourceOfMethodInvocationInstruction() method
+     * Determines whether this instruction calls a method on a field variable.
+     *
+     * <p>This is done using the getSourceOfMethodInvocationInstruction() method
      * and checking if the return of that method is a field use instruction
      *
      * @return a boolean.
      */
-
-
     public boolean isMethodCallOfField() {
-        if (!this.isMethodCall())
+        if (!this.isMethodCall()) {
             return false;
-        if (this.isInvokeStatic())
+        }
+        if (this.isInvokeStatic()) {
             return false;
+        }
         // If the instruction belongs to static initialization block of the
         // class, then the method call cannot be done on a fields.
-        if (this.methodName.contains("<clinit>"))
+        if (this.methodName.contains("<clinit>")) {
             return false;
+        }
         BytecodeInstruction srcInstruction = getSourceOfMethodInvocationInstruction();
-        if (srcInstruction == null)
+        if (srcInstruction == null) {
             return false;
+        }
 
         //is a field use? But field uses are also "GETSTATIC"
         if (srcInstruction.isFieldNodeUse()) {
 
             //is static? if not, return yes. This control is not necessary in theory, but you never know...
             if (srcInstruction.isStaticDefUse()) {
-                //is static, check if the name of the class that contain the static field is equals to the current class name
-                //if is equals, return true, otherwise we are in a case where we are calling a field over an external static class
-                //e.g. System.out
+                // is static, check if the name of the class that contain the static field is equals
+                // to the current class name
+                // if is equals, return true, otherwise we are in a case where we are calling a field
+                // over an external static class
+                // e.g. System.out
                 if (srcInstruction.asmNode instanceof FieldInsnNode) {
                     String classNameField = ((FieldInsnNode) srcInstruction.asmNode).owner;
                     classNameField = classNameField.replace('/', '.');
@@ -929,9 +973,9 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     /**
-     * Determines the name of the field variable this method call is invoked on
-     * <p>
-     * This is done using the getSourceOfMethodInvocationInstruction() method
+     * Determines the name of the field variable this method call is invoked on.
+     *
+     * <p>This is done using the getSourceOfMethodInvocationInstruction() method
      * and returning its variable name
      *
      * @return a {@link java.lang.String} object.
@@ -939,8 +983,9 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     @Override
     public String getFieldMethodCallName() {
         BytecodeInstruction srcInstruction = getSourceOfMethodInvocationInstruction();
-        if (srcInstruction == null)
+        if (srcInstruction == null) {
             return null;
+        }
         return srcInstruction.getVariableName();
     }
 
@@ -948,15 +993,18 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * If this is a method call instruction this method will return the
      * instruction that loaded the reference of the Object the method is invoked
      * onto the stack.
-     * <p>
-     * This is done using getSourceOfStackInstruction()
-     * <p>
-     * The reference is found on top of the stack minus the number of the called
-     * methods argument
+     *
+     * <p>This is done using getSourceOfStackInstruction().
+     *
+     * <p>The reference is found on top of the stack minus the number of the called
+     * methods argument.
+     *
+     * @return a {@link BytecodeInstruction} object.
      */
     public BytecodeInstruction getSourceOfMethodInvocationInstruction() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return null;
+        }
 
         // the object on which this method is called is on top of the stack
         // minus the number of arguments the called method has
@@ -967,10 +1015,12 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * If this instruction is an array instruction this method will return the
      * BytecodeInstruction that loaded the reference of the array onto the
      * stack.
-     * <p>
-     * This is done using getSourceOfStackMethod()
-     * <p>
-     * The reference is found on top of the stack minus two
+     *
+     * <p>This is done using getSourceOfStackMethod().
+     *
+     * <p>The reference is found on top of the stack minus two.
+     *
+     * @return a {@link BytecodeInstruction} object.
      */
     public BytecodeInstruction getSourceOfArrayReference() {
         if (isArrayStoreInstruction()) {
@@ -995,24 +1045,28 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      * This method returns the BytecodeInstruction that loaded the reference
      * which is located on top of the stack minus positionFromTop when this
      * instruction is executed.
-     * <p>
-     * This is done using the CFGFrame created by the SourceInterpreter() of the
-     * BytecodeAnalyzer via the CFGGenerator
-     * <p>
-     * Note that this method may return null. This can happen when aliasing is
+     *
+     * <p>This is done using the CFGFrame created by the SourceInterpreter() of the
+     * BytecodeAnalyzer via the CFGGenerator.
+     *
+     * <p>Note that this method may return null. This can happen when aliasing is
      * involved. For example for method invocations on objects this can happen
      * when you first store the object in a local variable and then call a
-     * method on that variable
-     * <p>
-     * see PairTestClass.sourceCallerTest() for an even worse example.
-     * <p>
-     * TODO: this could be done better by following the SourceValues even
+     * method on that variable.
+     *
+     * <p>see PairTestClass.sourceCallerTest() for an even worse example.
+     *
+     * <p>TODO: this could be done better by following the SourceValues even
      * further.
+     *
+     * @param positionFromTop a int.
+     * @return a {@link BytecodeInstruction} object.
      */
     public BytecodeInstruction getSourceOfStackInstruction(int positionFromTop) {
-        if (frame == null)
+        if (frame == null) {
             throw new IllegalStateException(
                     "expect each BytecodeInstruction to have its CFGFrame set");
+        }
 
         int stackPos = frame.getStackSize() - (1 + positionFromTop);
         if (stackPos < 0) {
@@ -1026,17 +1080,18 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
         }
         Object sourceIns = source.insns.iterator().next();
         AbstractInsnNode sourceInstruction = (AbstractInsnNode) sourceIns;
-        BytecodeInstruction src = BytecodeInstructionPool.getInstance(classLoader).getInstruction(className,
+        BytecodeInstruction src = BytecodeInstructionPool.getInstance(classLoader).getInstruction(
+                className,
                 methodName,
                 sourceInstruction);
         return src;
     }
 
     public boolean isFieldMethodCallDefinition() {
-        if (!isMethodCallOfField())
+        if (!isMethodCallOfField()) {
             return false;
-        // before this instruction is categorized in the DefUsePool we do not
-        // know if
+        }
+        // before this instruction is categorized in the DefUsePool we do not know if
         // this instruction calls a pure or impure method, so we just label it
         // as both a Use and Definition for now
         if (!(DefUsePool.isKnownAsUse(this) && DefUsePool
@@ -1050,10 +1105,10 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
     }
 
     public boolean isFieldMethodCallUse() {
-        if (!isMethodCallOfField())
+        if (!isMethodCallOfField()) {
             return false;
-        // before this instruction is categorized in the DefUsePool we do not
-        // know if
+        }
+        // before this instruction is categorized in the DefUsePool we do not know if
         // this instruction calls a pure or impure method, so we just label it
         // as both a Use and Definition for now
         if ((DefUsePool.isKnownAsFieldMethodCall(this) && !DefUsePool.isKnownAsDefinition(this))) {
@@ -1067,14 +1122,15 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * isCallToPublicMethod
+     * isCallToPublicMethod.
      * </p>
      *
      * @return a boolean.
      */
     public boolean isCallToPublicMethod() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return false;
+        }
 
         if (getCalledCFG() == null) {
             // TODO not sure if I am supposed to throw an Exception at this
@@ -1087,14 +1143,15 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * isCallToStaticMethod
+     * isCallToStaticMethod.
      * </p>
      *
      * @return a boolean.
      */
     public boolean isCallToStaticMethod() {
-        if (!isMethodCall())
+        if (!isMethodCall()) {
             return false;
+        }
 
         if (getCalledCFG() == null) {
             // TODO not sure if I am supposed to throw an Exception at this
@@ -1107,7 +1164,7 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
 
     /**
      * <p>
-     * canBeInstrumented
+     * canBeInstrumented.
      * </p>
      *
      * @return a boolean.
@@ -1136,23 +1193,31 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         BytecodeInstruction other = (BytecodeInstruction) obj;
         if (className == null) {
-            if (other.className != null)
+            if (other.className != null) {
                 return false;
-        } else if (!className.equals(other.className))
+            }
+        } else if (!className.equals(other.className)) {
             return false;
-        if (instructionId != other.instructionId)
+        }
+        if (instructionId != other.instructionId) {
             return false;
+        }
         if (methodName == null) {
             return other.methodName == null;
-        } else return methodName.equals(other.methodName);
+        } else {
+            return methodName.equals(other.methodName);
+        }
     }
 
     // inherited from Object
@@ -1169,8 +1234,9 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
             return diff;
         }
         if (this.className != null) {
-            if (o.className == null)
+            if (o.className == null) {
                 return 1;
+            }
             diff = this.className.compareTo(o.className);
             if (diff != 0) {
                 return diff;
@@ -1180,8 +1246,9 @@ public class BytecodeInstruction extends ASMWrapper implements Serializable,
         }
 
         if (this.methodName != null) {
-            if (o.methodName == null)
+            if (o.methodName == null) {
                 return 1;
+            }
             diff = this.methodName.compareTo(o.methodName);
             if (diff != 0) {
                 return diff;

--- a/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionFactory.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionFactory.java
@@ -24,9 +24,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 public class BytecodeInstructionFactory {
 
     /**
-     * <p>
-     * createBytecodeInstruction
-     * </p>
+     * Creates a {@link BytecodeInstruction}.
      *
      * @param className      a {@link java.lang.String} object.
      * @param methodName     a {@link java.lang.String} object.
@@ -36,7 +34,10 @@ public class BytecodeInstructionFactory {
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      */
     public static BytecodeInstruction createBytecodeInstruction(ClassLoader classLoader,
-                                                                String className, String methodName, int instructionId, int bytecodeOffset,
+                                                                String className,
+                                                                String methodName,
+                                                                int instructionId,
+                                                                int bytecodeOffset,
                                                                 AbstractInsnNode node) {
 
         BytecodeInstruction instruction = new BytecodeInstruction(classLoader, className,

--- a/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionIdComparator.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionIdComparator.java
@@ -22,9 +22,9 @@ package org.evosuite.graphs.cfg;
 import java.util.Comparator;
 
 /**
- * Orders CFGVertices according to their id
- * <p>
- * This is mainly used to put BytecodeInstructions into a PriorityQueue in
+ * Orders CFGVertices according to their id.
+ *
+ * <p>This is mainly used to put BytecodeInstructions into a PriorityQueue in
  * ControlFlowGraph.getMaximalInitialDistance()
  *
  * @author Gordon Fraser

--- a/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionPool.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/BytecodeInstructionPool.java
@@ -29,9 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * <p>
  * BytecodeInstructionPool class.
- * </p>
  *
  * @author Andre Mis
  */
@@ -65,13 +63,13 @@ public class BytecodeInstructionPool {
 
     /**
      * Called by each CFGGenerator for it's corresponding method.
-     * <p>
-     * The MethodNode contains all instructions within a method. A call to
+     *
+     * <p>The MethodNode contains all instructions within a method. A call to
      * registerMethodNode() fills the instructionMap of the
      * BytecodeInstructionPool with the instructions in that method and returns
      * a List containing the BytecodeInstructions within that method.
-     * <p>
-     * While registering all instructions the lineNumber of each
+     *
+     * <p>While registering all instructions the lineNumber of each
      * BytecodeInstruction is set.
      *
      * @param node       a {@link org.objectweb.asm.tree.MethodNode} object.
@@ -87,8 +85,8 @@ public class BytecodeInstructionPool {
         // is registered multiple times (e.g., during testability transformation and
         // then again during CFG generation). This ensures consistency with the
         // MethodNode's ASM nodes.
-        if (instructionMap.containsKey(className) &&
-            instructionMap.get(className).containsKey(methodName)) {
+        if (instructionMap.containsKey(className)
+                && instructionMap.get(className).containsKey(methodName)) {
             instructionMap.get(className).get(methodName).clear();
         }
 
@@ -98,17 +96,19 @@ public class BytecodeInstructionPool {
         for (int instructionId = 0; instructionId < node.instructions.size(); instructionId++) {
             AbstractInsnNode instructionNode = node.instructions.get(instructionId);
 
-            BytecodeInstruction instruction = BytecodeInstructionFactory.createBytecodeInstruction(classLoader,
-                    className,
-                    methodName,
-                    instructionId,
-                    bytecodeOffset,
-                    instructionNode);
+            BytecodeInstruction instruction = BytecodeInstructionFactory
+                    .createBytecodeInstruction(classLoader,
+                            className,
+                            methodName,
+                            instructionId,
+                            bytecodeOffset,
+                            instructionNode);
 
-            if (instruction.isLineNumber())
+            if (instruction.isLineNumber()) {
                 lastLineNumber = instruction.getLineNumber();
-            else if (lastLineNumber != -1)
+            } else if (lastLineNumber != -1) {
                 instruction.setLineNumber(lastLineNumber);
+            }
 
             bytecodeOffset += getBytecodeIncrement(instructionNode);
 
@@ -122,19 +122,21 @@ public class BytecodeInstructionPool {
         }
 
         List<BytecodeInstruction> r = getInstructionsIn(className, methodName);
-        if (r == null || r.size() == 0)
+        if (r == null || r.size() == 0) {
             throw new IllegalStateException(
-                    "expect instruction pool to return non-null non-empty list of instructions for a previously registered method "
-                            + methodName);
+                    "expect instruction pool to return non-null non-empty list of instructions "
+                            + "for a previously registered method " + methodName);
+        }
 
         return r;
     }
 
     /**
      * Determine how many bytes the current instruction occupies together with
-     * its operands
+     * its operands.
      *
-     * @return
+     * @param instructionNode a {@link org.objectweb.asm.tree.AbstractInsnNode} object.
+     * @return number of bytes
      */
     private int getBytecodeIncrement(AbstractInsnNode instructionNode) {
         int opcode = instructionNode.getOpcode();
@@ -150,20 +152,22 @@ public class BytecodeInstructionPool {
             case Opcodes.LLOAD:
             case Opcodes.LSTORE:
                 VarInsnNode varNode = (VarInsnNode) instructionNode;
-                if (varNode.var > 3)
+                if (varNode.var > 3) {
                     return 1;
-                else
+                } else {
                     return 0;
+                }
             case Opcodes.BIPUSH: // byte
             case Opcodes.NEWARRAY:
             case Opcodes.RET:
                 return 1;
             case Opcodes.LDC:
                 LdcInsnNode ldcNode = (LdcInsnNode) instructionNode;
-                if (ldcNode.cst instanceof Double || ldcNode.cst instanceof Long)
+                if (ldcNode.cst instanceof Double || ldcNode.cst instanceof Long) {
                     return 2; // LDC2_W
-                else
+                } else {
                     return 1;
+                }
             case 19: //LDC_W
             case 20: //LDC2_W
                 return 2;
@@ -214,21 +218,24 @@ public class BytecodeInstructionPool {
                 return 4;
             // case Opcodes.GOTO_W
             // case Opcodes.JSR_W
+            default:
+                return 0;
         }
-        return 0;
     }
 
     private void registerMethodNode(MethodNode node) {
-        for (MethodNode mn : knownMethodNodes)
-            if (mn == node)
+        for (MethodNode mn : knownMethodNodes) {
+            if (mn == node) {
                 logger.debug("CFGGenerator.analyze() apparently got called for the same MethodNode twice");
+            }
+        }
 
         knownMethodNodes.add(node);
     }
 
     /**
      * <p>
-     * registerInstruction
+     * registerInstruction.
      * </p>
      *
      * @param instruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -237,12 +244,14 @@ public class BytecodeInstructionPool {
         String className = instruction.getClassName();
         String methodName = instruction.getMethodName();
 
-        if (!instructionMap.containsKey(className))
+        if (!instructionMap.containsKey(className)) {
             instructionMap.put(className,
                     new LinkedHashMap<>());
-        if (!instructionMap.get(className).containsKey(methodName))
+        }
+        if (!instructionMap.get(className).containsKey(methodName)) {
             instructionMap.get(className).put(methodName,
                     new ArrayList<>());
+        }
 
         instructionMap.get(className).get(methodName).add(instruction);
         logger.debug("Registering instruction " + instruction);
@@ -252,9 +261,9 @@ public class BytecodeInstructionPool {
             if (previous.isLabel()) {
                 LabelNode ln = (LabelNode) previous.asmNode;
                 if (ln.getLabel() instanceof AnnotatedLabel) {
-                    AnnotatedLabel aLabel = (AnnotatedLabel) ln.getLabel();
-                    if (aLabel.isStartTag()) {
-                        if (aLabel.shouldIgnore()) {
+                    AnnotatedLabel annotatedLabel = (AnnotatedLabel) ln.getLabel();
+                    if (annotatedLabel.isStartTag()) {
+                        if (annotatedLabel.shouldIgnore()) {
                             logger.debug("Ignoring artificial branch: " + instruction);
                             return;
                         }
@@ -272,7 +281,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * getInstruction
+     * getInstruction.
      * </p>
      *
      * @param className     a {@link java.lang.String} object.
@@ -293,7 +302,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * getInstruction
+     * getInstruction.
      * </p>
      *
      * @param className     a {@link java.lang.String} object.
@@ -315,8 +324,9 @@ public class BytecodeInstructionPool {
             return null;
         }
         for (BytecodeInstruction instruction : instructionMap.get(className).get(methodName)) {
-            if (instruction.getInstructionId() == instructionId)
+            if (instruction.getInstructionId() == instructionId) {
                 return instruction;
+            }
         }
 
         logger.debug("unknown instruction " + instructionId + ", have "
@@ -330,7 +340,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * getInstruction
+     * getInstruction.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -352,8 +362,9 @@ public class BytecodeInstructionPool {
             return null;
         }
         for (BytecodeInstruction instruction : instructionMap.get(className).get(methodName)) {
-            if (instruction.asmNode == node)
+            if (instruction.asmNode == node) {
                 return instruction;
+            }
         }
 
         logger.debug("unknown instruction: " + node + ", have "
@@ -366,7 +377,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * knownClasses
+     * knownClasses.
      * </p>
      *
      * @return a {@link java.util.Set} object.
@@ -377,7 +388,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * knownMethods
+     * knownMethods.
      * </p>
      *
      * @param className a {@link java.lang.String} object.
@@ -386,22 +397,24 @@ public class BytecodeInstructionPool {
     public Set<String> knownMethods(String className) {
         Set<String> r = new LinkedHashSet<>();
 
-        if (instructionMap.get(className) != null)
+        if (instructionMap.get(className) != null) {
             r.addAll(instructionMap.get(className).keySet());
+        }
 
         return r;
     }
 
     public boolean hasMethod(String className, String methodName) {
-        if (instructionMap.get(className) != null)
+        if (instructionMap.get(className) != null) {
             return instructionMap.get(className).containsKey(methodName);
+        }
 
         return false;
     }
 
     /**
      * <p>
-     * getInstructionsIn
+     * getInstructionsIn.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -410,8 +423,9 @@ public class BytecodeInstructionPool {
      */
     public List<BytecodeInstruction> getInstructionsIn(String className, String methodName) {
         if (instructionMap.get(className) == null
-                || instructionMap.get(className).get(methodName) == null)
+                || instructionMap.get(className).get(methodName) == null) {
             return null;
+        }
 
         List<BytecodeInstruction> r = new ArrayList<>(instructionMap.get(className).get(methodName));
 
@@ -419,8 +433,9 @@ public class BytecodeInstructionPool {
     }
 
     public List<BytecodeInstruction> getInstructionsIn(String className) {
-        if (instructionMap.get(className) == null)
+        if (instructionMap.get(className) == null) {
             return null;
+        }
 
         List<BytecodeInstruction> r = new ArrayList<>();
         Map<String, List<BytecodeInstruction>> methodMap = instructionMap.get(className);
@@ -445,7 +460,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * logInstructionsIn
+     * logInstructionsIn.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -468,7 +483,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * createFakeInstruction
+     * createFakeInstruction.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
@@ -492,7 +507,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * clear
+     * clear.
      * </p>
      */
     public void clear() {
@@ -506,7 +521,7 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * clear
+     * clear.
      * </p>
      *
      * @param className a {@link java.lang.String} object.
@@ -523,15 +538,16 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * clear
+     * clear.
      * </p>
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
      */
     public void clear(String className, String methodName) {
-        if (instructionMap.containsKey(className))
+        if (instructionMap.containsKey(className)) {
             instructionMap.get(className).remove(methodName);
+        }
     }
 
     public static void clearAll(String className, String methodName) {
@@ -542,51 +558,61 @@ public class BytecodeInstructionPool {
 
     /**
      * <p>
-     * forgetInstruction
+     * forgetInstruction.
      * </p>
      *
      * @param ins a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a boolean.
      */
     public boolean forgetInstruction(BytecodeInstruction ins) {
-        if (!instructionMap.containsKey(ins.getClassName()))
+        if (!instructionMap.containsKey(ins.getClassName())) {
             return false;
-        if (!instructionMap.get(ins.getClassName()).containsKey(ins.getMethodName()))
+        }
+        if (!instructionMap.get(ins.getClassName()).containsKey(ins.getMethodName())) {
             return false;
+        }
 
         return instructionMap.get(ins.getClassName()).get(ins.getMethodName()).remove(ins);
     }
 
     public int getFirstLineNumberOfMethod(String className, String methodName) {
-        if (instructionMap.get(className) == null)
+        if (instructionMap.get(className) == null) {
             throw new IllegalArgumentException("unknown class " + className);
-        if (instructionMap.get(className).get(methodName) == null)
+        }
+        if (instructionMap.get(className).get(methodName) == null) {
             throw new IllegalArgumentException("unknown method " + methodName
                     + " in class " + className);
-        if (instructionMap.get(className).get(methodName).isEmpty())
+        }
+        if (instructionMap.get(className).get(methodName).isEmpty()) {
             throw new IllegalArgumentException("no instructions in method " + methodName
                     + " in class " + className);
+        }
 
         int r = Integer.MAX_VALUE;
         for (BytecodeInstruction ins : instructionMap.get(className).get(methodName)) {
-            if (ins.getLineNumber() < r)
+            if (ins.getLineNumber() < r) {
                 r = ins.getLineNumber();
+            }
         }
         return r;
     }
 
     public BytecodeInstruction getFirstInstructionAtLineNumber(String className, String methodName, int lineNumber) {
         // TODO
-        if (instructionMap.get(className) == null)
+        if (instructionMap.get(className) == null) {
             return null;
-        if (instructionMap.get(className).get(methodName) == null)
+        }
+        if (instructionMap.get(className).get(methodName) == null) {
             return null;
-        if (instructionMap.get(className).get(methodName).isEmpty())
+        }
+        if (instructionMap.get(className).get(methodName).isEmpty()) {
             return null;
+        }
 
         for (BytecodeInstruction ins : instructionMap.get(className).get(methodName)) {
-            if (ins.getLineNumber() == lineNumber)
+            if (ins.getLineNumber() == lineNumber) {
                 return ins;
+            }
         }
         return null;
     }

--- a/client/src/main/java/org/evosuite/graphs/cfg/CFGClassAdapter.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/CFGClassAdapter.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The CFGClassAdapter calls a CFG generator for relevant methods
+ * The CFGClassAdapter calls a CFG generator for relevant methods.
  *
  * @author Gordon Fraser
  */
@@ -40,20 +40,21 @@ public class CFGClassAdapter extends ClassVisitor {
     public static final String LAMBDA_METHOD_NAME = "lambda$";
 
     /**
-     * Current class
+     * Current class.
      */
     private final String className;
 
     private final ClassLoader classLoader;
 
     /**
-     * Skip methods on enums - at least some
+     * Skip methods on enums - at least some.
      */
     private boolean isEnum = false;
 
     /**
-     * Constructor
+     * Constructor.
      *
+     * @param classLoader a {@link java.lang.ClassLoader} object.
      * @param visitor   a {@link org.objectweb.asm.ClassVisitor} object.
      * @param className a {@link java.lang.String} object.
      */
@@ -62,10 +63,6 @@ public class CFGClassAdapter extends ClassVisitor {
         this.className = className;
         this.classLoader = classLoader;
     }
-
-    /* (non-Javadoc)
-     * @see org.objectweb.asm.ClassAdapter#visit(int, int, java.lang.String, java.lang.String, java.lang.String, java.lang.String[])
-     */
 
     /**
      * {@inheritDoc}
@@ -80,16 +77,10 @@ public class CFGClassAdapter extends ClassVisitor {
         // We are removing final access to allow mocking
         // TODO: Is this redundant wrt RemoveFinalClassAdapter?
         super.visit(version, access & ~Opcodes.ACC_FINAL, name, signature, superName, interfaces);
-        if (superName.equals("java/lang/Enum"))
+        if (superName.equals("java/lang/Enum")) {
             isEnum = true;
+        }
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.objectweb.asm.ClassAdapter#visitMethod(int, java.lang.String,
-     * java.lang.String, java.lang.String, java.lang.String[])
-     */
 
     /**
      * {@inheritDoc}
@@ -102,18 +93,17 @@ public class CFGClassAdapter extends ClassVisitor {
                 exceptions);
         mv = new JSRInlinerAdapter(mv, methodAccess, name, descriptor, signature, exceptions);
 
-
         if (((methodAccess & Opcodes.ACC_SYNTHETIC) != 0 && !isLambdaMethodName(name))
                 || (methodAccess & Opcodes.ACC_BRIDGE) != 0) {
             return mv;
         }
 
         // We ignore deprecated only for dependencies, not for the SUT
-//		if (!Properties.USE_DEPRECATED
-//		        && (methodAccess & Opcodes.ACC_DEPRECATED) == Opcodes.ACC_DEPRECATED) {
-//			logger.info("Skipping deprecated method " + name);
-//			return mv;
-//		}
+        // if (!Properties.USE_DEPRECATED
+        // && (methodAccess & Opcodes.ACC_DEPRECATED) == Opcodes.ACC_DEPRECATED) {
+        // logger.info("Skipping deprecated method " + name);
+        // return mv;
+        // }
 
         if (isEnum) {
             if (name.equals("valueOf") || name.equals("values")) {
@@ -136,11 +126,11 @@ public class CFGClassAdapter extends ClassVisitor {
     }
 
     /**
-     * Just checks wheter the name of the method is of a synthetic lambda.
+     * Just checks whether the name of the method is of a synthetic lambda.
      * TODO: we do the same on the concolic engine VMs, eventually move this to a commons space.
      *
-     * @param methodName
-     * @return
+     * @param methodName a {@link java.lang.String} object.
+     * @return true if method name is a lambda method name.
      */
     private static boolean isLambdaMethodName(String methodName) {
         return methodName.startsWith(LAMBDA_METHOD_NAME);

--- a/client/src/main/java/org/evosuite/graphs/cfg/CFGFrame.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/CFGFrame.java
@@ -30,11 +30,11 @@ public class CFGFrame extends Frame {
     /**
      * <p>Constructor for CFGFrame.</p>
      *
-     * @param nLocals a int.
-     * @param nStack  a int.
+     * @param numLocals a int.
+     * @param numStack  a int.
      */
-    public CFGFrame(int nLocals, int nStack) {
-        super(nLocals, nStack);
+    public CFGFrame(int numLocals, int numStack) {
+        super(numLocals, numStack);
     }
 
     /**

--- a/client/src/main/java/org/evosuite/graphs/cfg/CFGGenerator.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/CFGGenerator.java
@@ -30,26 +30,26 @@ import java.util.List;
 
 /**
  * This classed is used to create the RawControlFlowGraph which can then be used
- * to create the ActualControlFlowGraph
- * <p>
- * When analyzing a CUT the BytecodeAnalyzer creates an instance of this class
- * for each method contained in it
- * <p>
- * This class's methods get called in the following order:
- * <p>
- * - upon constructing, the method at hand is registered via
+ * to create the ActualControlFlowGraph.
+ *
+ * <p>When analyzing a CUT the BytecodeAnalyzer creates an instance of this class
+ * for each method contained in it.
+ *
+ * <p>This class's methods get called in the following order:
+ *
+ * <p>- upon constructing, the method at hand is registered via
  * registerMethodNode() which fills the BytecodeInstructionPool with all
  * instructions inside that method
- * <p>
- * - then registerControlFlowEdge() is called by the BytecodeAnalyzer for each
+ *
+ * <p>- then registerControlFlowEdge() is called by the BytecodeAnalyzer for each
  * possible transition from one byteCode instruction to another within the
  * current method. In this step the CFGGenerator asks the
  * BytecodeInstructionPool for the previously created instructions and fills up
  * it's RawControlFlowGraph
- * <p>
- * After those calls the RawControlFlowGraph of the method at hand is complete
+ *
+ * <p>After those calls the RawControlFlowGraph of the method at hand is complete
  * It should contain a Vertex for each BytecodeInstruction inside the specified
- * method and an edge for every possible transition between these instructions
+ * method and an edge for every possible transition between these instructions.
  *
  * @author Andre Mis
  */
@@ -67,14 +67,14 @@ public class CFGGenerator {
 
     /**
      * Initializes this generator to generate the CFG for the method identified
-     * by the given parameters
-     * <p>
-     * Calls registerMethodNode() which in turn calls
+     * by the given parameters.
+     *
+     * <p>Calls registerMethodNode() which in turn calls
      * BytecodeInstructionPool.registerMethodNode() leading to the creation of
-     * all BytecodeInstruction instances for the method at hand
-     * <p>
-     * TODO might not want to give asm.MethodNode to the outside, but rather a
-     * MyMethodNode extended from BytecodeInstruction or something
+     * all BytecodeInstruction instances for the method at hand.
+     *
+     * <p>TODO might not want to give asm.MethodNode to the outside, but rather a
+     * MyMethodNode extended from BytecodeInstruction or something.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
@@ -88,13 +88,14 @@ public class CFGGenerator {
 
     /**
      * Adds the RawControlFlowGraph created by this instance to the GraphPool,
-     * computes the resulting ActualControlFlowGraph
+     * computes the resulting ActualControlFlowGraph.
      */
     public void registerCFGs() {
 
         int removed = getRawGraph().removeIsolatedNodes();
-        if (removed > 0)
+        if (removed > 0) {
             logger.info("removed isolated nodes: " + removed + " in " + methodName);
+        }
 
         // non-minimized cfg needed for defuse-coverage and control
         // dependence calculation
@@ -106,11 +107,13 @@ public class CFGGenerator {
 
     private void registerMethodNode(MethodNode currentMethod, String className,
                                     String methodName) {
-        if (nodeRegistered)
+        if (nodeRegistered) {
             throw new IllegalStateException(
                     "registerMethodNode must not be called more than once for each instance of CFGGenerator");
-        if (currentMethod == null || methodName == null || className == null)
+        }
+        if (currentMethod == null || methodName == null || className == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.currentMethod = currentMethod;
         this.className = className;
@@ -119,9 +122,9 @@ public class CFGGenerator {
         this.rawGraph = new RawControlFlowGraph(classLoader, className, methodName,
                 currentMethod.access);
 
-        List<BytecodeInstruction> instructionsInMethod = BytecodeInstructionPool.getInstance(classLoader).registerMethodNode(currentMethod,
-                className,
-                methodName);
+        List<BytecodeInstruction> instructionsInMethod = BytecodeInstructionPool
+                .getInstance(classLoader)
+                .registerMethodNode(currentMethod, className, methodName);
 
         // sometimes there is a Label at the very end of a method without a
         // controlFlowEdge to it. In order to keep the graph as connected as
@@ -129,18 +132,19 @@ public class CFGGenerator {
         int count = 0;
         for (BytecodeInstruction ins : instructionsInMethod) {
             count++;
-            if (!ins.isLabel() || count < instructionsInMethod.size())
+            if (!ins.isLabel() || count < instructionsInMethod.size()) {
                 rawGraph.addVertex(ins);
+            }
         }
 
         nodeRegistered = true;
     }
 
     /**
-     * Internal management of fields and actual building up of the rawGraph
-     * <p>
-     * Is called by the corresponding BytecodeAnalyzer whenever it detects a
-     * control flow edge
+     * Internal management of fields and actual building up of the rawGraph.
+     *
+     * <p>Is called by the corresponding BytecodeAnalyzer whenever it detects a
+     * control flow edge.
      *
      * @param src             a int.
      * @param dst             a int.
@@ -150,17 +154,20 @@ public class CFGGenerator {
      */
     public void registerControlFlowEdge(int src, int dst, Frame[] frames,
                                         boolean isExceptionEdge) {
-        if (!nodeRegistered)
+        if (!nodeRegistered) {
             throw new IllegalStateException(
-                    "CFGGenrator.registerControlFlowEdge() cannot be called unless registerMethodNode() was called first");
-        if (frames == null)
+                    "CFGGenrator.registerControlFlowEdge() cannot be called "
+                            + "unless registerMethodNode() was called first");
+        }
+        if (frames == null) {
             throw new IllegalArgumentException("null given");
+        }
         CFGFrame srcFrame = (CFGFrame) frames[src];
         Frame dstFrame = frames[dst];
 
-        if (srcFrame == null)
-            throw new IllegalArgumentException(
-                    "expect given frames to know srcFrame for " + src);
+        if (srcFrame == null) {
+            throw new IllegalArgumentException("expect given frames to know srcFrame for " + src);
+        }
 
         if (dstFrame == null) {
             // documentation of getFrames() tells us the following:
@@ -184,36 +191,39 @@ public class CFGGenerator {
         AbstractInsnNode dstNode = currentMethod.instructions.get(dst);
 
         // those nodes should have gotten registered by registerMethodNode()
-        BytecodeInstruction srcInstruction = BytecodeInstructionPool.getInstance(classLoader).getInstruction(className,
+        BytecodeInstruction srcInstruction = BytecodeInstructionPool.getInstance(classLoader).getInstruction(
+                className,
                 methodName,
                 src,
                 srcNode);
-        BytecodeInstruction dstInstruction = BytecodeInstructionPool.getInstance(classLoader).getInstruction(className,
+        BytecodeInstruction dstInstruction = BytecodeInstructionPool.getInstance(classLoader).getInstruction(
+                className,
                 methodName,
                 dst,
                 dstNode);
 
         srcInstruction.setCFGFrame(srcFrame);
 
-        if (dstInstruction == null)
+        if (dstInstruction == null) {
             throw new IllegalStateException(
                     "expect BytecodeInstructionPool to know the instructions in the method of this edge");
+        }
 
-        if (null == rawGraph.addEdge(srcInstruction, dstInstruction, isExceptionEdge))
+        if (null == rawGraph.addEdge(srcInstruction, dstInstruction, isExceptionEdge)) {
             logger.error("internal error while adding edge");
+        }
     }
 
     /**
      * Computes the ActualCFG with BasicBlocks rather then BytecodeInstructions
      * for this RawCFG.
-     * <p>
-     * See ActualControlFlowGraph and GraphPool for further details.
+     *
+     * <p>See ActualControlFlowGraph and GraphPool for further details.
      *
      * @return a {@link org.evosuite.graphs.cfg.ActualControlFlowGraph} object.
      */
     public ActualControlFlowGraph computeActualCFG() {
-        BytecodeInstructionPool.getInstance(classLoader).logInstructionsIn(className,
-                methodName);
+        BytecodeInstructionPool.getInstance(classLoader).logInstructionsIn(className, methodName);
 
         return new ActualControlFlowGraph(rawGraph);
     }
@@ -221,9 +231,7 @@ public class CFGGenerator {
     // getter
 
     /**
-     * <p>
-     * Getter for the field <code>rawGraph</code>.
-     * </p>
+     * <p>Getter for the field <code>rawGraph</code>.</p>
      *
      * @return a {@link org.evosuite.graphs.cfg.RawControlFlowGraph} object.
      */
@@ -232,9 +240,7 @@ public class CFGGenerator {
     }
 
     /**
-     * <p>
-     * Getter for the field <code>className</code>.
-     * </p>
+     * <p>Getter for the field <code>className</code>.</p>
      *
      * @return a {@link java.lang.String} object.
      */
@@ -243,9 +249,7 @@ public class CFGGenerator {
     }
 
     /**
-     * <p>
-     * Getter for the field <code>methodName</code>.
-     * </p>
+     * <p>Getter for the field <code>methodName</code>.</p>
      *
      * @return a {@link java.lang.String} object.
      */

--- a/client/src/main/java/org/evosuite/graphs/cfg/CFGMethodAdapter.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/CFGMethodAdapter.java
@@ -43,9 +43,9 @@ import java.util.*;
 /**
  * Create a minimized control flow graph for the method and store it. In
  * addition, this adapter also adds instrumentation for branch distance
- * measurement
- * <p>
- * defUse, concurrency and LCSAJs instrumentation is also added (if the
+ * measurement.
+ *
+ * <p>defUse, concurrency and LCSAJs instrumentation is also added (if the
  * properties are set).
  *
  * @author Gordon Fraser
@@ -63,8 +63,8 @@ public class CFGMethodAdapter extends MethodVisitor {
             ClassResetter.STATIC_RESET + "()V",
             ClassResetter.STATIC_RESET);
     /**
-     * The set of all methods which can be used during test case generation This
-     * excludes e.g. synthetic, initializers, private and deprecated methods
+     * The set of all methods which can be used during test case generation. This
+     * excludes e.g. synthetic, initializers, private and deprecated methods.
      */
     private static Map<ClassLoader, Map<String, Set<String>>> methods = new HashMap<>();
 
@@ -78,12 +78,12 @@ public class CFGMethodAdapter extends MethodVisitor {
     /**
      * This is the name + the description of the method. It is more like the
      * signature and less like the name. The name of the method can be found in
-     * this.plain_name
+     * this.plainName.
      */
     private final String methodName;
 
     private final MethodVisitor next;
-    private final String plain_name;
+    private final String plainName;
     private final int access;
     private final String className;
     private final ClassLoader classLoader;
@@ -91,14 +91,12 @@ public class CFGMethodAdapter extends MethodVisitor {
     private int lineNumber = 0;
 
     /**
-     * Can be set by annotation
+     * Can be set by annotation.
      */
     private boolean excludeMethod = false;
 
     /**
-     * <p>
      * Constructor for CFGMethodAdapter.
-     * </p>
      *
      * @param className  a {@link java.lang.String} object.
      * @param access     a int.
@@ -123,11 +121,12 @@ public class CFGMethodAdapter extends MethodVisitor {
         this.className = className; // .replace('/', '.');
         this.access = access;
         this.methodName = name + desc;
-        this.plain_name = name;
+        this.plainName = name;
         this.classLoader = classLoader;
 
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             methods.put(classLoader, new HashMap<>());
+        }
     }
 
     /* (non-Javadoc)
@@ -155,7 +154,7 @@ public class CFGMethodAdapter extends MethodVisitor {
     public void visitEnd() {
         logger.debug("Creating CFG of " + className + "." + methodName);
         boolean isExcludedMethod = excludeMethod || EXCLUDE.contains(methodName);
-        boolean isMainMethod = plain_name.equals("main") && Modifier.isStatic(access);
+        boolean isMainMethod = plainName.equals("main") && Modifier.isStatic(access);
 
         List<MethodInstrumentation> instrumentations = new ArrayList<>();
         if (DependencyAnalysis.shouldInstrument(className, methodName)) {
@@ -227,14 +226,16 @@ public class CFGMethodAdapter extends MethodVisitor {
                 logger.info("Created CFG for method " + methodName);
 
                 if (DependencyAnalysis.shouldInstrument(className, methodName)) {
-                    if (!methods.get(classLoader).containsKey(className))
+                    if (!methods.get(classLoader).containsKey(className)) {
                         methods.get(classLoader).put(className, new HashSet<>());
+                    }
 
                     // add the actual instrumentation
                     logger.info("Instrumenting method " + methodName + " in class "
                             + className);
-                    for (MethodInstrumentation instrumentation : instrumentations)
+                    for (MethodInstrumentation instrumentation : instrumentations) {
                         instrumentation.analyze(classLoader, mn, className, methodName, access);
+                    }
 
                     handleBranchlessMethods();
                     String id = className + "." + methodName;
@@ -250,7 +251,9 @@ public class CFGMethodAdapter extends MethodVisitor {
             }
 
         } else {
-            logger.debug("NOT Creating CFG of " + className + "." + methodName + ": " + checkForMain + ", " + ((!isExcludedMethod || executeOnExcluded)) + ", " + ((access & Opcodes.ACC_ABSTRACT) == 0) + ", " + ((access & Opcodes.ACC_NATIVE) == 0));
+            logger.debug("NOT Creating CFG of " + className + "." + methodName + ": " + checkForMain + ", "
+                    + ((!isExcludedMethod || executeOnExcluded)) + ", " + ((access & Opcodes.ACC_ABSTRACT) == 0) + ", "
+                    + ((access & Opcodes.ACC_NATIVE) == 0));
             super.visitEnd();
         }
         mn.accept(next);
@@ -282,22 +285,26 @@ public class CFGMethodAdapter extends MethodVisitor {
     }
 
     /**
-     * See description of CFGMethodAdapter.EXCLUDE
+     * See description of CFGMethodAdapter.EXCLUDE.
      *
-     * @return
+     * @return true if method is usable
      */
     private boolean isUsable() {
-        if ((this.access & Opcodes.ACC_SYNTHETIC) != 0)
+        if ((this.access & Opcodes.ACC_SYNTHETIC) != 0) {
             return false;
+        }
 
-        if ((this.access & Opcodes.ACC_BRIDGE) != 0)
+        if ((this.access & Opcodes.ACC_BRIDGE) != 0) {
             return false;
+        }
 
-        if ((this.access & Opcodes.ACC_NATIVE) != 0)
+        if ((this.access & Opcodes.ACC_NATIVE) != 0) {
             return false;
+        }
 
-        if (methodName.contains("<clinit>"))
+        if (methodName.contains("<clinit>")) {
             return false;
+        }
 
         // If we are not using reflection, covering private constructors is difficult?
         if (Properties.P_REFLECTION_ON_PRIVATE <= 0.0) {
@@ -319,13 +326,15 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static Set<String> getMethods(ClassLoader classLoader, String className) {
         Set<String> targetMethods = new HashSet<>();
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return targetMethods;
+        }
 
         for (String currentClass : methods.get(classLoader).keySet()) {
             if (currentClass.equals(className)
-                    || currentClass.startsWith(className + "$"))
+                    || currentClass.startsWith(className + "$")) {
                 targetMethods.addAll(methods.get(classLoader).get(currentClass));
+            }
         }
 
         return targetMethods;
@@ -342,8 +351,9 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static Set<String> getMethods(ClassLoader classLoader) {
         Set<String> targetMethods = new HashSet<>();
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return targetMethods;
+        }
 
         for (String currentClass : methods.get(classLoader).keySet()) {
             targetMethods.addAll(methods.get(classLoader).get(currentClass));
@@ -365,8 +375,9 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static Set<String> getMethodsPrefix(ClassLoader classLoader, String className) {
         Set<String> matchingMethods = new HashSet<>();
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return matchingMethods;
+        }
 
         for (String name : methods.get(classLoader).keySet()) {
             if (name.startsWith(className)) {
@@ -389,8 +400,9 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static int getNumMethodsPrefix(ClassLoader classLoader, String className) {
         int num = 0;
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return num;
+        }
 
         for (String name : methods.get(classLoader).keySet()) {
             if (name.startsWith(className)) {
@@ -412,8 +424,9 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static int getNumMethods(ClassLoader classLoader) {
         int num = 0;
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return num;
+        }
 
         for (String name : methods.get(classLoader).keySet()) {
             num += methods.get(classLoader).get(name).size();
@@ -435,8 +448,9 @@ public class CFGMethodAdapter extends MethodVisitor {
      */
     public static int getNumMethodsMemberClasses(ClassLoader classLoader, String className) {
         int num = 0;
-        if (!methods.containsKey(classLoader))
+        if (!methods.containsKey(classLoader)) {
             return num;
+        }
 
         for (String name : methods.get(classLoader).keySet()) {
             if (name.equals(className) || name.startsWith(className + "$")) {

--- a/client/src/main/java/org/evosuite/graphs/cfg/ControlDependency.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ControlDependency.java
@@ -38,9 +38,10 @@ public class ControlDependency implements Serializable, Comparable<ControlDepend
      * @param branchExpressionValue a boolean.
      */
     public ControlDependency(Branch branch, boolean branchExpressionValue) {
-        if (branch == null)
+        if (branch == null) {
             throw new IllegalArgumentException(
                     "control dependencies for the root branch are not permitted (null)");
+        }
 
         this.branch = branch;
         this.branchExpressionValue = branchExpressionValue;
@@ -64,33 +65,39 @@ public class ControlDependency implements Serializable, Comparable<ControlDepend
         return branchExpressionValue;
     }
 
-//	@Override
-//	public int hashCode() {
-//		final int prime = 31;
-//		int result = 1;
-//		result = prime * result + ((branch == null) ? 0 : branch.hashCode());
-//		result = prime * result + (branchExpressionValue ? 1231 : 1237);
-//		return result;
-//	}
-//
-//	@Override
-//	public boolean equals(Object obj) {
-//		if (this == obj)
-//			return true;
-//		if (obj == null)
-//			return false;
-//		if (getClass() != obj.getClass())
-//			return false;
-//		ControlDependency other = (ControlDependency) obj;
-//		if (branch == null) {
-//			if (other.branch != null)
-//				return false;
-//		} else if (!branch.equals(other.branch))
-//			return false;
-//		if (branchExpressionValue != other.branchExpressionValue)
-//			return false;
-//		return true;
-//	}
+    // @Override
+    // public int hashCode() {
+    //     final int prime = 31;
+    //     int result = 1;
+    //     result = prime * result + ((branch == null) ? 0 : branch.hashCode());
+    //     result = prime * result + (branchExpressionValue ? 1231 : 1237);
+    //     return result;
+    // }
+    //
+    // @Override
+    // public boolean equals(Object obj) {
+    //     if (this == obj) {
+    //         return true;
+    //     }
+    //     if (obj == null) {
+    //         return false;
+    //     }
+    //     if (getClass() != obj.getClass()) {
+    //         return false;
+    //     }
+    //     ControlDependency other = (ControlDependency) obj;
+    //     if (branch == null) {
+    //         if (other.branch != null) {
+    //             return false;
+    //         }
+    //     } else if (!branch.equals(other.branch)) {
+    //         return false;
+    //     }
+    //     if (branchExpressionValue != other.branchExpressionValue) {
+    //         return false;
+    //     }
+    //     return true;
+    // }
 
     /**
      * {@inheritDoc}
@@ -101,10 +108,11 @@ public class ControlDependency implements Serializable, Comparable<ControlDepend
         String r = "CD " + branch;
 
         if (!branch.isSwitchCaseBranch()) {
-            if (branchExpressionValue)
+            if (branchExpressionValue) {
                 r += " - TRUE";
-            else
+            } else {
                 r += " - FALSE";
+            }
         }
 
         return r;
@@ -112,11 +120,15 @@ public class ControlDependency implements Serializable, Comparable<ControlDepend
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ControlDependency that = (ControlDependency) o;
-        return branchExpressionValue == that.branchExpressionValue &&
-                Objects.equals(branch, that.branch);
+        return branchExpressionValue == that.branchExpressionValue
+                && Objects.equals(branch, that.branch);
     }
 
     @Override
@@ -128,8 +140,9 @@ public class ControlDependency implements Serializable, Comparable<ControlDepend
     @Override
     public int compareTo(ControlDependency o) {
         int x = branch.compareTo(o.branch);
-        if (x != 0)
+        if (x != 0) {
             return x;
+        }
 
         if (branchExpressionValue == o.branchExpressionValue) {
             return 0;

--- a/client/src/main/java/org/evosuite/graphs/cfg/ControlFlowEdge.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ControlFlowEdge.java
@@ -30,7 +30,7 @@ public class ControlFlowEdge extends DefaultEdge {
     private boolean isExceptionEdge;
 
     /**
-     * <p>Constructor for ControlFlowEdge.</p>
+     * Constructor for ControlFlowEdge.
      */
     public ControlFlowEdge() {
         this.cd = null;
@@ -38,7 +38,7 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>Constructor for ControlFlowEdge.</p>
+     * Constructor for ControlFlowEdge.
      *
      * @param isExceptionEdge a boolean.
      */
@@ -47,7 +47,7 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>Constructor for ControlFlowEdge.</p>
+     * Constructor for ControlFlowEdge.
      *
      * @param cd              a {@link org.evosuite.graphs.cfg.ControlDependency} object.
      * @param isExceptionEdge a boolean.
@@ -59,7 +59,7 @@ public class ControlFlowEdge extends DefaultEdge {
 
 
     /**
-     * Sort of a copy constructor
+     * Sort of a copy constructor.
      *
      * @param clone a {@link org.evosuite.graphs.cfg.ControlFlowEdge} object.
      */
@@ -71,7 +71,7 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>getControlDependency</p>
+     * <p>getControlDependency.</p>
      *
      * @return a {@link org.evosuite.graphs.cfg.ControlDependency} object.
      */
@@ -80,7 +80,7 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>hasControlDependency</p>
+     * <p>hasControlDependency.</p>
      *
      * @return a boolean.
      */
@@ -89,19 +89,20 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>getBranchInstruction</p>
+     * <p>getBranchInstruction.</p>
      *
      * @return a {@link org.evosuite.coverage.branch.Branch} object.
      */
     public Branch getBranchInstruction() {
-        if (cd == null)
+        if (cd == null) {
             return null;
+        }
 
         return cd.getBranch();
     }
 
     /**
-     * <p>isExceptionEdge</p>
+     * <p>isExceptionEdge.</p>
      *
      * @return a boolean.
      */
@@ -110,44 +111,45 @@ public class ControlFlowEdge extends DefaultEdge {
     }
 
     /**
-     * <p>getBranchExpressionValue</p>
+     * <p>getBranchExpressionValue.</p>
      *
      * @return a boolean.
      */
     public boolean getBranchExpressionValue() {
-        if (hasControlDependency())
+        if (hasControlDependency()) {
             return cd.getBranchExpressionValue();
+        }
 
         return true;
     }
 
-//	@Override
-//	public int hashCode() {
-//		final int prime = 31;
-//		int result = 1;
-//		result = prime * result + ((cd == null) ? 0 : cd.hashCode());
-//		result = prime * result + (isExceptionEdge ? 1231 : 1237);
-//		return result;
-//	}
-//
-//	@Override
-//	public boolean equals(Object obj) {
-//		if (this == obj)
-//			return true;
-//		if (obj == null)
-//			return false;
-//		if (getClass() != obj.getClass())
-//			return false;
-//		ControlFlowEdge other = (ControlFlowEdge) obj;
-//		if (cd == null) {
-//			if (other.cd != null)
-//				return false;
-//		} else if (!cd.equals(other.cd))
-//			return false;
-//		if (isExceptionEdge != other.isExceptionEdge)
-//			return false;
-//		return true;
-//	}
+    //    @Override
+    //    public int hashCode() {
+    //        final int prime = 31;
+    //        int result = 1;
+    //        result = prime * result + ((cd == null) ? 0 : cd.hashCode());
+    //        result = prime * result + (isExceptionEdge ? 1231 : 1237);
+    //        return result;
+    //    }
+    //
+    //    @Override
+    //    public boolean equals(Object obj) {
+    //        if (this == obj)
+    //            return true;
+    //        if (obj == null)
+    //            return false;
+    //        if (getClass() != obj.getClass())
+    //            return false;
+    //        ControlFlowEdge other = (ControlFlowEdge) obj;
+    //        if (cd == null) {
+    //            if (other.cd != null)
+    //                return false;
+    //        } else if (!cd.equals(other.cd))
+    //            return false;
+    //        if (isExceptionEdge != other.isExceptionEdge)
+    //            return false;
+    //        return true;
+    //    }
 
     /**
      * {@inheritDoc}
@@ -155,10 +157,12 @@ public class ControlFlowEdge extends DefaultEdge {
     @Override
     public String toString() {
         String r = "";
-        if (isExceptionEdge)
+        if (isExceptionEdge) {
             r += "E ";
-        if (cd != null)
+        }
+        if (cd != null) {
             r += cd.toString();
+        }
         return r;
     }
 }

--- a/client/src/main/java/org/evosuite/graphs/cfg/ControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ControlFlowGraph.java
@@ -32,18 +32,18 @@ import java.util.Set;
 
 
 /**
- * Abstract base class for both forms of CFGs inside EvoSuite
- * <p>
- * One implementation of this is cfg.RawControlFlowGraph, which is also known as
+ * Abstract base class for both forms of CFGs inside EvoSuite.
+ *
+ * <p>One implementation of this is cfg.RawControlFlowGraph, which is also known as
  * the complete CFG The other implementation of this is
  * cfg.ActualControlFlowGraph which is also known as the minimal CFG Look at the
- * respective classes for more detailed information
- * <p>
- * The CFGs can be accessed via the GraphPool which holds for each CUT and each
- * of their methods a complete and a minimal CFG
- * <p>
- * CFGs are created by the CFGGenerator during the analysis of the CUTs'
- * byteCode performed by the BytecodeAnalyzer
+ * respective classes for more detailed information.
+ *
+ * <p>The CFGs can be accessed via the GraphPool which holds for each CUT and each
+ * of their methods a complete and a minimal CFG.
+ *
+ * <p>CFGs are created by the CFGGenerator during the analysis of the CUTs'
+ * byteCode performed by the BytecodeAnalyzer.
  *
  * @author Gordon Fraser, Andre Mis
  */
@@ -60,7 +60,7 @@ public abstract class ControlFlowGraph<V> extends
     private int diameter = -1;
 
     /**
-     * Creates a fresh and empty CFG for the given class and method
+     * Creates a fresh and empty CFG for the given class and method.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
@@ -69,8 +69,9 @@ public abstract class ControlFlowGraph<V> extends
     protected ControlFlowGraph(String className, String methodName, int access) {
         super(ControlFlowEdge.class);
 
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.className = className;
         this.methodName = methodName;
@@ -79,19 +80,20 @@ public abstract class ControlFlowGraph<V> extends
 
     /**
      * Creates a CFG determined by the given jGraph for the given class and
-     * method
+     * method.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
      * @param access     a int.
-     * @param jGraph     a {@link org.jgrapht.graph.DefaultDirectedGraph} object.
+     * @param graph      a {@link org.jgrapht.graph.DefaultDirectedGraph} object.
      */
     protected ControlFlowGraph(String className, String methodName, int access,
-                               DefaultDirectedGraph<V, ControlFlowEdge> jGraph) {
-        super(jGraph, ControlFlowEdge.class);
+                               DefaultDirectedGraph<V, ControlFlowEdge> graph) {
+        super(graph, ControlFlowEdge.class);
 
-        if (className == null || methodName == null)
+        if (className == null || methodName == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         this.className = className;
         this.methodName = methodName;
@@ -99,7 +101,7 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>leadsToNode</p>
+     * <p>leadsToNode.</p>
      *
      * @param e a {@link org.evosuite.graphs.cfg.ControlFlowEdge} object.
      * @param b a V object.
@@ -113,15 +115,18 @@ public abstract class ControlFlowGraph<V> extends
         queue.add(getEdgeTarget(e));
         while (!queue.isEmpty()) {
             V current = queue.poll();
-            if (handled.contains(current))
+            if (handled.contains(current)) {
                 continue;
+            }
             handled.add(current);
 
-            for (V next : getChildren(current))
-                if (next.equals(b))
+            for (V next : getChildren(current)) {
+                if (next.equals(b)) {
                     return true;
-                else
+                } else {
                     queue.add(next);
+                }
+            }
         }
 
         return false;
@@ -138,9 +143,9 @@ public abstract class ControlFlowGraph<V> extends
 
     /**
      * Can be used to retrieve an instruction contained in this CFG identified
-     * by it's instructionId
-     * <p>
-     * If no such instruction exists in this CFG, null is returned
+     * by it's instructionId.
+     *
+     * <p>If no such instruction exists in this CFG, null is returned.
      *
      * @param instructionId a int.
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -148,7 +153,7 @@ public abstract class ControlFlowGraph<V> extends
     public abstract BytecodeInstruction getInstruction(int instructionId);
 
     /**
-     * Determines, whether a given instruction is contained in this CFG
+     * Determines, whether a given instruction is contained in this CFG.
      *
      * @param instruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a boolean.
@@ -156,13 +161,13 @@ public abstract class ControlFlowGraph<V> extends
     public abstract boolean containsInstruction(BytecodeInstruction instruction);
 
     /**
-     * Computes the diameter of this CFG and the mutation distances
-     * <p>
-     * Since both takes some time this is not automatically done on each CFG
-     * <p>
-     * GraphPool will automatically call this immediately after the
+     * Computes the diameter of this CFG and the mutation distances.
+     *
+     * <p>Since both takes some time this is not automatically done on each CFG.
+     *
+     * <p>GraphPool will automatically call this immediately after the
      * instantiation of an ActualControlFlowGraph, but not after the creation of
-     * a RawControlFlowGraph
+     * a RawControlFlowGraph.
      */
     public void finalise() {
         computeDiameter();
@@ -172,10 +177,10 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * Returns the Diameter of this CFG
-     * <p>
-     * If the diameter of this graph was not computed previously it is computed
-     * first
+     * Returns the Diameter of this CFG.
+     *
+     * <p>If the diameter of this graph was not computed previously it is computed
+     * first.
      *
      * @return a int.
      */
@@ -192,13 +197,13 @@ public abstract class ControlFlowGraph<V> extends
         // E = the number of edges of the graph.
         // N = the number of nodes of the graph.
         // M = E − N + 2
-        int E = this.edgeCount();
-        int N = this.vertexCount();
-        return E - N + 2;
+        int edgeCount = this.edgeCount();
+        int vertexCount = this.vertexCount();
+        return edgeCount - vertexCount + 2;
     }
 
     /**
-     * <p>computeDiameter</p>
+     * <p>computeDiameter.</p>
      */
     protected void computeDiameter() {
         // The diameter is just an upper bound for the approach level
@@ -212,20 +217,22 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>determineEntryPoint</p>
+     * <p>determineEntryPoint.</p>
      *
      * @return a V object.
      */
     public V determineEntryPoint() {
         Set<V> candidates = determineEntryPoints();
 
-        if (candidates.size() > 1)
+        if (candidates.size() > 1) {
             throw new IllegalStateException(
                     "expect CFG of a method to contain at most one instruction with no parent in "
                             + methodName);
+        }
 
-        for (V instruction : candidates)
+        for (V instruction : candidates) {
             return instruction;
+        }
 
         // there was a back loop to the first instruction within this CFG, so no
         // candidate
@@ -255,7 +262,7 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>getMethodAccess</p>
+     * <p>getMethodAccess.</p>
      *
      * @return a int.
      */
@@ -264,7 +271,7 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>isPublicMethod</p>
+     * <p>isPublicMethod.</p>
      *
      * @return a boolean.
      */
@@ -273,7 +280,7 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>isStaticMethod</p>
+     * <p>isStaticMethod.</p>
      *
      * @return a boolean.
      */
@@ -298,7 +305,7 @@ public abstract class ControlFlowGraph<V> extends
     }
 
     /**
-     * <p>getCFGType</p>
+     * <p>getCFGType.</p>
      *
      * @return a {@link java.lang.String} object.
      */

--- a/client/src/main/java/org/evosuite/graphs/cfg/EntryBlock.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/EntryBlock.java
@@ -24,7 +24,7 @@ public class EntryBlock extends BasicBlock {
     private static final long serialVersionUID = -4279595207017734232L;
 
     /**
-     * <p>Constructor for EntryBlock.</p>
+     * Constructor for EntryBlock.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.

--- a/client/src/main/java/org/evosuite/graphs/cfg/ExitBlock.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/ExitBlock.java
@@ -24,7 +24,7 @@ public class ExitBlock extends BasicBlock {
     private static final long serialVersionUID = 970110985248711972L;
 
     /**
-     * <p>Constructor for ExitBlock.</p>
+     * Constructor for ExitBlock.
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.

--- a/client/src/main/java/org/evosuite/graphs/cfg/RawControlFlowGraph.java
+++ b/client/src/main/java/org/evosuite/graphs/cfg/RawControlFlowGraph.java
@@ -37,9 +37,9 @@ import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Represents the complete CFG of a method
- * <p>
- * Essentially this is a graph containing all BytecodeInstrucions of a method as
+ * Represents the complete CFG of a method.
+ *
+ * <p>Essentially this is a graph containing all BytecodeInstrucions of a method as
  * nodes. From each such instruction there is an edge to each possible
  * instruction the control flow can reach immediately after that instruction.
  *
@@ -52,6 +52,8 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
     private final ClassLoader classLoader;
 
     /**
+     * <p>Getter for the field <code>classLoader</code>.</p>
+     *
      * @return the classLoader
      */
     public ClassLoader getClassLoader() {
@@ -59,9 +61,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
     }
 
     /**
-     * <p>
      * Constructor for RawControlFlowGraph.
-     * </p>
      *
      * @param className  a {@link java.lang.String} object.
      * @param methodName a {@link java.lang.String} object.
@@ -108,7 +108,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * addEdge
+     * addEdge.
      * </p>
      *
      * @param src             a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -121,11 +121,13 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
         logger.debug("Adding edge to RawCFG of " + className + "." + methodName + ": " + this.vertexCount());
 
-        if (BranchPool.getInstance(classLoader).isKnownAsBranch(src))
-            if (src.isBranch())
+        if (BranchPool.getInstance(classLoader).isKnownAsBranch(src)) {
+            if (src.isBranch()) {
                 return addBranchEdge(src, target, isExceptionEdge);
-            else if (src.isSwitch())
+            } else if (src.isSwitch()) {
                 return addSwitchBranchEdge(src, target, isExceptionEdge);
+            }
+        }
 
         return addUnlabeledEdge(src, target, isExceptionEdge);
     }
@@ -158,9 +160,10 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
             // Exception edges are not governed by switch case decisions.
             return internalAddEdge(src, target, new ControlFlowEdge(true));
         }
-        if (!target.isLabel())
+        if (!target.isLabel()) {
             throw new IllegalStateException(
                     "expect control flow edges from switch statements to always target labelNodes");
+        }
 
         LabelNode label = (LabelNode) target.getASMNode();
 
@@ -176,12 +179,15 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
             Set<ControlFlowEdge> soFar = incomingEdgesOf(target);
             boolean handled = false;
-            for (ControlFlowEdge old : soFar)
-                if (switchCaseBranch.equals(old.getBranchInstruction()))
+            for (ControlFlowEdge old : soFar) {
+                if (switchCaseBranch.equals(old.getBranchInstruction())) {
                     handled = true;
+                }
+            }
 
-            if (handled)
+            if (handled) {
                 continue;
+            }
 
             ControlDependency cd = new ControlDependency(switchCaseBranch, true);
             ControlFlowEdge e = new ControlFlowEdge(cd, isExceptionEdge);
@@ -200,9 +206,10 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
             logger.debug("unable to add edge from " + src.toString() + " to "
                     + target.toString() + " into the rawCFG of " + getMethodName());
             e = super.getEdge(src, target);
-            if (e == null)
+            if (e == null) {
                 throw new IllegalStateException(
                         "internal graph error - completely unexpected");
+            }
         }
 
         return e;
@@ -222,15 +229,16 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * determineBasicBlockFor
+     * determineBasicBlockFor.
      * </p>
      *
      * @param instruction a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
      * @return a {@link org.evosuite.graphs.cfg.BasicBlock} object.
      */
     public BasicBlock determineBasicBlockFor(BytecodeInstruction instruction) {
-        if (instruction == null)
+        if (instruction == null) {
             throw new IllegalArgumentException("null given");
+        }
 
         logger.debug("creating basic block for " + instruction);
 
@@ -247,15 +255,17 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
             logger.debug("handling " + current.toString());
 
             // add child to queue
-            if (outDegreeOf(current) == 1)
+            if (outDegreeOf(current) == 1) {
                 for (BytecodeInstruction child : getChildren(current)) {
                     // this must be only one edge if inDegree was 1
 
-                    if (blockNodes.contains(child))
+                    if (blockNodes.contains(child)) {
                         continue;
+                    }
 
-                    if (handledChildren.contains(child))
+                    if (handledChildren.contains(child)) {
                         continue;
+                    }
                     handledChildren.add(child);
 
                     if (inDegreeOf(child) < 2) {
@@ -268,17 +278,20 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                         queue.add(child);
                     }
                 }
+            }
 
             // add parent to queue
-            if (inDegreeOf(current) == 1)
+            if (inDegreeOf(current) == 1) {
                 for (BytecodeInstruction parent : getParents(current)) {
                     // this must be only one edge if outDegree was 1
 
-                    if (blockNodes.contains(parent))
+                    if (blockNodes.contains(parent)) {
                         continue;
+                    }
 
-                    if (handledParents.contains(parent))
+                    if (handledParents.contains(parent)) {
                         continue;
+                    }
                     handledParents.add(parent);
 
                     if (outDegreeOf(parent) < 2) {
@@ -289,6 +302,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                         queue.add(parent);
                     }
                 }
+            }
         }
 
         BasicBlock r = new BasicBlock(classLoader, className, methodName, blockNodes);
@@ -304,8 +318,9 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
     public BytecodeInstruction determineEntryPoint() {
 
         BytecodeInstruction noParent = super.determineEntryPoint();
-        if (noParent != null)
+        if (noParent != null) {
             return noParent;
+        }
 
         // copied from ControlFlowGraph.determineEntryPoint():
         // there was a back loop to the first instruction within this CFG, so no
@@ -325,8 +340,9 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
         // if the last instruction loops back to a previous instruction there is
         // no node without a child, so just take the last byteCode instruction
 
-        if (r.isEmpty())
+        if (r.isEmpty()) {
             r.add(getInstructionWithBiggestId());
+        }
 
         return r;
 
@@ -334,7 +350,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * getInstructionWithSmallestId
+     * getInstructionWithSmallestId.
      * </p>
      *
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -347,7 +363,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * getInstructionWithBiggestId
+     * getInstructionWithBiggestId.
      * </p>
      *
      * @return a {@link org.evosuite.graphs.cfg.BytecodeInstruction} object.
@@ -400,13 +416,15 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
         queue.add(v);
         while (queue.peek() != null) {
             BytecodeInstruction current = queue.poll();
-            if (visited.contains(current))
+            if (visited.contains(current)) {
                 continue;
+            }
             Set<ControlFlowEdge> incomingEdges = graph.incomingEdgesOf(current);
             for (ControlFlowEdge incomingEdge : incomingEdges) {
                 BytecodeInstruction source = graph.getEdgeSource(incomingEdge);
-                if (source.getInstructionId() >= current.getInstructionId())
+                if (source.getInstructionId() >= current.getInstructionId()) {
                     continue;
+                }
                 queue.add(source);
             }
             visited.add(current);
@@ -431,13 +449,15 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
         queue.add(v);
         while (queue.peek() != null) {
             BytecodeInstruction current = queue.poll();
-            if (visited.contains(current))
+            if (visited.contains(current)) {
                 continue;
+            }
             Set<ControlFlowEdge> outgoingEdges = graph.outgoingEdgesOf(current);
             for (ControlFlowEdge outgoingEdge : outgoingEdges) {
                 BytecodeInstruction target = graph.getEdgeTarget(outgoingEdge);
-                if (target.getInstructionId() < current.getInstructionId())
+                if (target.getInstructionId() < current.getInstructionId()) {
                     continue;
+                }
                 queue.add(target);
             }
             visited.add(current);
@@ -449,38 +469,43 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * getUsesForDef
+     * getUsesForDef.
      * </p>
      *
      * @param def a {@link org.evosuite.coverage.dataflow.Definition} object.
      * @return a {@link java.util.Set} object.
      */
     public Set<Use> getUsesForDef(Definition def) {
-        if (!graph.containsVertex(def))
+        if (!graph.containsVertex(def)) {
             throw new IllegalArgumentException("unknown Definition");
+        }
 
         return getUsesForDef(def, def, new HashSet<>());
     }
 
     private Set<Use> getUsesForDef(Definition targetDef,
                                    BytecodeInstruction currentInstruction, Set<BytecodeInstruction> handled) {
-        if (!graph.containsVertex(currentInstruction))
+        if (!graph.containsVertex(currentInstruction)) {
             throw new IllegalArgumentException("vertex not in graph");
+        }
 
         Set<Use> r = new HashSet<>();
 
-        if (handled.contains(currentInstruction))
+        if (handled.contains(currentInstruction)) {
             return r;
+        }
         handled.add(currentInstruction);
 
         Set<ControlFlowEdge> outgoingEdges = graph.outgoingEdgesOf(currentInstruction);
         for (ControlFlowEdge e : outgoingEdges) {
             BytecodeInstruction edgeTarget = graph.getEdgeTarget(e);
 
-            if (targetDef.canBeActiveFor(edgeTarget))
+            if (targetDef.canBeActiveFor(edgeTarget)) {
                 r.add(DefUseFactory.makeUse(edgeTarget));
-            if (canOverwriteDU(targetDef, edgeTarget))
+            }
+            if (canOverwriteDU(targetDef, edgeTarget)) {
                 continue;
+            }
             // don not follow edges going to previous instructions (avoid loops)
             // if (edgeTarget.getInstructionId() >
             // currentInstruction.getInstructionId())
@@ -491,17 +516,19 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * hasDefClearPathToMethodExit
+     * hasDefClearPathToMethodExit.
      * </p>
      *
      * @param duVertex a {@link org.evosuite.coverage.dataflow.Definition} object.
      * @return a boolean.
      */
     public boolean hasDefClearPathToMethodExit(Definition duVertex) {
-        if (!graph.containsVertex(duVertex))
+        if (!graph.containsVertex(duVertex)) {
             throw new IllegalArgumentException("vertex not in graph");
-        if (duVertex.isLocalDU())
+        }
+        if (duVertex.isLocalDU()) {
             return false;
+        }
 
         return hasDefClearPathToMethodExit(duVertex, duVertex,
                 new HashSet<>());
@@ -509,17 +536,19 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * hasDefClearPathFromMethodEntry
+     * hasDefClearPathFromMethodEntry.
      * </p>
      *
      * @param duVertex a {@link org.evosuite.coverage.dataflow.Use} object.
      * @return a boolean.
      */
     public boolean hasDefClearPathFromMethodEntry(Use duVertex) {
-        if (!graph.containsVertex(duVertex))
+        if (!graph.containsVertex(duVertex)) {
             throw new IllegalArgumentException("vertex not in graph");
-        if (duVertex.isLocalDU())
+        }
+        if (duVertex.isLocalDU()) {
             return false;
+        }
 
         return hasDefClearPathFromMethodEntry(duVertex, duVertex,
                 new HashSet<>());
@@ -527,59 +556,70 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     private boolean hasDefClearPathToMethodExit(Definition targetDefUse,
                                                 BytecodeInstruction currentVertex, Set<BytecodeInstruction> handled) {
-        if (!graph.containsVertex(currentVertex))
+        if (!graph.containsVertex(currentVertex)) {
             throw new IllegalArgumentException("vertex not in graph");
+        }
 
-        if (handled.contains(currentVertex))
+        if (handled.contains(currentVertex)) {
             return false;
+        }
         handled.add(currentVertex);
 
         Set<ControlFlowEdge> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
-        if (outgoingEdges.size() == 0)
+        if (outgoingEdges.size() == 0) {
             return true;
+        }
 
         for (ControlFlowEdge e : outgoingEdges) {
             BytecodeInstruction edgeTarget = graph.getEdgeTarget(e);
 
-            if (canOverwriteDU(targetDefUse, edgeTarget))
+            if (canOverwriteDU(targetDefUse, edgeTarget)) {
                 continue;
+            }
 
             // if (edgeTarget.getInstructionId() >
             // currentVertex.getInstructionId() // dont follow backedges (loops)
             // && hasDefClearPathToMethodExit(targetDefUse, edgeTarget,
             // handled))
-            if (hasDefClearPathToMethodExit(targetDefUse, edgeTarget, handled))
+            if (hasDefClearPathToMethodExit(targetDefUse, edgeTarget, handled)) {
                 return true;
+            }
         }
         return false;
     }
 
     private boolean hasDefClearPathFromMethodEntry(Use targetDefUse,
-                                                   BytecodeInstruction currentVertex, Set<BytecodeInstruction> handled) {
-        if (!graph.containsVertex(currentVertex))
+                                                   BytecodeInstruction currentVertex,
+                                                   Set<BytecodeInstruction> handled) {
+        if (!graph.containsVertex(currentVertex)) {
             throw new IllegalArgumentException("vertex not in graph");
+        }
 
-        if (handled.contains(currentVertex))
+        if (handled.contains(currentVertex)) {
             return false;
+        }
         handled.add(currentVertex);
 
         Set<ControlFlowEdge> incomingEdges = graph.incomingEdgesOf(currentVertex);
-        if (incomingEdges.size() == 0)
+        if (incomingEdges.size() == 0) {
             return true;
+        }
 
         for (ControlFlowEdge e : incomingEdges) {
             BytecodeInstruction edgeStart = graph.getEdgeSource(e);
 
             // skip edges coming from a def for the same field
-            if (canOverwriteDU(targetDefUse, edgeStart, new HashSet<>()))
+            if (canOverwriteDU(targetDefUse, edgeStart, new HashSet<>())) {
                 continue;
+            }
 
             // if (edgeTarget.getInstructionId() >
             // currentVertex.getInstructionId() // dont follow backedges (loops)
             // && hasDefClearPathToMethodExit(targetDefUse, edgeTarget,
             // handled))
-            if (hasDefClearPathFromMethodEntry(targetDefUse, edgeStart, handled))
+            if (hasDefClearPathFromMethodEntry(targetDefUse, edgeStart, handled)) {
                 return true;
+            }
 
         }
         return false;
@@ -615,7 +655,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * Checks if the given DefUse has a definition-clear path to its methods
-     * exit
+     * exit.
      *
      * @param targetDU a {@link org.evosuite.coverage.dataflow.DefUse} object.
      * @param handle   a {@link java.util.Set} object.
@@ -629,23 +669,26 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
     }
 
     /**
-     * Auxiliary method for hasDefClearPath(DefUse, Set)
+     * Auxiliary method for hasDefClearPath(DefUse, Set).
      */
     private boolean hasDefClearPath(DefUse targetDU, BytecodeInstruction currentVertex,
                                     Set<String> handle) {
-        if (!graph.containsVertex(currentVertex))
+        if (!graph.containsVertex(currentVertex)) {
             throw new IllegalArgumentException("vertex not in graph");
+        }
 
         handle.add(methodName);
 
         String targetVariable = targetDU.getVariableName();
 
-        if (currentVertex.isDefinitionForVariable(targetVariable))
+        if (currentVertex.isDefinitionForVariable(targetVariable)) {
             return false;
+        }
 
         Set<ControlFlowEdge> outgoingEdges = graph.outgoingEdgesOf(currentVertex);
-        if (outgoingEdges.size() == 0)
+        if (outgoingEdges.size() == 0) {
             return true;
+        }
 
         for (ControlFlowEdge e : outgoingEdges) {
             BytecodeInstruction edgeTarget = graph.getEdgeTarget(e);
@@ -653,14 +696,16 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
             // handle edgeTarget being another method call!
             if (canBeOverwritingMethod(targetDU, edgeTarget)
                     && !handle.contains(edgeTarget.getCalledMethod())
-                    && canOverwriteDU(targetDU, edgeTarget, handle))
+                    && canOverwriteDU(targetDU, edgeTarget, handle)) {
                 continue;
+            }
 
-            if (/*
-             * edgeTarget.getInstructionId() > currentVertex
-             * .getInstructionId() // dont follow backedges (loops) &&
-             */hasDefClearPath(targetDU, edgeTarget, handle))
+            // if (edgeTarget.getInstructionId() > currentVertex.getInstructionId()
+            //         // dont follow backedges (loops)
+            //         && hasDefClearPath(targetDU, edgeTarget, handle))
+            if (hasDefClearPath(targetDU, edgeTarget, handle)) {
                 return true;
+            }
         }
 
         return false;
@@ -674,8 +719,9 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                                    Set<String> handle) {
 
         // skip edges going into another def for the same field
-        if (targetDefUse.canBecomeActiveDefinition(edgeTarget))
+        if (targetDefUse.canBecomeActiveDefinition(edgeTarget)) {
             return true;
+        }
 
         return callsOverwritingMethod(targetDefUse, edgeTarget, handle);
     }
@@ -714,7 +760,7 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * determineMethodCalls
+     * determineMethodCalls.
      * </p>
      *
      * @return a {@link java.util.List} object.
@@ -727,14 +773,14 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
 
     /**
      * <p>
-     * determineMethodCallsToOwnClass
+     * determineMethodCallsToOwnClass.
      * </p>
      *
      * @return a {@link java.util.List} object.
      */
     public List<BytecodeInstruction> determineMethodCallsToOwnClass() {
         List<BytecodeInstruction> calls = new ArrayList<>();
-        for (BytecodeInstruction ins : determineMethodCalls())
+        for (BytecodeInstruction ins : determineMethodCalls()) {
             if (ins.isMethodCallForClass(className)) {
 
                 // somehow ASMs MethodInsnNode.owner and thus
@@ -745,10 +791,12 @@ public class RawControlFlowGraph extends ControlFlowGraph<BytecodeInstruction> {
                 // TODO so for now we have this workaround: if A is our CUT then
                 // the GraphPool does not know B.
 
-                if (GraphPool.getInstance(classLoader).getRawCFG(className,
-                        ins.getCalledMethod()) != null)
+                if (GraphPool.getInstance(classLoader)
+                        .getRawCFG(className, ins.getCalledMethod()) != null) {
                     calls.add(ins);
+                }
             }
+        }
 
         return calls;
     }


### PR DESCRIPTION
This PR addresses Checkstyle violations in the `org.evosuite.graphs.cfg` package within the `client` module.

Changes include:
- Renaming fields to follow Java naming conventions (e.g., `ID` -> `Id`, `plain_name` -> `plainName`).
- Adding braces to control flow statements (`if`, `for`, `else`) to comply with `NeedBraces`.
- Formatting Javadoc comments to satisfy `SummaryJavadoc`, `JavadocParagraph`, and `NonEmptyAtclauseDescription` rules.
- Fixing line length violations.
- Resolving `MissingSwitchDefault` in `BytecodeInstructionPool`.
- Correcting `FileTabCharacter` issues.

Verified that the code compiles and passes relevant tests (`BasicBlockTest`, `CFGMethodAdapterTest`, `ControlFlowGraphTest`) and that `mvn checkstyle:check` reports zero violations for the modified package.

---
*PR created automatically by Jules for task [609817712575651066](https://jules.google.com/task/609817712575651066) started by @gofraser*