### PR TITLE
Apply Checkstyle to org.evosuite.testcase.utils in client module

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/utils/HeuristicsUtil.java
+++ b/client/src/main/java/org/evosuite/testcase/utils/HeuristicsUtil.java
@@ -1,11 +1,12 @@
 package org.evosuite.testcase.utils;
+
 import java.util.ArrayList;
 
 public class HeuristicsUtil {
     /**
-     * List of particles of a method name that can be excluded or avoided when syggesting names.
+     * List of particles of a method name that can be excluded or avoided when suggesting names.
      */
-    private static ArrayList<String> avoidableParticles = new ArrayList<String>(){
+    private static ArrayList<String> avoidableParticles = new ArrayList<String>() {
         {
             add("get");
             add("to");
@@ -16,19 +17,23 @@ public class HeuristicsUtil {
     };
 
     /**
-     * Returns a boolean value that indicates if the first word of a method can be avoided/excluded
+     * Indicates whether the first word of a method can be avoided/excluded
      * on method name suggestion.
-     * @return boolean
+     *
+     * @param firstWord the word to check
+     * @return true if the word is avoidable
      */
-
-    public static boolean containsAvoidableParticle(String firstWord){
+    public static boolean containsAvoidableParticle(String firstWord) {
         return avoidableParticles.contains(firstWord);
     }
+
     /**
-     * Separates camelcase strings and retrieves the parts in a list.
-     * @return ArrayList<String>
+     * Splits camelCase strings into a list of words.
+     *
+     * @param name the string to split
+     * @return the list of words
      */
-    public static ArrayList<String> separateByCamelCase(String name){
+    public static ArrayList<String> separateByCamelCase(String name) {
         ArrayList<String> separatedName = new ArrayList<>();
         for (String word : name.split("(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")) {
             separatedName.add(word);

--- a/client/src/main/java/org/evosuite/testcase/utils/StatementClassChecker.java
+++ b/client/src/main/java/org/evosuite/testcase/utils/StatementClassChecker.java
@@ -42,6 +42,12 @@ public enum StatementClassChecker {
         this.statementCheck = statementCheck;
     }
 
+    /**
+     * Checks if the statement is of the type defined by this checker.
+     *
+     * @param statement the statement to check
+     * @return true if the statement matches the type
+     */
     public Boolean checkClassType(Statement statement) {
         return statementCheck.apply(statement);
     }

--- a/client/src/main/java/org/evosuite/testcase/utils/TestChromosomeUtils.java
+++ b/client/src/main/java/org/evosuite/testcase/utils/TestChromosomeUtils.java
@@ -3,7 +3,11 @@ package org.evosuite.testcase.utils;
 import org.evosuite.Properties;
 import org.evosuite.testcase.TestCase;
 import org.evosuite.testcase.TestChromosome;
-import org.evosuite.testcase.statements.*;
+import org.evosuite.testcase.statements.ArrayStatement;
+import org.evosuite.testcase.statements.ConstructorStatement;
+import org.evosuite.testcase.statements.MethodStatement;
+import org.evosuite.testcase.statements.PrimitiveStatement;
+import org.evosuite.testcase.statements.Statement;
 import org.evosuite.testcase.variable.VariableReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,16 +20,19 @@ public class TestChromosomeUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(TestChromosomeUtils.class);
 
-    private TestChromosomeUtils() {}
+    private TestChromosomeUtils() {
+    }
 
     /**
-     * This method checks whether the test has only primitive type statements. Indeed,
-     * crossover and mutation can lead to tests with no method calls (methods or constructors
+     * Checks if the test chromosome contains any method or constructor calls.
+     * <p>
+     * Indeed, crossover and mutation can lead to tests with no method calls (methods or constructors
      * call), thus, when executed they will never cover something in the class under test.
+     * </p>
      *
-     * @param test to check
+     * @param test the test chromosome to check
      * @return true if the test has at least one method or constructor call (i.e., the test may
-     * cover something when executed; false otherwise
+     *     cover something when executed); false otherwise
      */
     public static boolean hasMethodCall(TestChromosome test) {
         boolean flag = false;
@@ -50,12 +57,15 @@ public class TestChromosomeUtils {
     }
 
     /**
-     * When a test case is changed via crossover and/or mutation, it can contains some
+     * Removes unused primitive variables from the test chromosome.
+     * <p>
+     * When a test case is changed via crossover and/or mutation, it can contain some
      * primitive variables that are not used as input (or to store the output) of method calls.
      * Thus, this method removes all these "trash" statements.
+     * </p>
      *
-     * @param chromosome the chromosome.
-     * @return true or false depending on whether "unused variables" are removed
+     * @param chromosome the chromosome
+     * @return true if any unused variables were removed
      */
     public static boolean removeUnusedVariables(TestChromosome chromosome) {
         int sizeBefore = chromosome.size();


### PR DESCRIPTION
This PR applies Checkstyle to the `org.evosuite.testcase.utils` package in the `client` module. 
It fixes violations such as missing Javadocs, whitespace issues, wildcard imports, and indentation. 
Meaningful Javadoc comments have been added where missing. 
Code logic remains unchanged. 
Verified by running `mvn checkstyle:check` and `TestChromosomeUtilsTest`.


---
*PR created automatically by Jules for task [5770144956172970936](https://jules.google.com/task/5770144956172970936) started by @gofraser*