### PR TITLE
Apply Checkstyle fixes to org.evosuite.result package

### DIFF
--- a/client/src/main/java/org/evosuite/result/BranchInfo.java
+++ b/client/src/main/java/org/evosuite/result/BranchInfo.java
@@ -35,6 +35,12 @@ public class BranchInfo implements Serializable {
 
     private final boolean truthValue;
 
+    /**
+     * Creates a new BranchInfo instance from the given Branch object and truth value.
+     *
+     * @param branch     the branch to create info for
+     * @param truthValue the truth value of the branch execution
+     */
     public BranchInfo(Branch branch, boolean truthValue) {
         this.className = branch.getClassName();
         this.methodName = branch.getMethodName();
@@ -42,6 +48,14 @@ public class BranchInfo implements Serializable {
         this.truthValue = truthValue;
     }
 
+    /**
+     * Creates a new BranchInfo instance with the specified class name, method name, line number, and truth value.
+     *
+     * @param className  the name of the class containing the branch
+     * @param methodName the name of the method containing the branch
+     * @param lineNo     the line number of the branch instruction
+     * @param truthValue the truth value of the branch execution
+     */
     public BranchInfo(String className, String methodName, int lineNo,
                       boolean truthValue) {
         this.className = className;

--- a/client/src/main/java/org/evosuite/result/Failure.java
+++ b/client/src/main/java/org/evosuite/result/Failure.java
@@ -45,12 +45,25 @@ public class Failure implements Serializable {
 
     private final int lineNo;
 
+    /**
+     * Creates a new Failure instance from a contract violation.
+     *
+     * @param violation the contract violation to create the failure from
+     */
     public Failure(ContractViolation violation) {
         this.className = Properties.TARGET_CLASS;
         this.lineNo = violation.getPosition();
         initializeFromContractViolation(violation);
     }
 
+    /**
+     * Creates a new Failure instance from a throwable exception, its position in the test case, and the test case
+     * itself.
+     *
+     * @param t        the throwable that caused the failure
+     * @param position the position in the test case where the failure occurred
+     * @param test     the test case in which the failure occurred
+     */
     public Failure(Throwable t, int position, TestCase test) {
         this.className = Properties.TARGET_CLASS;
         this.methodName = getMethodName(test, position);

--- a/client/src/main/java/org/evosuite/result/MutationInfo.java
+++ b/client/src/main/java/org/evosuite/result/MutationInfo.java
@@ -35,6 +35,11 @@ public class MutationInfo implements Serializable {
 
     private final String replacement;
 
+    /**
+     * Creates a new MutationInfo instance from the given Mutation object.
+     *
+     * @param m the mutation to create info for
+     */
     public MutationInfo(Mutation m) {
         this.className = m.getClassName();
         this.methodName = m.getMethodName();
@@ -42,6 +47,15 @@ public class MutationInfo implements Serializable {
         this.replacement = m.getDescription();
     }
 
+    /**
+     * Creates a new MutationInfo instance with the specified class name, method name, line number, and replacement
+     * description.
+     *
+     * @param className   the name of the class containing the mutation
+     * @param methodName  the name of the method containing the mutation
+     * @param lineNo      the line number of the mutation
+     * @param replacement the description of the mutation replacement
+     */
     public MutationInfo(String className, String methodName, int lineNo,
                         String replacement) {
         this.className = className;

--- a/client/src/main/java/org/evosuite/result/TestGenerationResultBuilder.java
+++ b/client/src/main/java/org/evosuite/result/TestGenerationResultBuilder.java
@@ -46,6 +46,13 @@ import java.util.Set;
 
 public class TestGenerationResultBuilder {
 
+    /**
+     * Builds a test generation result indicating an error.
+     *
+     * @param errorMessage the error message describing the failure
+     * @param <T>          the type of chromosome
+     * @return the test generation result with error status
+     */
     public static <T extends Chromosome<T>> TestGenerationResult<T> buildErrorResult(String errorMessage) {
         TestGenerationResultImpl<T> result = new TestGenerationResultImpl<T>();
         result.setStatus(Status.ERROR);
@@ -56,6 +63,12 @@ public class TestGenerationResultBuilder {
         return result;
     }
 
+    /**
+     * Builds a test generation result indicating a timeout.
+     *
+     * @param <T> the type of chromosome
+     * @return the test generation result with timeout status
+     */
     public static <T extends Chromosome<T>> TestGenerationResult<T> buildTimeoutResult() {
         TestGenerationResultImpl<T> result = new TestGenerationResultImpl<T>();
         result.setStatus(Status.TIMEOUT);
@@ -65,6 +78,12 @@ public class TestGenerationResultBuilder {
         return result;
     }
 
+    /**
+     * Builds a test generation result indicating success.
+     *
+     * @param <T> the type of chromosome
+     * @return the test generation result with success status
+     */
     public static <T extends Chromosome<T>> TestGenerationResult<T> buildSuccessResult() {
         TestGenerationResultImpl<T> result = new TestGenerationResultImpl<>();
         result.setStatus(Status.SUCCESS);
@@ -80,6 +99,11 @@ public class TestGenerationResultBuilder {
         resetTestData();
     }
 
+    /**
+     * Returns the singleton instance of the TestGenerationResultBuilder.
+     *
+     * @return the singleton instance
+     */
     public static TestGenerationResultBuilder getInstance() {
         if (instance == null) {
             instance = new TestGenerationResultBuilder();
@@ -179,6 +203,15 @@ public class TestGenerationResultBuilder {
 
     private final LinkedHashMap<FitnessFunction<?>, Double> targetCoverages = new LinkedHashMap<>();
 
+    /**
+     * Sets the test case information for a specific test method.
+     *
+     * @param name     the name of the test method
+     * @param code     the source code of the test method
+     * @param testCase the EvoSuite test case object
+     * @param comment  any comments associated with the test
+     * @param result   the execution result of the test case
+     */
     public void setTestCase(String name, String code, TestCase testCase, String comment, ExecutionResult result) {
         testCode.put(name, code);
         testCases.put(name, testCase);
@@ -233,10 +266,20 @@ public class TestGenerationResultBuilder {
         uncoveredMutants.removeAll(mutationCoverage);
     }
 
+    /**
+     * Sets the source code of the entire test suite.
+     *
+     * @param code the test suite source code
+     */
     public void setTestSuiteCode(String code) {
         this.code = code;
     }
 
+    /**
+     * Sets the genetic algorithm instance used during test generation.
+     *
+     * @param ga the genetic algorithm instance
+     */
     public void setGeneticAlgorithm(GeneticAlgorithm<?> ga) {
         this.ga = ga;
         // Only gather coverage values if the population has been initialized.
@@ -247,6 +290,11 @@ public class TestGenerationResultBuilder {
         }
     }
 
+    /**
+     * Sets the DSE algorithm instance used during test generation.
+     *
+     * @param dse the DSE algorithm instance
+     */
     public void setDSEAlgorithm(ExplorationAlgorithmBase dse) {
         this.dse = dse;
         for (Map.Entry<FitnessFunction<TestSuiteChromosome>, Double> e : dse.getGeneratedTestSuite()


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.result` package in the `client` module. Specifically, added meaningful Javadoc comments to public constructors and methods in `BranchInfo.java`, `Failure.java`, `MutationInfo.java`, and `TestGenerationResultBuilder.java`. Verified that `mvn checkstyle:check` reports zero violations for the package and that the module compiles successfully. No methods were renamed and no non-Java files are included.

---
*PR created automatically by Jules for task [14229595311565503588](https://jules.google.com/task/14229595311565503588) started by @gofraser*