### PR TITLE
Apply Checkstyle to org.evosuite.testcase.localsearch package

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/localsearch/AbstractStringLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/AbstractStringLocalSearch.java
@@ -70,9 +70,9 @@ public abstract class AbstractStringLocalSearch extends StatementLocalSearch {
             int position = oldValue.length();
             char[] characters = Arrays.copyOf(oldValue.toCharArray(), position + 1);
             for (char replacement = 9; replacement < 128; replacement++) {
-                 if (LocalSearchBudget.getInstance().isFinished()) {
-                     return improvement;
-                 }
+                if (LocalSearchBudget.getInstance().isFinished()) {
+                    return improvement;
+                }
                 characters[position] = replacement;
                 String newString = new String(characters);
                 p.setValue(newString);
@@ -94,9 +94,9 @@ public abstract class AbstractStringLocalSearch extends StatementLocalSearch {
             int position = 0;
             char[] characters = (" " + oldValue).toCharArray();
             for (char replacement = 9; replacement < 128; replacement++) {
-                 if (LocalSearchBudget.getInstance().isFinished()) {
-                     return improvement;
-                 }
+                if (LocalSearchBudget.getInstance().isFinished()) {
+                    return improvement;
+                }
                 characters[position] = replacement;
                 String newString = new String(characters);
                 p.setValue(newString);

--- a/client/src/main/java/org/evosuite/testcase/localsearch/ArrayLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/ArrayLocalSearch.java
@@ -53,10 +53,6 @@ public class ArrayLocalSearch extends StatementLocalSearch {
     }
 
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -87,7 +83,8 @@ public class ArrayLocalSearch extends StatementLocalSearch {
                 break;
             }
             logger.debug("Local search on statement " + position);
-            StatementLocalSearch search = StatementLocalSearch.getLocalSearchFor(test.getTestCase().getStatement(position));
+            StatementLocalSearch search = StatementLocalSearch.getLocalSearchFor(
+                    test.getTestCase().getStatement(position));
             if (search != null) {
                 if (search.doSearch(test, position, objective)) {
                     hasImproved = true;

--- a/client/src/main/java/org/evosuite/testcase/localsearch/BooleanLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/BooleanLocalSearch.java
@@ -40,10 +40,6 @@ public class BooleanLocalSearch extends StatementLocalSearch {
 
     private boolean oldValue;
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
-
     /**
      * {@inheritDoc}
      */

--- a/client/src/main/java/org/evosuite/testcase/localsearch/BranchCoverageMap.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/BranchCoverageMap.java
@@ -44,6 +44,11 @@ public class BranchCoverageMap implements SearchListener<TestSuiteChromosome> {
 
     }
 
+    /**
+     * Return the singleton instance.
+     *
+     * @return the singleton instance.
+     */
     public static BranchCoverageMap getInstance() {
         if (instance == null) {
             instance = new BranchCoverageMap();

--- a/client/src/main/java/org/evosuite/testcase/localsearch/DSETestCaseLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/DSETestCaseLocalSearch.java
@@ -37,8 +37,7 @@ import java.util.Set;
  * Applies DSE on a given test case. If the test case belongs to a suite, it
  * should be provided by using the constructor that receives a suite chromosome.
  *
- * <p>
- * If the test case has no symbolic variables (or these variables are not
+ * <p>If the test case has no symbolic variables (or these variables are not
  * reached due to a thrown exception during test execution), or it does not
  * reach an uncovered branch, DSE is skipped on this test case.
  *
@@ -233,10 +232,11 @@ public class DSETestCaseLocalSearch extends TestCaseLocalSearch<TestChromosome> 
      * @param testChromosome       the test case to apply DSE
      * @param localSearchObjective the objective to measure fitness improvement
      * @return a set with statement indexes in the test case with symbolic
-     * variables
+     *     variables
      */
     private static Set<Integer> collectStatementIndexesWithSymbolicVariables(TestChromosome testChromosome,
-                                                                             LocalSearchObjective<TestChromosome> localSearchObjective) {
+                                                                             LocalSearchObjective<TestChromosome>
+                                                                                     localSearchObjective) {
 
         // Only apply local search up to the point where an exception was thrown
         // TODO: Check whether this conflicts with test expansion
@@ -288,7 +288,8 @@ public class DSETestCaseLocalSearch extends TestCaseLocalSearch<TestChromosome> 
      * @param suite the suite.
      * @return .
      */
-    private static <E extends AbstractTestChromosome<E>> Set<Branch> collectCoveredBranches(AbstractTestSuiteChromosome<?, E> suite) {
+    private static <E extends AbstractTestChromosome<E>> Set<Branch> collectCoveredBranches(
+            AbstractTestSuiteChromosome<?, E> suite) {
         final Set<Branch> suiteCoveredBranches = new HashSet<>();
         for (E test : suite.getTestChromosomes()) {
             final Set<Branch> testCoveredBranches = getCoveredBranches(test);

--- a/client/src/main/java/org/evosuite/testcase/localsearch/EnumLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/EnumLocalSearch.java
@@ -40,10 +40,6 @@ public class EnumLocalSearch extends StatementLocalSearch {
 
     private Object oldValue;
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
-
     /**
      * {@inheritDoc}
      */

--- a/client/src/main/java/org/evosuite/testcase/localsearch/FloatLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/FloatLocalSearch.java
@@ -93,9 +93,8 @@ public class FloatLocalSearch<T extends Number> extends NumericalLocalSearch<T> 
         ExecutionResult oldResult = test.getLastExecutionResult();
 
         if (p.getValue().getClass().equals(Float.class)) {
-            p.setValue((T) Float.valueOf((float)newValue));
-        } else
-             {
+            p.setValue((T) Float.valueOf((float) newValue));
+        } else {
             p.setValue((T) Double.valueOf(newValue));
         }
 

--- a/client/src/main/java/org/evosuite/testcase/localsearch/NullReferenceSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/NullReferenceSearch.java
@@ -37,8 +37,8 @@ import java.util.Map;
  */
 public class NullReferenceSearch extends StatementLocalSearch {
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
+    /**
+     * {@inheritDoc}
      */
     @Override
     public boolean doSearch(TestChromosome test, int statement,

--- a/client/src/main/java/org/evosuite/testcase/localsearch/NumericalLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/NumericalLocalSearch.java
@@ -40,8 +40,8 @@ public abstract class NumericalLocalSearch<T> extends StatementLocalSearch {
         boolean improved = executeSearch(test, statement, objective, p);
 
         if (improved) {
-             NumericalPrimitiveStatement<T> ps = (NumericalPrimitiveStatement<T>) oldTest.getStatement(oldStatement);
-             ps.setValue(p.getValue());
+            NumericalPrimitiveStatement<T> ps = (NumericalPrimitiveStatement<T>) oldTest.getStatement(oldStatement);
+            ps.setValue(p.getValue());
         }
         test.setChanged(true);
         test.setTestCase(oldTest);

--- a/client/src/main/java/org/evosuite/testcase/localsearch/ParameterLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/ParameterLocalSearch.java
@@ -38,8 +38,7 @@ import java.util.List;
 /**
  * Local search on the parameters of a function call.
  *
- * <p>
- * 1. null/non-null 2. Other assignable values in test case 3. Type hierarchy.
+ * <p>1. null/non-null 2. Other assignable values in test case 3. Type hierarchy.
  *
  * @author Gordon Fraser
  */
@@ -60,10 +59,6 @@ public class ParameterLocalSearch extends StatementLocalSearch {
         test.setLastExecutionResult(oldResult);
         test.setChanged(oldChanged);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/localsearch/ReferenceLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/ReferenceLocalSearch.java
@@ -58,8 +58,8 @@ public class ReferenceLocalSearch extends StatementLocalSearch {
         REPLACE, PARAMETER, CALL
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
+    /**
+     * {@inheritDoc}
      */
     @Override
     public boolean doSearch(TestChromosome test, int statement,
@@ -104,6 +104,8 @@ public class ReferenceLocalSearch extends StatementLocalSearch {
                     break;
                 case CALL:
                     addCall(test, statement);
+                    break;
+                default:
                     break;
             }
 

--- a/client/src/main/java/org/evosuite/testcase/localsearch/StatementLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/StatementLocalSearch.java
@@ -49,18 +49,24 @@ public abstract class StatementLocalSearch {
 
 
     /**
-     * <p>
-     * doSearch
-     * </p>
+     * <p>doSearch.</p>
      *
      * @param test      a {@link org.evosuite.testcase.TestChromosome} object.
      * @param statement a int.
      * @param objective a {@link org.evosuite.ga.localsearch.LocalSearchObjective} object.
+     * @return a boolean.
      */
     public abstract boolean doSearch(TestChromosome test, int statement,
                                      LocalSearchObjective<TestChromosome> objective);
 
-
+    /**
+     * <p>doSearch.</p>
+     *
+     * @param test      a {@link org.evosuite.testcase.TestChromosome} object.
+     * @param statements a {@link java.util.Set} object.
+     * @param objective a {@link org.evosuite.ga.localsearch.LocalSearchObjective} object.
+     * @return a boolean.
+     */
     public boolean doSearch(TestChromosome test, Set<Integer> statements,
                             LocalSearchObjective<TestChromosome> objective) {
         boolean success = false;
@@ -83,6 +89,12 @@ public abstract class StatementLocalSearch {
         return 0;
     }
 
+    /**
+     * <p>getLocalSearchFor.</p>
+     *
+     * @param statement a {@link org.evosuite.testcase.statements.Statement} object.
+     * @return a {@link org.evosuite.testcase.localsearch.StatementLocalSearch} object.
+     */
     public static StatementLocalSearch getLocalSearchFor(Statement statement) {
 
         StatementLocalSearch search = null;

--- a/client/src/main/java/org/evosuite/testcase/localsearch/StringAVMLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/StringAVMLocalSearch.java
@@ -34,10 +34,6 @@ import org.evosuite.utils.Randomness;
  */
 public class StringAVMLocalSearch extends AbstractStringLocalSearch {
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -56,8 +52,7 @@ public class StringAVMLocalSearch extends AbstractStringLocalSearch {
         for (int i = 0; i < Properties.LOCAL_SEARCH_PROBES; i++) {
             if (Randomness.nextDouble() > 0.5) {
                 p.increment();
-            } else
-                 {
+            } else {
                 p.randomize();
             }
 

--- a/client/src/main/java/org/evosuite/testcase/localsearch/StringLocalSearch.java
+++ b/client/src/main/java/org/evosuite/testcase/localsearch/StringLocalSearch.java
@@ -36,10 +36,6 @@ import org.evosuite.utils.Randomness;
  */
 public class StringLocalSearch extends AbstractStringLocalSearch {
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.LocalSearch#doSearch(org.evosuite.testcase.TestChromosome, int, org.evosuite.ga.LocalSearchObjective)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -56,8 +52,7 @@ public class StringLocalSearch extends AbstractStringLocalSearch {
         for (int i = 0; i < Properties.LOCAL_SEARCH_PROBES; i++) {
             if (Randomness.nextDouble() > 0.5) {
                 p.increment();
-            } else
-                 {
+            } else {
                 p.randomize();
             }
 


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.testcase.localsearch` package in the client module.
- Added missing Javadocs to `BranchCoverageMap`, `StatementLocalSearch`.
- Fixed indentation and formatting in `AbstractStringLocalSearch`, `FloatLocalSearch`, `StringLocalSearch`, `NumericalLocalSearch`, `StringAVMLocalSearch`.
- Fixed line length violations in `DSETestCaseLocalSearch`, `ArrayLocalSearch`, `BooleanLocalSearch`, `EnumLocalSearch`, `ReferenceLocalSearch`, `ParameterLocalSearch`, `NullReferenceSearch`.
- Removed redundant Javadoc blocks (`/* (non-Javadoc) ... */`) in favor of `{@inheritDoc}`.
- Added missing default case to switch in `ReferenceLocalSearch`.
- Verified 0 Checkstyle violations and successful test execution.

---
*PR created automatically by Jules for task [8093138701518974245](https://jules.google.com/task/8093138701518974245) started by @gofraser*