### PR TITLE
Apply Checkstyle fixes to org.evosuite.classpath package

### DIFF
--- a/client/src/main/java/org/evosuite/classpath/ClassPathHacker.java
+++ b/client/src/main/java/org/evosuite/classpath/ClassPathHacker.java
@@ -80,10 +80,20 @@ public class ClassPathHacker {
         }
     }
 
+    /**
+     * Gets the cause of failure if tool initialization failed.
+     *
+     * @return the cause message
+     */
     public static String getCause() {
         return cause;
     }
 
+    /**
+     * True if JUnit check is available.
+     *
+     * @return true if available, false otherwise
+     */
     public static boolean isJunitCheckAvailable() {
         return junitCheckAvailable;
     }
@@ -135,10 +145,22 @@ public class ClassPathHacker {
     }
 
 
+    /**
+     * Sets up the continuous class loader with the given classpath.
+     *
+     * @param cp the classpath string
+     * @throws IOException if an I/O error occurs
+     */
     public static void setupContinuousClassLoader(String cp) throws IOException {
         setupContinuousClassLoader(cp.split(File.pathSeparator));
     }
 
+    /**
+     * Sets up the continuous class loader with the given classpath entries.
+     *
+     * @param cpEntries the classpath entries
+     * @throws IOException if an I/O error occurs
+     */
     public static void setupContinuousClassLoader(String[] cpEntries) throws IOException {
         List<URL> list = new ArrayList<>();
         for (String cpEntry : cpEntries) {
@@ -169,7 +191,9 @@ public class ClassPathHacker {
     }
 
     /**
-     * get a classLoader that can load the cuts for continuous integration.
+     * Gets a classLoader that can load the cuts for continuous integration.
+     *
+     * @return the continuous class loader
      */
     public static ClassLoader getContinuousClassLoader() {
         return continuousClassLoader != null ? continuousClassLoader : Thread.currentThread().getContextClassLoader();

--- a/client/src/main/java/org/evosuite/classpath/ClassPathHandler.java
+++ b/client/src/main/java/org/evosuite/classpath/ClassPathHandler.java
@@ -73,6 +73,11 @@ public class ClassPathHandler {
         getInstance().evosuiteClassPath = null;
     }
 
+    /**
+     * Gets the EvoSuite classpath.
+     *
+     * @return the EvoSuite classpath
+     */
     public String getEvoSuiteClassPath() {
         if (evosuiteClassPath == null) {
             evosuiteClassPath = System.getProperty("java.class.path");
@@ -155,6 +160,12 @@ public class ClassPathHandler {
         return targetClassPath;
     }
 
+    /**
+     * Writes the given classpath to a temporary file.
+     *
+     * @param classpath the classpath string to write
+     * @return the absolute path of the temporary file
+     */
     public static String writeClasspathToFile(String classpath) {
 
         try {
@@ -227,8 +238,10 @@ public class ClassPathHandler {
     }
 
     /**
-     * This is meant only for running the EvoSuite test cases, whose CUTs will be in the
-     * classpath of EvoSuite itself.
+     * Changes the target classpath to match the EvoSuite classpath.
+     *
+     * <p>This is meant only for running the EvoSuite test cases, whose CUTs will be in the
+     * classpath of EvoSuite itself.</p>
      */
     public void changeTargetCPtoTheSameAsEvoSuite() {
 

--- a/client/src/main/java/org/evosuite/classpath/ResourceList.java
+++ b/client/src/main/java/org/evosuite/classpath/ResourceList.java
@@ -143,6 +143,9 @@ public class ResourceList {
     // --------- public methods  -----------------
     // -------------------------------------------
 
+    /**
+     * Resets the cache.
+     */
     public synchronized void resetCache() {
         if (cache != null) {
             cache.close();
@@ -150,6 +153,9 @@ public class ResourceList {
         cache = null;
     }
 
+    /**
+     * Clears all caches.
+     */
     public static void resetAllCaches() {
         instanceMap.clear();
     }
@@ -321,6 +327,13 @@ public class ResourceList {
         }
     }
 
+    /**
+     * True if the given resource is an interface.
+     *
+     * @param resource the resource path
+     * @return true if the resource is an interface, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
     public static boolean isInterface(String resource) throws IOException {
         try (InputStream input = ResourceList.class.getClassLoader().getResourceAsStream(resource)) {
             if (input == null) {
@@ -330,6 +343,13 @@ public class ResourceList {
         }
     }
 
+    /**
+     * True if the given class name corresponds to an interface.
+     *
+     * @param className the fully qualified class name
+     * @return true if the class is an interface, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
     public boolean isClassAnInterface(String className) throws IOException {
         try (InputStream input = getClassAsStream(className)) {
             if (input == null) {
@@ -339,6 +359,13 @@ public class ResourceList {
         }
     }
 
+    /**
+     * True if the given class is deprecated.
+     *
+     * @param className the fully qualified class name
+     * @return true if the class is deprecated, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
     public boolean isClassDeprecated(String className) throws IOException {
         try (InputStream input = getClassAsStream(className)) {
             if (input == null) {
@@ -348,6 +375,13 @@ public class ResourceList {
         }
     }
 
+    /**
+     * True if the given class is testable.
+     *
+     * @param className the fully qualified class name
+     * @return true if the class is testable, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
     public boolean isClassTestable(String className) throws IOException {
         try (InputStream input = getClassAsStream(className)) {
             if (input == null) {
@@ -433,7 +467,7 @@ public class ResourceList {
     }
 
     /**
-     * Remove last '.' token.
+     * Gets the parent package name of the given class.
      *
      * @param className the class name
      * @return the parent package name


### PR DESCRIPTION
Applied Checkstyle fixes to `org.evosuite.classpath` package by adding meaningful Javadoc comments to public methods in `ResourceList.java`, `ClassPathHandler.java`, and `ClassPathHacker.java`. Verified that Checkstyle now passes with 0 violations and relevant tests pass.

---
*PR created automatically by Jules for task [1231958858589770654](https://jules.google.com/task/1231958858589770654) started by @gofraser*