### PR TITLE
Fix Checkstyle violations in org.evosuite.contracts package

### DIFF
--- a/client/src/main/java/org/evosuite/contracts/ContractViolation.java
+++ b/client/src/main/java/org/evosuite/contracts/ContractViolation.java
@@ -112,10 +112,21 @@ public class ContractViolation {
         return statement.getPosition();
     }
 
+    /**
+     * Gets the exception associated with the violation.
+     *
+     * @return a {@link java.lang.Throwable} object, or null if no exception occurred.
+     */
     public Throwable getException() {
         return exception;
     }
 
+    /**
+     * Checks if the violation exception is of the specified type.
+     *
+     * @param throwableClass a {@link java.lang.Class} of the throwable to check against.
+     * @return true if the exception matches the given type.
+     */
     public boolean isExceptionOfType(Class<?> throwableClass) {
         if (exception == null) {
             return false;
@@ -128,6 +139,12 @@ public class ContractViolation {
         }
     }
 
+    /**
+     * Checks if the violation resulted from a specific method call or constructor.
+     *
+     * @param methodName the name of the method to check against.
+     * @return true if the violation resulted from the specified method.
+     */
     public boolean resultsFromMethod(String methodName) {
         if (statement instanceof MethodStatement) {
             MethodStatement ms = (MethodStatement) statement;
@@ -262,6 +279,11 @@ public class ContractViolation {
                 + " with exception " + exception;
     }
 
+    /**
+     * Updates the class loader for the test case and contract involved in the violation.
+     *
+     * @param classLoader the new {@link java.lang.ClassLoader} to use.
+     */
     public void changeClassLoader(ClassLoader classLoader) {
         ((DefaultTestCase) test).changeClassLoader(classLoader);
         contract.changeClassLoader(classLoader);

--- a/client/src/main/java/org/evosuite/contracts/FailingTestSet.java
+++ b/client/src/main/java/org/evosuite/contracts/FailingTestSet.java
@@ -56,6 +56,11 @@ public class FailingTestSet {
 
     private static int violationCount = 0;
 
+    /**
+     * Adds a failing test to the set of violations.
+     *
+     * @param violation a {@link org.evosuite.contracts.ContractViolation} object.
+     */
     public static void addFailingTest(ContractViolation violation) {
         violationCount++;
         if (!hasViolation(violation)) {
@@ -117,6 +122,11 @@ public class FailingTestSet {
         return Collections.unmodifiableCollection(violations);
     }
 
+    /**
+     * Gets the list of failing test cases derived from the violations.
+     *
+     * @return a {@link java.util.List} of {@link org.evosuite.testcase.TestCase} objects.
+     */
     public static List<TestCase> getFailingTests() {
         List<TestCase> tests = new ArrayList<>();
         ContractChecker.setActive(false);
@@ -181,17 +191,28 @@ public class FailingTestSet {
         return false;
     }
 
+    /**
+     * Updates the class loader for all stored violations.
+     *
+     * @param classLoader the new {@link java.lang.ClassLoader} to use.
+     */
     public static void changeClassLoader(ClassLoader classLoader) {
         for (ContractViolation violation : violations) {
             violation.changeClassLoader(classLoader);
         }
     }
 
+    /**
+     * Clears all recorded violations and resets the count.
+     */
     public static void clear() {
         violations.clear();
         violationCount = 0;
     }
 
+    /**
+     * Sends the statistics of contract violations to the client node.
+     */
     public static void sendStatistics() {
         if (!Properties.NEW_STATISTICS) {
             return;

--- a/client/src/main/java/org/evosuite/contracts/JUnitTheoryContract.java
+++ b/client/src/main/java/org/evosuite/contracts/JUnitTheoryContract.java
@@ -40,6 +40,13 @@ public class JUnitTheoryContract extends Contract {
 
     private Object theoryReceiver;
 
+    /**
+     * Creates a new JUnitTheoryContract.
+     *
+     * @param theoryMethod a {@link org.evosuite.utils.generic.GenericMethod} object.
+     * @throws java.lang.InstantiationException if the declaring class cannot be instantiated.
+     * @throws java.lang.IllegalAccessException if the declaring class or constructor is not accessible.
+     */
     public JUnitTheoryContract(GenericMethod theoryMethod) throws InstantiationException, IllegalAccessException {
         this.theoryMethod = theoryMethod;
         this.theoryReceiver = theoryMethod.getDeclaringClass().newInstance();


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.contracts` package in the `client` module. This involved adding meaningful Javadoc comments to public methods and constructors in `JUnitTheoryContract.java`, `FailingTestSet.java`, and `ContractViolation.java`. Verified that no other changes were made and ran `ContractGenerationSystemTest` to ensure no regressions.

---
*PR created automatically by Jules for task [16793329953743348537](https://jules.google.com/task/16793329953743348537) started by @gofraser*