### PR TITLE
Apply checkstyle to org.evosuite.strategy package

### DIFF
--- a/client/src/main/java/org/evosuite/strategy/EntBugTestStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/EntBugTestStrategy.java
@@ -45,8 +45,8 @@ import java.util.Set;
  *
  * @author José Campos
  *
- * <pre>
- * {@literal @}inproceedings{Campos:2013,
+ *     <pre>
+ *     {@literal @}inproceedings{Campos:2013,
  *     author = {Campos, Jos{\'e} and Abreu, Rui and Fraser, Gordon and d'Amorim, Marcelo},
  *     title = {{Entropy-Based Test Generation for Improved Fault Localization}},
  *     booktitle = {Proceedings of the 28th IEEE/ACM International Conference on
@@ -63,8 +63,8 @@ import java.util.Set;
  *     publisher = {ACM},
  *     address = {New York, NY, USA},
  *     keywords = {Fault localization, test case generation},
- * }
- * </pre>
+ *     }
+ *     </pre>
  */
 public class EntBugTestStrategy extends TestGenerationStrategy {
 
@@ -89,7 +89,8 @@ public class EntBugTestStrategy extends TestGenerationStrategy {
         }
 
         // What's the search target
-        RhoCoverageFactory rhoFactory = (RhoCoverageFactory) FitnessFunctions.getFitnessFactory(Properties.Criterion.RHO);
+        RhoCoverageFactory rhoFactory = (RhoCoverageFactory) FitnessFunctions.getFitnessFactory(
+                Properties.Criterion.RHO);
         RhoCoverageTestFitness rhoTestFitnessFunction = new RhoCoverageTestFitness();
         ga.addFitnessFunction(rhoTestFitnessFunction);
 

--- a/client/src/main/java/org/evosuite/strategy/MAPElitesStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/MAPElitesStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  *
@@ -121,7 +121,8 @@ public class MAPElitesStrategy extends TestGenerationStrategy {
             LoggingUtils.getEvoLogger().info("");
         }
 
-        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) { //avoid printing time related info in system tests due to lack of determinism
+        // avoid printing time related info in system tests due to lack of determinism
+        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) {
             LoggingUtils.getEvoLogger().info("* Search finished after "
                     + (endTime - startTime)
                     + "s and "

--- a/client/src/main/java/org/evosuite/strategy/NoveltyStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/NoveltyStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  *
@@ -145,7 +145,8 @@ public class NoveltyStrategy extends TestGenerationStrategy {
             LoggingUtils.getEvoLogger().info("");
         }
 
-        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) { //avoid printing time related info in system tests due to lack of determinism
+        // avoid printing time related info in system tests due to lack of determinism
+        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) {
             LoggingUtils.getEvoLogger().info(
                     "* Search finished after {}s and {} generations, {} statements, best individual has fitness: {}",
                     (endTime - startTime),

--- a/client/src/main/java/org/evosuite/strategy/PropertiesMapElitesSearchFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesMapElitesSearchFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  *

--- a/client/src/main/java/org/evosuite/strategy/PropertiesNoveltySearchFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesNoveltySearchFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors
  *
@@ -198,7 +198,7 @@ public class PropertiesNoveltySearchFactory extends PropertiesSearchAlgorithmFac
 
         // Some statistics
         //if (Properties.STRATEGY == Strategy.EVOSUITE)
-        //	ga.addListener(SearchStatistics.getInstance());
+        //    ga.addListener(SearchStatistics.getInstance());
         // ga.addListener(new MemoryMonitor());
         // ga.addListener(MutationStatistics.getInstance());
         // ga.addListener(BestChromosomeTracker.getInstance());

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -139,7 +139,8 @@ public class PropertiesSuiteGAFactory
                 : super.getPopulationLimit();
     }
 
-    protected GeneticAlgorithm<TestSuiteChromosome> getGeneticAlgorithm(ChromosomeFactory<TestSuiteChromosome> factory) {
+    protected GeneticAlgorithm<TestSuiteChromosome> getGeneticAlgorithm(
+            ChromosomeFactory<TestSuiteChromosome> factory) {
         switch (Properties.ALGORITHM) {
             case ONE_PLUS_ONE_EA:
                 logger.info("Chosen search algorithm: (1+1)EA");

--- a/client/src/main/java/org/evosuite/strategy/WholeTestSuiteStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/WholeTestSuiteStrategy.java
@@ -89,7 +89,8 @@ public class WholeTestSuiteStrategy extends TestGenerationStrategy {
 
         List<TestFitnessFunction> goals = getGoals(true);
         if (!canGenerateTestsForSUT()) {
-            LoggingUtils.getEvoLogger().info("* Found no testable methods in the target class {}", Properties.TARGET_CLASS);
+            LoggingUtils.getEvoLogger().info("* Found no testable methods in the target class {}",
+                    Properties.TARGET_CLASS);
             ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, goals.size());
 
             return new TestSuiteChromosome();
@@ -127,7 +128,8 @@ public class WholeTestSuiteStrategy extends TestGenerationStrategy {
             LoggingUtils.getEvoLogger().info("");
         }
 
-        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) { //avoid printing time related info in system tests due to lack of determinism
+        // avoid printing time related info in system tests due to lack of determinism
+        if (!Properties.IS_RUNNING_A_SYSTEM_TEST) {
             LoggingUtils.getEvoLogger().info(
                     "* Search finished after {}s and {} generations, {} statements, best individual has fitness: {}",
                     (endTime - startTime),


### PR DESCRIPTION
Applied checkstyle fixes to `org.evosuite.strategy` package in `client` module.
Fixes include:
- License headers changed to `/*` to avoid `SummaryJavadoc` check.
- Line length fixes.
- Indentation fix in `EntBugTestStrategy.java` `<pre>` block.
- Tab removal in `PropertiesNoveltySearchFactory.java`.

---
*PR created automatically by Jules for task [12200828582819502437](https://jules.google.com/task/12200828582819502437) started by @gofraser*