### PR TITLE
Apply Checkstyle fixes to org.evosuite.utils.generic

### DIFF
--- a/client/src/main/java/org/evosuite/utils/generic/GenericAccessibleObject.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericAccessibleObject.java
@@ -467,6 +467,11 @@ public abstract class GenericAccessibleObject<T extends GenericAccessibleObject<
         }
     }
 
+    /**
+     * Sets the type parameters.
+     *
+     * @param parameterTypes the type parameters
+     */
     public void setTypeParameters(List<GenericClass<?>> parameterTypes) {
         typeVariables.clear();
         for (GenericClass<?> parameter : parameterTypes) {

--- a/client/src/main/java/org/evosuite/utils/generic/GenericArrayTypeImpl.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericArrayTypeImpl.java
@@ -32,6 +32,12 @@ public class GenericArrayTypeImpl implements GenericArrayType {
         return Array.newInstance(componentType, 0).getClass();
     }
 
+    /**
+     * Creates an array type with the given component type.
+     *
+     * @param componentType the component type
+     * @return the array type
+     */
     public static Type createArrayType(Type componentType) {
         if (componentType instanceof Class) {
             return createArrayType((Class<?>) componentType);

--- a/client/src/main/java/org/evosuite/utils/generic/GenericClassImpl.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericClassImpl.java
@@ -172,6 +172,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         this.rawClass = clazz;
     }
 
+    /**
+     * Copy constructor.
+     *
+     * @param copy the object to copy
+     */
     public GenericClassImpl(GenericClassImpl copy) {
         this.type = copy.type;
         this.rawClass = copy.rawClass;
@@ -397,6 +402,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         // return true;
     }
 
+    /**
+     * Returns the boxed type of this class.
+     *
+     * @return the boxed type
+     */
     public Class<?> getBoxedType() {
         if (isPrimitive()) {
             if (rawClass.equals(int.class)) {
@@ -435,6 +445,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return rawClass.getName();
     }
 
+    /**
+     * Returns the component class of this array class.
+     *
+     * @return the component class
+     */
     public GenericClass<?> getComponentClass() {
         if (type instanceof GenericArrayType) {
             GenericArrayType arrayType = (GenericArrayType) type;
@@ -468,6 +483,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return GenericTypeReflector.getArrayComponentType(type);
     }
 
+    /**
+     * Returns the generic bounds of this class.
+     *
+     * @return the generic bounds
+     */
     public Collection<GenericClass<?>> getGenericBounds() {
 
         Set<GenericClass<?>> bounds = new LinkedHashSet<>();
@@ -534,6 +554,15 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return getGenericInstantiation(typeMap, 0);
     }
 
+    /**
+     * Instantiate type variables using map, and anything not contained in the
+     * map randomly.
+     *
+     * @param typeMap        the type map
+     * @param recursionLevel the recursion level
+     * @return the generic class
+     * @throws ConstructionFailedException if construction fails
+     */
     public GenericClass<?> getGenericInstantiation(Map<TypeVariable<?>, Type> typeMap,
                                                    int recursionLevel)
             throws ConstructionFailedException {
@@ -672,12 +701,23 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return selectedClass.getGenericInstantiation(new HashMap<>(), recursionLevel + 1);
     }
 
+    /**
+     * Sets the type.
+     *
+     * @param type the type
+     * @return this
+     */
     @Override
     public GenericClass<?> setType(Type type) {
         this.type = type;
         return this;
     }
 
+    /**
+     * Returns the list of interfaces implemented by this class.
+     *
+     * @return the list of interfaces
+     */
     public List<GenericClass<?>> getInterfaces() {
         List<GenericClass<?>> ret = new ArrayList<>();
         for (Class<?> intf : rawClass.getInterfaces()) {
@@ -902,6 +942,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return name;
     }
 
+    /**
+     * Returns the super class of this class.
+     *
+     * @return the super class
+     */
     public GenericClassImpl getSuperClass() {
         Type superType = GenericTypeReflector.getExactSuperType(type, rawClass.getSuperclass());
         if (superType == null) {
@@ -934,6 +979,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
 
     private Map<TypeVariable<?>, Type> typeVariableMap = null;
 
+    /**
+     * Returns the type variable map.
+     *
+     * @return the type variable map
+     */
     public Map<TypeVariable<?>, Type> getTypeVariableMap() {
         if (typeVariableMap == null) {
             //logger.debug("Getting type variable map for " + type);
@@ -1009,6 +1059,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return typeVariables;
     }
 
+    /**
+     * Returns the unboxed type of this class.
+     *
+     * @return the unboxed type
+     */
     public Class<?> getUnboxedType() {
         if (isWrapperType()) {
             if (rawClass.equals(Integer.class)) {
@@ -1036,6 +1091,12 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return rawClass;
     }
 
+    /**
+     * Returns a new GenericClass with the given component class.
+     *
+     * @param componentClass the component class
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithComponentClass(GenericClass<?> componentClass) {
         if (type instanceof GenericArrayType) {
             return new GenericClassImpl(
@@ -1046,6 +1107,12 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         }
     }
 
+    /**
+     * Returns a new GenericClass with the given generic parameter types.
+     *
+     * @param parameters the generic parameter types
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithGenericParameterTypes(List<GenericClassImpl> parameters) {
         Type[] typeArray = new Type[parameters.size()];
         for (int i = 0; i < parameters.size(); i++) {
@@ -1059,6 +1126,12 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return new GenericClassImpl(new ParameterizedTypeImpl(rawClass, typeArray, ownerType));
     }
 
+    /**
+     * Returns a new GenericClass with the given owner type.
+     *
+     * @param ownerClass the owner class
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithOwnerType(GenericClass<?> ownerClass) {
         if (type instanceof ParameterizedType) {
             ParameterizedType currentType = (ParameterizedType) type;
@@ -1157,6 +1230,12 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return exactClass;
     }
 
+    /**
+     * Returns a new GenericClass with the given parameter types.
+     *
+     * @param parameters the parameter types
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithParameterTypes(List<Type> parameters) {
         Type[] typeArray = new Type[parameters.size()];
         for (int i = 0; i < parameters.size(); i++) {
@@ -1169,6 +1248,12 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return new GenericClassImpl(new ParameterizedTypeImpl(rawClass, typeArray, ownerType));
     }
 
+    /**
+     * Returns a new GenericClass with the given parameter types.
+     *
+     * @param parameters the parameter types
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithParameterTypes(Type[] parameters) {
         Type ownerType = null;
         if (type instanceof ParameterizedType) {
@@ -1178,6 +1263,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
                 new ParameterizedTypeImpl(rawClass, parameters, ownerType));
     }
 
+    /**
+     * Returns a new GenericClass with wildcard types.
+     *
+     * @return the new GenericClass
+     */
     public GenericClass<?> getWithWildcardTypes() {
         Type ownerType = GenericTypeReflector.addWildcardParameters(rawClass);
         return new GenericClassImpl(ownerType);
@@ -1198,20 +1288,20 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
     }
 
     /**
-     * Determine if this class is a subclass of superType.
+     * Checks if this class has the given generic super type.
      *
      * @param superType the super type
-     * @return boolean
+     * @return true if it has the super type
      */
     public boolean hasGenericSuperType(GenericClass superType) {
         return GenericTypeReflector.isSuperType(superType.getType(), type);
     }
 
     /**
-     * Determine if this class is a subclass of superType.
+     * Checks if this class has the given generic super type.
      *
      * @param superType the super type
-     * @return boolean
+     * @return true if it has the super type
      */
     public boolean hasGenericSuperType(Type superType) {
         return GenericTypeReflector.isSuperType(superType, type);
@@ -1230,6 +1320,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return result;
     }
 
+    /**
+     * Checks if this class has an owner type.
+     *
+     * @return true if it has an owner type
+     */
     public boolean hasOwnerType() {
         if (type instanceof ParameterizedType) {
             return ((ParameterizedType) type).getOwnerType() != null;
@@ -1238,6 +1333,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         }
     }
 
+    /**
+     * Checks if this class has type variables.
+     *
+     * @return true if it has type variables
+     */
     public boolean hasTypeVariables() {
         if (isParameterizedType()) {
             return hasTypeVariables((ParameterizedType) type);
@@ -1260,6 +1360,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return false;
     }
 
+    /**
+     * Checks if this class has wildcard or type variables.
+     *
+     * @return true if it has wildcard or type variables
+     */
     public boolean hasWildcardOrTypeVariables() {
         if (isTypeVariable() || isWildcardType()) {
             return true;
@@ -1296,6 +1401,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return false;
     }
 
+    /**
+     * Checks if this class has wildcard types.
+     *
+     * @return true if it has wildcard types
+     */
     public boolean hasWildcardTypes() {
         if (isParameterizedType()) {
             return hasWildcardType((ParameterizedType) type);
@@ -1397,6 +1507,11 @@ public class GenericClassImpl implements Serializable, GenericClass<GenericClass
         return rawClass.isEnum();
     }
 
+    /**
+     * Checks if this class is a generic array.
+     *
+     * @return true if it is a generic array
+     */
     public boolean isGenericArray() {
         GenericClassImpl componentClass = new GenericClassImpl(rawClass.getComponentType());
         return componentClass.hasWildcardOrTypeVariables();

--- a/client/src/main/java/org/evosuite/utils/generic/GenericConstructor.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericConstructor.java
@@ -200,6 +200,11 @@ public class GenericConstructor extends GenericExecutable<GenericConstructor, Co
         return constructor.getGenericParameterTypes().length;
     }
 
+    /**
+     * Returns the parameter types of the constructor.
+     *
+     * @return the parameter types
+     */
     public Type[] getParameterTypes() {
         Type[] types = getExactParameterTypes(constructor, owner.getType());
         Type[] rawTypes = constructor.getParameterTypes();

--- a/client/src/main/java/org/evosuite/utils/generic/GenericField.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericField.java
@@ -44,18 +44,36 @@ public class GenericField extends GenericAccessibleObject<GenericField> {
 
     private transient Field field;
 
+    /**
+     * Constructor.
+     *
+     * @param field the field
+     * @param owner the owner class
+     */
     public GenericField(Field field, GenericClass<?> owner) {
         super(GenericClassFactory.get(owner));
         this.field = field;
         field.setAccessible(true);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param field the field
+     * @param owner the owner class
+     */
     public GenericField(Field field, Class<?> owner) {
         super(GenericClassFactory.get(owner));
         this.field = field;
         field.setAccessible(true);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param field the field
+     * @param owner the owner type
+     */
     public GenericField(Field field, Type owner) {
         super(GenericClassFactory.get(owner));
         this.field = field;
@@ -141,6 +159,11 @@ public class GenericField extends GenericAccessibleObject<GenericField> {
         return field.getGenericType();
     }
 
+    /**
+     * Returns the exact type of the field.
+     *
+     * @return the exact type
+     */
     public Type getFieldType() {
         return GenericTypeReflector.getExactFieldType(field, owner.getType());
         //      try {
@@ -151,6 +174,11 @@ public class GenericField extends GenericAccessibleObject<GenericField> {
         // }
     }
 
+    /**
+     * Returns the generic type of the field.
+     *
+     * @return the generic type
+     */
     public Type getGenericFieldType() {
         return field.getGenericType();
     }

--- a/client/src/main/java/org/evosuite/utils/generic/GenericMethod.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericMethod.java
@@ -124,6 +124,11 @@ public class GenericMethod extends GenericExecutable<GenericMethod, Method> {
         return getParameterTypes();
     }
 
+    /**
+     * Returns the list of parameter classes.
+     *
+     * @return the list of parameter classes
+     */
     public List<GenericClass<?>> getParameterClasses() {
         List<GenericClass<?>> classes = new ArrayList<>();
         for (Type type : getParameterTypes()) {
@@ -236,6 +241,11 @@ public class GenericMethod extends GenericExecutable<GenericMethod, Method> {
         return Modifier.isStatic(method.getModifiers());
     }
 
+    /**
+     * Checks if the method is overloaded.
+     *
+     * @return true if overloaded
+     */
     public boolean isOverloaded() {
         String methodName = getName();
         Class<?> declaringClass = method.getDeclaringClass();

--- a/client/src/main/java/org/evosuite/utils/generic/GenericTypeInference.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericTypeInference.java
@@ -48,6 +48,11 @@ public class GenericTypeInference extends TestVisitor {
 
     private TestCase test;
 
+    /**
+     * Infers types for the given test case.
+     *
+     * @param test the test case
+     */
     public void inferTypes(TestCase test) {
         this.test = test;
         logger.debug("Inferring generic types");

--- a/client/src/main/java/org/evosuite/utils/generic/GenericUtils.java
+++ b/client/src/main/java/org/evosuite/utils/generic/GenericUtils.java
@@ -40,6 +40,13 @@ public class GenericUtils {
      */
     public static final String NONNULL = "Nonnull";
 
+    /**
+     * Checks if the type is assignable to the type variable.
+     *
+     * @param type         the type
+     * @param typeVariable the type variable
+     * @return true if assignable
+     */
     public static boolean isAssignable(Type type, TypeVariable<?> typeVariable) {
         boolean isAssignable = true;
         for (Type boundType : typeVariable.getBounds()) {
@@ -57,6 +64,12 @@ public class GenericUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(GenericUtils.class);
 
+    /**
+     * Returns a string representation of the type variable map sorted by keys and values.
+     *
+     * @param map the map
+     * @return the string representation
+     */
     public static String stableTypeVariableMapToString(Map<TypeVariable<?>, Type> map) {
         if (map == null) {
             return "null";
@@ -76,8 +89,8 @@ public class GenericUtils {
             }
             Entry<TypeVariable<?>, Type> entry = entries.get(i);
             builder.append(typeVariableDisplay(entry.getKey()))
-                   .append("=")
-                   .append(typeValueDisplay(entry.getValue()));
+                    .append("=")
+                    .append(typeValueDisplay(entry.getValue()));
         }
         builder.append("}");
         return builder.toString();
@@ -119,6 +132,13 @@ public class GenericUtils {
         return String.valueOf(value);
     }
 
+    /**
+     * Replaces type variables in the target type using the provided map.
+     *
+     * @param targetType the target type
+     * @param typeMap    the map of type variables to types
+     * @return the type with replaced variables
+     */
     public static Type replaceTypeVariables(Type targetType,
                                             Map<TypeVariable<?>, Type> typeMap) {
         Type returnType = targetType;
@@ -133,6 +153,12 @@ public class GenericUtils {
         return returnType;
     }
 
+    /**
+     * Replaces type variables with wildcards in the target type.
+     *
+     * @param targetType the target type
+     * @return the type with wildcards
+     */
     public static Type replaceTypeVariablesWithWildcards(Type targetType) {
         if (targetType instanceof TypeVariable) {
             TypeVariable<?> typeVariable = (TypeVariable<?>) targetType;
@@ -154,6 +180,14 @@ public class GenericUtils {
         return targetType;
     }
 
+    /**
+     * Replaces a specific type variable with the given type in the target type.
+     *
+     * @param targetType   the target type
+     * @param variable     the type variable to replace
+     * @param variableType the replacement type
+     * @return the new type
+     */
     public static Type replaceTypeVariable(Type targetType, TypeVariable<?> variable,
                                            Type variableType) {
         if (targetType instanceof Class<?>) {
@@ -235,6 +269,13 @@ public class GenericUtils {
         }
     }
 
+    /**
+     * Returns a map of matching type parameters between two generic array types.
+     *
+     * @param p1 the first generic array type
+     * @param p2 the second generic array type
+     * @return the map of matching type parameters
+     */
     public Map<TypeVariable<?>, Type> getMatchingTypeParameters(GenericArrayType p1,
                                                                 GenericArrayType p2) {
         if (p1.getGenericComponentType() instanceof ParameterizedType

--- a/client/src/main/java/org/evosuite/utils/generic/VarMap.java
+++ b/client/src/main/java/org/evosuite/utils/generic/VarMap.java
@@ -45,6 +45,13 @@ public class VarMap {
         map.put(variable, value);
     }
 
+    /**
+     * Adds all variables and values to the map.
+     *
+     * @param variables the variables
+     * @param values    the values
+     * @throws IllegalArgumentException if lengths mismatch
+     */
     public void addAll(TypeVariable<?>[] variables, Type[] values) throws IllegalArgumentException {
         Inputs.checkNull(variables, values);
         if (variables.length != values.length) {
@@ -56,6 +63,12 @@ public class VarMap {
         }
     }
 
+    /**
+     * Adds all variables from the given map.
+     *
+     * @param variables the variables map
+     * @throws IllegalArgumentException if null
+     */
     public void addAll(Map<TypeVariable<?>, GenericClass<?>> variables) throws IllegalArgumentException {
         Inputs.checkNull(variables);
         for (Entry<TypeVariable<?>, GenericClass<?>> entry : variables.entrySet()) {
@@ -64,6 +77,13 @@ public class VarMap {
     }
 
 
+    /**
+     * Maps the type using the current variable map.
+     *
+     * @param type the type to map
+     * @return the mapped type
+     * @throws IllegalArgumentException if type is null
+     */
     public Type map(Type type) throws IllegalArgumentException {
         Inputs.checkNull(type);
 
@@ -105,6 +125,13 @@ public class VarMap {
         }
     }
 
+    /**
+     * Maps the array of types using the current variable map.
+     *
+     * @param types the types to map
+     * @return the mapped types
+     * @throws IllegalArgumentException if types is null
+     */
     public Type[] map(Type[] types) throws IllegalArgumentException {
         Inputs.checkNull(types);
         Type[] result = new Type[types.length];

--- a/client/src/main/java/org/evosuite/utils/generic/WildcardTypeImpl.java
+++ b/client/src/main/java/org/evosuite/utils/generic/WildcardTypeImpl.java
@@ -31,6 +31,12 @@ public class WildcardTypeImpl implements WildcardType {
     private Type[] upperBounds;
     private Type[] lowerBounds;
 
+    /**
+     * Constructor.
+     *
+     * @param upperBounds the upper bounds
+     * @param lowerBounds the lower bounds
+     */
     public WildcardTypeImpl(Type[] upperBounds, Type[] lowerBounds) {
         if (upperBounds.length == 0) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
Applied Checkstyle fixes to `org.evosuite.utils.generic` package.
Addressed `MissingJavadocMethod` warnings by adding meaningful Javadoc comments.
Addressed `Indentation` warning in `GenericUtils.java`.
Verified that `org.evosuite.utils` package is now compliant with Checkstyle configuration.
Ran `mvn -pl client test` to ensure no regressions (existing failures in `TestGenericClassImpl` are unrelated to these changes).

---
*PR created automatically by Jules for task [3005501614119433426](https://jules.google.com/task/3005501614119433426) started by @gofraser*