### PR TITLE
Fix Checkstyle violations in MockitoConfiguration.java

### DIFF
--- a/client/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/client/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -21,15 +21,15 @@ package org.mockito.configuration;
 
 /**
  * Class needed to be on classpath to configure Mockito, which cannot be
- * configured programmatically :(
- * <p>
- * This is essential during search, but should NOT be part of standalone runtime.
- * <p>
- * During search, the same SUT class can be loaded by different classloader (eg, search,
+ * configured programmatically.
+ *
+ * <p>This is essential during search, but should NOT be part of standalone runtime.
+ *
+ * <p>During search, the same SUT class can be loaded by different classloader (eg, search,
  * assertion generation, junit checks), and would lead to class cast exceptions because
- * Mockito does cache class definitions. So, we have to disable such behavior
- * <p>
- * Created by Andrea Arcuri on 21/08/15.
+ * Mockito does cache class definitions. So, we have to disable such behavior.
+ *
+ * <p>Created by Andrea Arcuri on 21/08/15.
  */
 public class MockitoConfiguration extends DefaultMockitoConfiguration {
 


### PR DESCRIPTION
This PR fixes Checkstyle violations in `client/src/main/java/org/mockito/configuration/MockitoConfiguration.java`. The changes are purely documentation (Javadoc) formatting improvements to comply with `JavadocParagraph` and `SummaryJavadoc` rules. No functional code changes were made.

Verification:
- Ran `mvn -pl client checkstyle:check -Dcheckstyle.includes=**/MockitoConfiguration.java` and confirmed 0 violations.
- Verified compilation with `mvn compile -pl client`.
- Ran basic tests `mvn test -pl client -Dtest=org.evosuite.PropertiesTest`.

---
*PR created automatically by Jules for task [15251905737231645552](https://jules.google.com/task/15251905737231645552) started by @gofraser*