### PR TITLE
Apply Checkstyle to org.evosuite.testcase.mutation

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/mutation/InsertionStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/mutation/InsertionStrategy.java
@@ -35,33 +35,29 @@ public interface InsertionStrategy {
      * given position {@code lastPosition}. The test case must not be {@code null} but it can be
      * empty.
      *
-     * <p>
-     * A test case might contain faulty statements, causing an exception when the test case is
+     * <p>A test case might contain faulty statements, causing an exception when the test case is
      * executed. In such situations, the test case's sequence of statements is only valid up to the
      * first faulty statement. Callers have to specify the position of the last statement known to
      * be valid by supplying an appropriate index {@code lastPosition}.
      *
-     * <p>
-     * All statements inserted by this method are inserted after {@code lastPosition}. In other
+     * <p>All statements inserted by this method are inserted after {@code lastPosition}. In other
      * words, {@code lastPosition + 1} is considered the insertion point for new statements. If
      * {@code lastPosition + 1 < test.size()}, already existing statements located after the
      * insertion point will be moved towards the end of the sequence as necessary. None of those
      * statements will be deleted or overwritten.
      *
-     * <p>
-     * If the given test case is empty (as is the case when generating an initial population) the
+     * <p>If the given test case is empty (as is the case when generating an initial population) the
      * insertion point is assumed to be at index 0, regardless of the given {@code lastPosition}.
      *
-     * <p>
-     * After a successful insertion, the position of the last known valid statement is updated and
+     * <p>After a successful insertion, the position of the last known valid statement is updated and
      * returned. This might not necessarily be {@code lastPosition + 1}, e.g., when multiple
      * statements were inserted. If insertion was unsuccessful, a negative number is returned.
      *
      * @param test         the test case in which to insert
      * @param lastPosition the position of the last valid statement in the test case, defining the
-     *                     insertion point for new statements
+     *     insertion point for new statements
      * @return the updated position of the last valid statement after insertion, or a negative
-     * number if insertion failed
+     *     number if insertion failed
      */
     int insertStatement(TestCase test, int lastPosition);
 }

--- a/client/src/main/java/org/evosuite/testcase/mutation/RandomInsertion.java
+++ b/client/src/main/java/org/evosuite/testcase/mutation/RandomInsertion.java
@@ -63,7 +63,9 @@ public class RandomInsertion implements InsertionStrategy {
 
         // Determine intended action based on probabilities
         boolean attemptUUT = Properties.INSERTION_UUT > 0 && r <= Properties.INSERTION_UUT;
-        boolean attemptEnv = Properties.INSERTION_ENVIRONMENT > 0 && r > Properties.INSERTION_UUT && r <= Properties.INSERTION_UUT + Properties.INSERTION_ENVIRONMENT;
+        boolean attemptEnv = Properties.INSERTION_ENVIRONMENT > 0
+                && r > Properties.INSERTION_UUT
+                && r <= Properties.INSERTION_UUT + Properties.INSERTION_ENVIRONMENT;
 
         // Fallback or explicit parameter insertion
         // If we didn't pick UUT or ENV, then we picked PARAM.
@@ -80,7 +82,7 @@ public class RandomInsertion implements InsertionStrategy {
                 logger.debug("Inserted random call to UUT");
             }
         } else if (attemptEnv && TestCluster.getInstance().getNumOfEnvironmentCalls() > 0) {
-             /*
+            /*
                 Insert a call to the environment, i.e., external resources for the test case such
                 as handles to files on the file system, sockets that open network connections, etc.
                 As such call is likely to depend on many constraints, we do not specify here the


### PR DESCRIPTION
Applied checkstyle fixes to the `org.evosuite.testcase.mutation` package.
This includes:
- Fixing `JavadocParagraph` and `JavadocTagContinuationIndentation` in `InsertionStrategy.java`.
- Fixing `LineLength` and `CommentsIndentation` in `RandomInsertion.java`.

Verified with `mvn checkstyle:check` and ran `RandomInsertionTest`.

---
*PR created automatically by Jules for task [17847105034219457104](https://jules.google.com/task/17847105034219457104) started by @gofraser*