### PR TITLE
Apply Checkstyle to org.evosuite.maven package

### DIFF
--- a/plugins/maven/src/main/java/org/evosuite/maven/CleanMojo.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/CleanMojo.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 
 /**
- * Remove all local files created by EvoSuite so far
+ * Remove all local files created by EvoSuite so far.
  */
 @Mojo(name = "clean")
 public class CleanMojo extends AbstractMojo {

--- a/plugins/maven/src/main/java/org/evosuite/maven/CoverageMojo.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/CoverageMojo.java
@@ -44,7 +44,8 @@ import java.util.Set;
  *
  * @author José Campos
  */
-@Mojo(name = "coverage", requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST)
+@Mojo(name = "coverage", requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST,
+        requiresDependencyCollection = ResolutionScope.TEST)
 public class CoverageMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
@@ -60,7 +61,7 @@ public class CoverageMojo extends AbstractMojo {
     private RepositorySystemSession repoSession;
 
     /**
-     * Coverage criterion. Can define more than one criterion by using a ':' separated list
+     * Coverage criterion. Can define more than one criterion by using a ':' separated list.
      */
     // FIXME would be nice to have the value of Properties.CRITERION but seems to be not possible
     // FIXME OUTPUT:METHOD:METHODNOEXCEPTION relies on Observers, to have coverage of these criteria
@@ -70,10 +71,10 @@ public class CoverageMojo extends AbstractMojo {
     private String criterion;
 
     /**
-     * Maximum seconds allowed
+     * Maximum seconds allowed.
      */
     @Parameter(property = "global_timeout", defaultValue = "120")
-    private int global_timeout;
+    private int globalTimeout;
 
 
     @Parameter(property = "output_variables", defaultValue = "TARGET_CLASS,criterion,Coverage,Total_Goals,Covered_Goals"
@@ -82,7 +83,7 @@ public class CoverageMojo extends AbstractMojo {
             + ",CBranchCoverage,CBranchCoverageBitString"
             + ",WeakMutationScore,WeakMutationCoverageBitString"
             + ",MethodTraceCoverage,MethodTraceCoverageBitString")
-    private String output_variables;
+    private String outputVariables;
 
     /**
      * A colon(:) separated list of JUnit suites to execute. Can be a prefix (i.e., package name),
@@ -126,8 +127,8 @@ public class CoverageMojo extends AbstractMojo {
         }
 
         params.add("-Dcriterion=" + this.criterion);
-        params.add("-Doutput_variables=" + this.output_variables);
-        params.add("-Dglobal_timeout=" + this.global_timeout);
+        params.add("-Doutput_variables=" + this.outputVariables);
+        params.add("-Dglobal_timeout=" + this.globalTimeout);
         // in theory should be safe to execute source-code
         params.add("-Dsandbox=false");
         params.add("-Dvirtual_fs=false");

--- a/plugins/maven/src/main/java/org/evosuite/maven/GenerateMojo.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/GenerateMojo.java
@@ -43,26 +43,27 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Generate JUnit tests
+ * Generate JUnit tests.
  */
-@Mojo(name = "generate", requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST)
+@Mojo(name = "generate", requiresDependencyResolution = ResolutionScope.TEST,
+        requiresDependencyCollection = ResolutionScope.TEST)
 @Execute(phase = LifecyclePhase.COMPILE)
 public class GenerateMojo extends AbstractMojo {
 
     /**
-     * Total Memory (in MB) that CTG will use
+     * Total Memory (in MB) that CTG will use.
      */
     @Parameter(property = "memoryInMB", defaultValue = "800")
     private int memoryInMB;
 
     /**
-     * Number of cores CTG will use
+     * Number of cores CTG will use.
      */
     @Parameter(property = "cores", defaultValue = "1")
     private int numberOfCores;
 
     /**
-     * Comma ',' separated list of CUTs to use in CTG. If none specified, then test all classes
+     * Comma ',' separated list of CUTs to use in CTG. If none specified, then test all classes.
      */
     @Parameter(property = "cuts")
     private String cuts;
@@ -70,28 +71,31 @@ public class GenerateMojo extends AbstractMojo {
     /**
      * Absolute path to a file having the list of CUTs specified. This is needed for operating
      * systems like Windows that have constraints on the size of input parameters and so could
-     * not use "cuts" parameter instead if too many CUTs are specified
+     * not use "cuts" parameter instead if too many CUTs are specified.
      */
     @Parameter(property = "cutsFile")
     private String cutsFile;
 
     /**
-     * How many minutes to allocate for each class
+     * How many minutes to allocate for each class.
      */
     @Parameter(property = "timeInMinutesPerClass", defaultValue = "2")
     private int timeInMinutesPerClass;
 
     /**
-     * How many minutes to allocate for each project/module. If this parameter is not set, then the total time will be timeInMinutesPerClass x number_of_classes
+     * How many minutes to allocate for each project/module.
+     * If this parameter is not set, then the total time will be
+     * timeInMinutesPerClass x number_of_classes.
      */
     @Parameter(property = "timeInMinutesPerProject", defaultValue = "0")
     private int timeInMinutesPerProject;
 
     /**
-     * Coverage criterion. Can define more than one criterion by using a ':' separated list
+     * Coverage criterion. Can define more than one criterion by using a ':' separated list.
      */
     // FIXME would be nice to have the value of Properties.CRITERION but seems to be not possible
-    @Parameter(property = "criterion", defaultValue = "LINE:BRANCH:EXCEPTION:WEAKMUTATION:OUTPUT:METHOD:METHODNOEXCEPTION:CBRANCH")
+    @Parameter(property = "criterion",
+            defaultValue = "LINE:BRANCH:EXCEPTION:WEAKMUTATION:OUTPUT:METHOD:METHODNOEXCEPTION:CBRANCH")
     private String criterion;
 
     @Parameter(property = "spawnManagerPort", defaultValue = "")
@@ -101,7 +105,7 @@ public class GenerateMojo extends AbstractMojo {
     private String extraArgs;
 
     /**
-     * Schedule used to run CTG (SIMPLE, BUDGET, SEEDING, BUDGET_AND_SEEDING, HISTORY)
+     * Schedule used to run CTG (SIMPLE, BUDGET, SEEDING, BUDGET_AND_SEEDING, HISTORY).
      */
     @Parameter(property = "schedule", defaultValue = "BUDGET")
     private String schedule;
@@ -159,12 +163,13 @@ public class GenerateMojo extends AbstractMojo {
                     continue;
                 }
 
-                if (!file.getAbsolutePath().startsWith(project.getBuild().getOutputDirectory())) {
-					/*
-						This can happen in multi-module projects when module A has dependency on
-						module B. Then, both A and B source folders will end up on compile classpath,
-						although we are interested only in A
-					 */
+                if (!file.getAbsolutePath().startsWith(
+                        project.getBuild().getOutputDirectory())) {
+                    /*
+                     * This can happen in multi-module projects when module A has dependency on
+                     * module B. Then, both A and B source folders will end up on compile classpath,
+                     * although we are interested only in A.
+                     */
                     continue;
                 }
 
@@ -251,7 +256,8 @@ public class GenerateMojo extends AbstractMojo {
                 throw new MojoFailureException("", e);
             }
 
-            params.add("-Dctg_history_file=" + dir + File.separator + Properties.CTG_DIR + File.separator + "history_file");
+            params.add("-Dctg_history_file=" + dir + File.separator + Properties.CTG_DIR
+                    + File.separator + "history_file");
         }
         params.add("-Dctg_memory=" + memoryInMB);
         params.add("-Dctg_cores=" + numberOfCores);
@@ -270,7 +276,8 @@ public class GenerateMojo extends AbstractMojo {
             params.add("-Dctg_time=" + timeInMinutesPerProject);
             params.add("-Dctg_min_time_per_job=" + timeInMinutesPerClass);
         } else {
-            params.add("-Dctg_time_per_class=" + timeInMinutesPerClass); // there is no time limit, so test all classes X minutes
+            // there is no time limit, so test all classes X minutes
+            params.add("-Dctg_time_per_class=" + timeInMinutesPerClass);
         }
         if (cuts != null) {
             params.add("-Dctg_selected_cuts=" + cuts);

--- a/plugins/maven/src/main/java/org/evosuite/maven/InfoMojo.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/InfoMojo.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Obtain info of generated tests so far
+ * Obtain info of generated tests so far.
  */
 @Mojo(name = "info")
 public class InfoMojo extends AbstractMojo {

--- a/plugins/maven/src/main/java/org/evosuite/maven/PrepareMojo.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/PrepareMojo.java
@@ -59,8 +59,8 @@ public class PrepareMojo extends AbstractMojo {
         getLog().info("Analyzing test folder: " + dir.getAbsolutePath());
         //NOTE: this check can fail, likely due to permissions...
         //if(!dir.isDirectory()){
-        //	getLog().error("Target folder for compiled tests is not a folder: "+dir.getAbsolutePath());
-        //	return;
+        //    getLog().error("Target folder for compiled tests is not a folder: " + dir.getAbsolutePath());
+        //    return;
         //}
 
         if (!dir.exists()) {
@@ -72,7 +72,8 @@ public class PrepareMojo extends AbstractMojo {
 
         getLog().info("Found " + list.size() + " EvoSuite scaffolding files");
 
-        File scaffolding = new File(project.getBasedir() + File.separator + InitializingListener.SCAFFOLDING_LIST_FILE_STRING);
+        File scaffolding = new File(project.getBasedir() + File.separator
+                + InitializingListener.SCAFFOLDING_LIST_FILE_STRING);
         try {
             PrintWriter out = new PrintWriter(scaffolding);
             for (String s : list) {

--- a/plugins/maven/src/main/java/org/evosuite/maven/util/EvoSuiteRunner.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/util/EvoSuiteRunner.java
@@ -40,29 +40,26 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Note: we cannot call EvoSuite directly on same JVM, like the following:
+ * Note: we cannot call EvoSuite directly on same JVM, like the following.
  *
- * <p>
- * <code>
+ * <p><code>
  * ContinuousTestGeneration ctg = new ContinuousTestGeneration(target,cp,prefix,conf);
  * ctg.execute();
- * </code>
+ * </code></p>
  *
- * <p>
- * Reason is that Maven uses its own classloaders, and setting their classpath
+ * <p>Reason is that Maven uses its own classloaders, and setting their classpath
  * becomes very messy, if possible at all.
- * So, we need to call EvoSuite on separated process
+ * So, we need to call EvoSuite on separated process.</p>
  *
- * <p>
- * TODO: most likely this code should be moved to a library, as other plugins (eg Netbeans)
- * will use it as well
+ * <p>TODO: most likely this code should be moved to a library, as other plugins (eg Netbeans)
+ * will use it as well.</p>
  */
 public class EvoSuiteRunner {
 
     public static final String EVOSUITE_HOME_VARIABLE = "EVOSUITE_HOME";
 
     /**
-     * The maven logger of the plugin
+     * The maven logger of the plugin.
      */
     private final Log logger;
 
@@ -95,10 +92,11 @@ public class EvoSuiteRunner {
     }
 
     /**
-     * This is blocking
+     * This is blocking.
      *
-     * @param params
-     * @return
+     * @param dir    The directory to run in.
+     * @param params Parameters to pass to EvoSuite.
+     * @return True if successful.
      */
     public boolean runEvoSuite(String dir, List<String> params) {
         List<String> cmd = getCommandToRunEvoSuite();
@@ -112,9 +110,9 @@ public class EvoSuiteRunner {
     }
 
     /**
-     * We run the EvoSuite that is provided with the plugin
+     * We run the EvoSuite that is provided with the plugin.
      *
-     * @return
+     * @return The command to run.
      */
     private List<String> getCommandToRunEvoSuite() {
 
@@ -186,7 +184,7 @@ public class EvoSuiteRunner {
 
 
     /**
-     * Check if there is a valid installation of EvoSuite on the current machine
+     * Check if there is a valid installation of EvoSuite on the current machine.
      */
     @Deprecated
     private List<String> getCommandToRunExternalEvoSuite() {
@@ -198,8 +196,8 @@ public class EvoSuiteRunner {
 
         String home = System.getenv(EVOSUITE_HOME_VARIABLE);
         if (home == null || home.isEmpty()) {
-            logger.error("Need to set the environment variable " + EVOSUITE_HOME_VARIABLE +
-                    " pointing to where EvoSuite is installed");
+            logger.error("Need to set the environment variable " + EVOSUITE_HOME_VARIABLE
+                    + " pointing to where EvoSuite is installed");
             return null;
         }
 

--- a/plugins/maven/src/main/java/org/evosuite/maven/util/FileUtils.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/util/FileUtils.java
@@ -28,12 +28,12 @@ import java.util.List;
 public class FileUtils {
 
     /**
-     * Scans a set of directories
+     * Scans a set of directories.
      *
-     * @param roots    Directories to scan
-     * @param includes
-     * @param excludes
-     * @return
+     * @param roots    Directories to scan.
+     * @param includes Patterns to include.
+     * @param excludes Patterns to exclude.
+     * @return A list of files found.
      */
     public static List<File> scan(List<String> roots, String[] includes, String[] excludes) {
         List<File> files = new ArrayList<>();
@@ -44,12 +44,12 @@ public class FileUtils {
     }
 
     /**
-     * Scans a single directory
+     * Scans a single directory.
      *
-     * @param root     Directory to scan
-     * @param includes
-     * @param excludes
-     * @return
+     * @param root     Directory to scan.
+     * @param includes Patterns to include.
+     * @param excludes Patterns to exclude.
+     * @return A list of files found.
      */
     public static List<File> scan(File root, String[] includes, String[] excludes) {
         List<File> files = new ArrayList<>();

--- a/plugins/maven/src/main/java/org/evosuite/maven/util/HistoryChanges.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/util/HistoryChanges.java
@@ -28,23 +28,21 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * <p>
- * HistoryChanges class
- * <p>
- * <p>
- * On each execution of EvoSuite-Maven-Plugin this class checks which
- * files have changed since EvoSuite was invoked the last time
- * <p>
- * How? This class keeps a file with the following format
- * __absolute_file_path__ \t __md5_hash__
- * <p>
- * then, if a file has a different hash, i.e., has been changed, another
+ * HistoryChanges class.
+ *
+ * <p>On each execution of EvoSuite-Maven-Plugin this class checks which
+ * files have changed since EvoSuite was invoked the last time.</p>
+ *
+ * <p>How? This class keeps a file with the following format
+ * __absolute_file_path__ \t __md5_hash__</p>
+ *
+ * <p>then, if a file has a different hash, i.e., has been changed, another
  * file called 'history_file' is keep with the following format
- * (Added)A/(Modified)M \t __absolute_file_path__
- * <p>
- * therefore, when EvoSuite-Maven-Plugin is executed with HistorySchedule
+ * (Added)A/(Modified)M \t __absolute_file_path__</p>
+ *
+ * <p>therefore, when EvoSuite-Maven-Plugin is executed with HistorySchedule
  * enabled, the 'history_file' will be used to identify which files have
- * added/modified and perform the schedule.
+ * added/modified and perform the schedule.</p>
  *
  * @author José Campos
  */
@@ -52,80 +50,83 @@ public class HistoryChanges {
 
     public static void keepTrack(String basedir, List<File> files) throws Exception {
 
-        File dot_evosuite = new File(basedir + File.separator + Properties.CTG_DIR);
-        if (!dot_evosuite.exists()) {
-            if (!dot_evosuite.mkdir()) {
-                throw new Exception("No permission to create the directory '" + basedir + File.separator + Properties.CTG_DIR + "'");
+        File dotEvoSuite = new File(basedir + File.separator + Properties.CTG_DIR);
+        if (!dotEvoSuite.exists()) {
+            if (!dotEvoSuite.mkdir()) {
+                throw new Exception("No permission to create the directory '"
+                        + basedir + File.separator + Properties.CTG_DIR + "'");
             }
         }
 
-        File hash_file = new File(basedir + File.separator + Properties.CTG_DIR + File.separator + "hash_file");
-        File history_file = new File(basedir + File.separator + Properties.CTG_DIR + File.separator + "history_file");
+        File hashFile = new File(basedir + File.separator + Properties.CTG_DIR + File.separator + "hash_file");
+        File historyFile = new File(basedir + File.separator + Properties.CTG_DIR + File.separator + "history_file");
 
-        if (!hash_file.exists()) {
+        if (!hashFile.exists()) {
             try {
                 // create the hash_file <Path, Hash>
-                if (!hash_file.createNewFile()) {
-                    throw new Exception("No permission to create the file '" + basedir + File.separator + Properties.CTG_DIR + File.separator + "hash_file" + "'");
+                if (!hashFile.createNewFile()) {
+                    throw new Exception("No permission to create the file '" + basedir + File.separator
+                            + Properties.CTG_DIR + File.separator + "hash_file" + "'");
                 }
                 // and the history_file as well
-                if (!history_file.createNewFile()) {
-                    throw new Exception("No permission to create the file '" + basedir + File.separator + Properties.CTG_DIR + File.separator + "history_file" + "'");
+                if (!historyFile.createNewFile()) {
+                    throw new Exception("No permission to create the file '" + basedir + File.separator
+                            + Properties.CTG_DIR + File.separator + "history_file" + "'");
                 }
 
-                FileWriter hash_file_fw = new FileWriter(hash_file.getAbsoluteFile());
-                BufferedWriter hash_file_bw = new BufferedWriter(hash_file_fw);
-                FileWriter history_file_fw = new FileWriter(history_file.getAbsoluteFile());
-                BufferedWriter history_file_bw = new BufferedWriter(history_file_fw);
+                FileWriter hashFileFw = new FileWriter(hashFile.getAbsoluteFile());
+                BufferedWriter hashFileBw = new BufferedWriter(hashFileFw);
+                FileWriter historyFileFw = new FileWriter(historyFile.getAbsoluteFile());
+                BufferedWriter historyFileBw = new BufferedWriter(historyFileFw);
 
                 // add content to hash_file and to history_file
                 for (File file : files) {
-                    hash_file_bw.write(file.getAbsolutePath() + "\t" + MD5.hash(file) + "\n");
-                    history_file_bw.write("A" + "\t" + file.getAbsolutePath() + "\n");
+                    hashFileBw.write(file.getAbsolutePath() + "\t" + MD5.hash(file) + "\n");
+                    historyFileBw.write("A" + "\t" + file.getAbsolutePath() + "\n");
                 }
 
-                hash_file_bw.close();
-                history_file_bw.close();
+                hashFileBw.close();
+                historyFileBw.close();
             } catch (IOException e) {
                 throw new Exception("IOException: ", e);
             }
         } else {
             // read content of hash_file
-            Map<String, String> hash_file_content = new LinkedHashMap<>();
+            Map<String, String> hashFileContent = new LinkedHashMap<>();
 
-            try (BufferedReader br = new BufferedReader(new FileReader(hash_file))) {
-                String sCurrentLine;
-                while ((sCurrentLine = br.readLine()) != null) {
-                    String[] split = sCurrentLine.split("\t");
-                    hash_file_content.put(split[0], split[1]);
+            try (BufferedReader br = new BufferedReader(new FileReader(hashFile))) {
+                String currentLine;
+                while ((currentLine = br.readLine()) != null) {
+                    String[] split = currentLine.split("\t");
+                    hashFileContent.put(split[0], split[1]);
                 }
             } catch (IOException e) {
                 throw new Exception("reading the content of hash_file ", e);
             }
 
             try {
-                FileWriter hash_file_fw = new FileWriter(hash_file.getAbsoluteFile());
-                BufferedWriter hash_file_bw = new BufferedWriter(hash_file_fw);
-                hash_file_bw.write(""); // clean file
+                FileWriter hashFileFw = new FileWriter(hashFile.getAbsoluteFile());
+                BufferedWriter hashFileBw = new BufferedWriter(hashFileFw);
+                hashFileBw.write(""); // clean file
 
-                FileWriter history_file_fw = new FileWriter(history_file.getAbsoluteFile());
-                BufferedWriter history_file_bw = new BufferedWriter(history_file_fw);
-                history_file_bw.write(""); // clean file
+                FileWriter historyFileFw = new FileWriter(historyFile.getAbsoluteFile());
+                BufferedWriter historyFileBw = new BufferedWriter(historyFileFw);
+                historyFileBw.write(""); // clean file
 
                 // compare each hash
                 for (File file : files) {
                     String hash = MD5.hash(file);
-                    hash_file_bw.write(file.getAbsolutePath() + "\t" + hash + "\n");
+                    hashFileBw.write(file.getAbsolutePath() + "\t" + hash + "\n");
 
-                    if (!hash_file_content.containsKey(file.getAbsolutePath())) {
-                        history_file_bw.write("A" + "\t" + file.getAbsolutePath() + "\n");
-                    } else if (!hash_file_content.get(file.getAbsolutePath()).equals(hash)) {
-                        history_file_bw.write("M" + "\t" + file.getAbsolutePath() + "\n");
+                    if (!hashFileContent.containsKey(file.getAbsolutePath())) {
+                        historyFileBw.write("A" + "\t" + file.getAbsolutePath() + "\n");
+                    } else if (!hashFileContent.get(file.getAbsolutePath()).equals(hash)) {
+                        historyFileBw.write("M" + "\t" + file.getAbsolutePath() + "\n");
                     }
                 }
 
-                hash_file_bw.close();
-                history_file_bw.close();
+                hashFileBw.close();
+                historyFileBw.close();
             } catch (IOException e) {
                 throw new Exception("IOException: ", e);
             }

--- a/plugins/maven/src/main/java/org/evosuite/maven/util/ProjectUtils.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/util/ProjectUtils.java
@@ -29,15 +29,17 @@ import java.util.Collection;
 import java.util.List;
 
 /**
+ * Utility class to interact with MavenProject.
+ *
  * @author José Campos
  */
 public class ProjectUtils {
 
     /**
-     * Get compile elements (i.e., classes under /target/classes)
+     * Get compile elements (i.e., classes under /target/classes).
      *
-     * @param project
-     * @return
+     * @param project The maven project.
+     * @return List of compile classpath elements.
      */
     public static List<String> getCompileClasspathElements(MavenProject project) {
         List<String> compileClassPath = new ArrayList<>();
@@ -58,10 +60,10 @@ public class ProjectUtils {
 
     /**
      * Get JUnit elements (i.e., classes under /target/test-classes) and compiled
-     * elements (i.e., classes under /target/classes)
+     * elements (i.e., classes under /target/classes).
      *
-     * @param project
-     * @return
+     * @param project The maven project.
+     * @return List of test classpath elements.
      */
     public static List<String> getTestClasspathElements(MavenProject project) {
         List<String> testClassPath = new ArrayList<>();
@@ -81,10 +83,10 @@ public class ProjectUtils {
     }
 
     /**
-     * Get runtime elements
+     * Get runtime elements.
      *
-     * @param project
-     * @return
+     * @param project The maven project.
+     * @return List of runtime classpath elements.
      */
     public static List<String> getRuntimeClasspathElements(MavenProject project) {
         List<String> runtimeClassPath = new ArrayList<>();
@@ -102,10 +104,10 @@ public class ProjectUtils {
     }
 
     /**
-     * Get project's dependencies
+     * Get project's dependencies.
      *
-     * @param project
-     * @return
+     * @param project The maven project.
+     * @return List of dependency path elements.
      */
     public static List<String> getDependencyPathElements(MavenProject project) {
         List<String> dependencyArtifacts = new ArrayList<>();
@@ -125,10 +127,10 @@ public class ProjectUtils {
 
     /**
      * Convert a list of strings to a single string separated
-     * by File.pathSeparator (i.e., ':')
+     * by File.pathSeparator (i.e., ':').
      *
-     * @param elements
-     * @return
+     * @param elements The elements to join.
+     * @return The classpath string.
      */
     public static String toClasspathString(Collection<String> elements) {
         final StringBuilder str = new StringBuilder();


### PR DESCRIPTION
Applied checkstyle fixes to `org.evosuite.maven` package in `plugins/maven`.
Fixed issues including:
- Naming conventions (camelCase)
- Javadoc formatting (periods, paragraph tags)
- Missing Javadoc descriptions
- Line length limits
- File tab characters
- Newline at end of file

Verified with `mvn checkstyle:check -pl plugins/maven` and `mvn clean install -pl plugins/maven`.

---
*PR created automatically by Jules for task [17711291875949989061](https://jules.google.com/task/17711291875949989061) started by @gofraser*