### PR TITLE
Apply checkstyle fixes to org.evosuite.junit package

### DIFF
--- a/client/src/main/java/org/evosuite/junit/CoverageReportGenerator.java
+++ b/client/src/main/java/org/evosuite/junit/CoverageReportGenerator.java
@@ -32,6 +32,12 @@ import java.io.File;
  */
 public class CoverageReportGenerator {
 
+    /**
+     * Writes the coverage matrix to a file for the specified criterion.
+     *
+     * @param coverage the coverage matrix
+     * @param criterion the coverage criterion
+     */
     public static void writeCoverage(boolean[][] coverage, Properties.Criterion criterion) {
 
         StringBuilder suite = new StringBuilder();

--- a/client/src/main/java/org/evosuite/junit/DetermineSUT.java
+++ b/client/src/main/java/org/evosuite/junit/DetermineSUT.java
@@ -71,6 +71,14 @@ public class DetermineSUT {
         }
     }
 
+    /**
+     * Determines the name of the System Under Test (SUT) from the given target class and classpath.
+     *
+     * @param fullyQualifiedTargetClass the fully qualified name of the target class
+     * @param targetClassPath the classpath where the target class is located
+     * @return the name of the SUT
+     * @throws NoJUnitClassException if no JUnit class is found
+     */
     public String getSUTName(String fullyQualifiedTargetClass, String targetClassPath)
             throws NoJUnitClassException {
         this.targetName = fullyQualifiedTargetClass;
@@ -111,6 +119,15 @@ public class DetermineSUT {
         return sortedNames.get(0);
     }
 
+    /**
+     * Identifies classes called by the target class to find potential SUT candidates.
+     *
+     * @param fullyQualifiedTargetClass the fully qualified name of the target class
+     * @param targetClasses a set of potential target classes
+     * @return a set of called classes
+     * @throws ClassNotFoundException if a class cannot be found
+     * @throws NoJUnitClassException if no JUnit class is found
+     */
     public Set<String> determineCalledClasses(String fullyQualifiedTargetClass,
                                               Set<String> targetClasses) throws ClassNotFoundException,
             NoJUnitClassException {

--- a/client/src/main/java/org/evosuite/junit/JUnitFailure.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitFailure.java
@@ -30,6 +30,15 @@ import java.util.List;
  */
 public class JUnitFailure {
 
+    /**
+     * Initializes a JUnitFailure with the provided failure details.
+     *
+     * @param message failure message
+     * @param exceptionClassName name of the exception class
+     * @param descriptionMethodName name of the method description
+     * @param isAssertionError true if the failure is an assertion error
+     * @param trace stack trace of the failure
+     */
     public JUnitFailure(String message, String exceptionClassName,
                         String descriptionMethodName, boolean isAssertionError, String trace) {
         super();

--- a/client/src/main/java/org/evosuite/junit/JUnitResult.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitResult.java
@@ -60,6 +60,11 @@ public class JUnitResult {
     private Class<?> junitClass;
 
 
+    /**
+     * Initializes a new JUnitResult with the given name.
+     *
+     * @param name the name of the test
+     */
     public JUnitResult(String name) {
         this.successful = true;
         this.name = name;
@@ -68,6 +73,12 @@ public class JUnitResult {
     }
 
 
+    /**
+     * Initializes a new JUnitResult with the given name and JUnit class.
+     *
+     * @param name the name of the test
+     * @param junitClass the JUnit class
+     */
     public JUnitResult(String name, Class<?> junitClass) {
         this.successful = true;
         this.name = name;

--- a/client/src/main/java/org/evosuite/junit/JUnitResultBuilder.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitResultBuilder.java
@@ -81,6 +81,12 @@ public class JUnitResultBuilder {
         return junitResult;
     }
 
+    /**
+     * Builds a JUnitResult from a list of test execution results.
+     *
+     * @param results list of pairs containing test identifiers and execution results
+     * @return the built JUnitResult
+     */
     public JUnitResult build(List<Pair<TestIdentifier, TestExecutionResult>> results) {
         boolean wasSuccessful = results.stream().map(Pair::getRight)
                 .noneMatch(r -> r.getStatus() != TestExecutionResult.Status.SUCCESSFUL);

--- a/client/src/main/java/org/evosuite/junit/JUnitRunner.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitRunner.java
@@ -57,6 +57,9 @@ public class JUnitRunner {
         this.junitClass = junitClass;
     }
 
+    /**
+     * Executes the JUnit tests using the configured test format (JUnit 4 or 5).
+     */
     public void run() {
 
         if (Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT4) {

--- a/client/src/main/java/org/evosuite/junit/naming/methods/CoverageGoalTestNameGenerationStrategy.java
+++ b/client/src/main/java/org/evosuite/junit/naming/methods/CoverageGoalTestNameGenerationStrategy.java
@@ -84,6 +84,12 @@ public class CoverageGoalTestNameGenerationStrategy implements TestNameGeneratio
 
     public static final int MAX_CHARS = 70;
 
+    /**
+     * Initializes the strategy with test cases and execution results to generate goal-based test names.
+     *
+     * @param testCases list of test cases
+     * @param results list of execution results
+     */
     public CoverageGoalTestNameGenerationStrategy(List<TestCase> testCases, List<ExecutionResult> results) {
         addGoalsNotIncludedInTargetCriteria(results);
         Map<TestCase, Set<TestFitnessFunction>> testToGoals = initializeCoverageMapFromResults(results);

--- a/client/src/main/java/org/evosuite/junit/rules/StaticStateResetter.java
+++ b/client/src/main/java/org/evosuite/junit/rules/StaticStateResetter.java
@@ -30,6 +30,11 @@ public class StaticStateResetter extends BaseRule {
 
     private final String[] classNames;
 
+    /**
+     * Initializes the StaticStateResetter with the specified classes to reset.
+     *
+     * @param classesToReset the classes to reset
+     */
     public StaticStateResetter(String... classesToReset) {
         classNames = Arrays.copyOf(classesToReset, classesToReset.length);
         org.evosuite.Properties.RESET_STATIC_FIELDS = true;

--- a/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
+++ b/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
@@ -129,6 +129,13 @@ public class Scaffolding {
         return builder.toString();
     }
 
+    /**
+     * Generates the scaffolding file name for the given test name.
+     *
+     * @param testName the name of the test
+     * @return the name of the scaffolding file
+     * @throws IllegalArgumentException if the test name is null or empty
+     */
     public static String getFileName(String testName) throws IllegalArgumentException {
         if (testName == null || testName.trim().isEmpty()) {
             throw new IllegalArgumentException("Empty test name");

--- a/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriterUtils.java
+++ b/client/src/main/java/org/evosuite/junit/writer/TestSuiteWriterUtils.java
@@ -67,6 +67,12 @@ public class TestSuiteWriterUtils {
     }
 
 
+    /**
+     * Checks if the execution results indicate the use of mocks.
+     *
+     * @param results list of execution results
+     * @return true if mocks are used
+     */
     public static boolean doesUseMocks(List<ExecutionResult> results) {
         for (ExecutionResult er : results) {
             for (Statement st : er.test) {
@@ -78,6 +84,12 @@ public class TestSuiteWriterUtils {
         return false;
     }
 
+    /**
+     * Checks if any of the execution results encountered a security exception.
+     *
+     * @param results list of execution results
+     * @return true if any security exception occurred
+     */
     public static boolean hasAnySecurityException(List<ExecutionResult> results) {
         for (ExecutionResult result : results) {
             if (result.hasSecurityException()) {
@@ -96,6 +108,13 @@ public class TestSuiteWriterUtils {
         return false;
     }
 
+    /**
+     * Determines the name of a test case based on its position or carved name.
+     *
+     * @param tests list of test cases
+     * @param position position of the test in the list
+     * @return the name of the test
+     */
     public static String getNameOfTest(List<TestCase> tests, int position) {
 
         TestCase test = tests.get(position);
@@ -112,6 +131,12 @@ public class TestSuiteWriterUtils {
         return testName;
     }
 
+    /**
+     * Merges properties read during execution from all results.
+     *
+     * @param results list of execution results
+     * @return a set of merged properties
+     */
     public static Set<String> mergeProperties(List<ExecutionResult> results) {
         if (results == null) {
             return null;
@@ -126,6 +151,12 @@ public class TestSuiteWriterUtils {
         return set;
     }
 
+    /**
+     * Determines if system properties should be reset based on execution results.
+     *
+     * @param results list of execution results
+     * @return true if properties should be reset
+     */
     public static boolean shouldResetProperties(List<ExecutionResult> results) {
         /*
          * Note: we need to reset the properties even if the SUT only read them. Reason is
@@ -160,6 +191,11 @@ public class TestSuiteWriterUtils {
         return dirname;
     }
 
+    /**
+     * Retrieves the appropriate unit test adapter based on the configured output format.
+     *
+     * @return the unit test adapter
+     */
     public static UnitTestAdapter getAdapter() {
         if (Properties.TEST_FORMAT == OutputFormat.JUNIT3) {
             return new JUnit3TestAdapter();


### PR DESCRIPTION
Applied checkstyle fixes to the `org.evosuite.junit` package in the `client` module. Added meaningful Javadoc comments to various methods and constructors to resolve `MissingJavadocMethod` violations. Verified that the code compiles and relevant tests pass.

---
*PR created automatically by Jules for task [2494712967872559851](https://jules.google.com/task/2494712967872559851) started by @gofraser*