### PR TITLE
Apply checkstyle to org.evosuite.testcase.statements.numeric

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/BooleanPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/BooleanPrimitiveStatement.java
@@ -25,24 +25,24 @@ import org.evosuite.utils.Randomness;
 
 
 /**
- * <p>BooleanPrimitiveStatement class.</p>
+ * Primitive statement for boolean values.
  *
  * @author fraser
  */
 public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boolean> {
 
     /**
-     * <p>Constructor for BooleanPrimitiveStatement.</p>
+     * Constructs a new BooleanPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Boolean} object.
+     * @param value the initial value.
      */
     public BooleanPrimitiveStatement(TestCase tc, Boolean value) {
         super(tc, boolean.class, value);
     }
 
     /**
-     * <p>Constructor for BooleanPrimitiveStatement.</p>
+     * Constructs a new BooleanPrimitiveStatement with default value false.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
@@ -52,10 +52,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
 
     private static final long serialVersionUID = 2864789903354543815L;
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -63,10 +59,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
     public void zero() {
         value = false;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -76,10 +68,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
         value = !value;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -87,10 +75,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
     public void increment(long delta) {
         delta();
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -100,10 +84,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
         value = Randomness.nextBoolean();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -111,10 +91,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
     public void increment() {
         delta();
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
 
     /**
      * {@inheritDoc}
@@ -124,10 +100,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
         delta();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -136,10 +108,6 @@ public class BooleanPrimitiveStatement extends NumericalPrimitiveStatement<Boole
         // TODO Auto-generated method stub
 
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/BytePrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/BytePrimitiveStatement.java
@@ -29,30 +29,24 @@ import org.evosuite.utils.Randomness;
 import java.lang.reflect.Type;
 
 /**
- * <p>
- * BytePrimitiveStatement class.
- * </p>
+ * Primitive statement for byte values.
  *
  * @author fraser
  */
 public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
 
     /**
-     * <p>
-     * Constructor for BytePrimitiveStatement.
-     * </p>
+     * Constructs a new BytePrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Byte} object.
+     * @param value the initial value.
      */
     public BytePrimitiveStatement(TestCase tc, Byte value) {
         super(tc, byte.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for BytePrimitiveStatement.
-     * </p>
+     * Constructs a new BytePrimitiveStatement with default value 0.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
@@ -61,22 +55,16 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
     }
 
     /**
-     * <p>
-     * Constructor for BytePrimitiveStatement.
-     * </p>
+     * Constructs a new BytePrimitiveStatement with default value 0 and given type.
      *
      * @param tc   a {@link org.evosuite.testcase.TestCase} object.
-     * @param type a {@link java.lang.reflect.Type} object.
+     * @param type the type of the value.
      */
     public BytePrimitiveStatement(TestCase tc, Type type) {
         super(tc, type, (byte) 0);
     }
 
     private static final long serialVersionUID = -8123457944460041347L;
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -85,10 +73,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
     public void zero() {
         value = (byte) 0;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -99,10 +83,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
         value = (byte) (value + delta);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -110,10 +90,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
     public void increment(long delta) {
         value = (byte) (value + delta);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -128,10 +104,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -139,10 +111,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
     public void increment() {
         increment((byte) 1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
 
     /**
      * {@inheritDoc}
@@ -152,10 +120,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
         increment((byte) -1);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -163,10 +127,6 @@ public class BytePrimitiveStatement extends NumericalPrimitiveStatement<Byte> {
     public void setMid(Byte min, Byte max) {
         value = (byte) (min + ((max - min) / 2));
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/CharPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/CharPrimitiveStatement.java
@@ -25,7 +25,7 @@ import org.evosuite.utils.Randomness;
 
 
 /**
- * <p>CharPrimitiveStatement class.</p>
+ * Primitive statement for character values.
  *
  * @author fraser
  */
@@ -34,29 +34,23 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
     private static final long serialVersionUID = -1960567565801078784L;
 
     /**
-     * <p>Constructor for CharPrimitiveStatement.</p>
+     * Constructs a new CharPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Character} object.
+     * @param value the initial value.
      */
     public CharPrimitiveStatement(TestCase tc, Character value) {
         super(tc, char.class, value);
-        // TODO Auto-generated constructor stub
     }
 
     /**
-     * <p>Constructor for CharPrimitiveStatement.</p>
+     * Constructs a new CharPrimitiveStatement with default value.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public CharPrimitiveStatement(TestCase tc) {
         super(tc, char.class, (char) 0);
-        // TODO Auto-generated constructor stub
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -65,10 +59,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
     public void zero() {
         value = (char) 0;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -79,10 +69,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
         value = (char) (value + delta);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -90,10 +76,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
     public void increment(long delta) {
         value = (char) (value + delta);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -103,10 +85,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
         value = Randomness.nextChar();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -114,10 +92,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
     public void increment() {
         increment((char) 1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -127,10 +101,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
         value = (char) (min + ((max - min) / 2));
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -138,10 +108,6 @@ public class CharPrimitiveStatement extends NumericalPrimitiveStatement<Characte
     public void decrement() {
         increment(-1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/DoublePrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/DoublePrimitiveStatement.java
@@ -30,9 +30,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * <p>
- * DoublePrimitiveStatement class.
- * </p>
+ * Primitive statement for double values.
  *
  * @author fraser
  */
@@ -41,31 +39,23 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
     private static final long serialVersionUID = 6229514439946892566L;
 
     /**
-     * <p>
-     * Constructor for DoublePrimitiveStatement.
-     * </p>
+     * Constructs a new DoublePrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Double} object.
+     * @param value the initial value.
      */
     public DoublePrimitiveStatement(TestCase tc, Double value) {
         super(tc, double.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for DoublePrimitiveStatement.
-     * </p>
+     * Constructs a new DoublePrimitiveStatement with default value 0.0.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public DoublePrimitiveStatement(TestCase tc) {
         super(tc, double.class, 0.0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -75,29 +65,21 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
         value = 0.0;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
-
     /**
      * {@inheritDoc}
      */
     @Override
     public void delta() {
-        double P = Randomness.nextDouble();
-        if (P < 1d / 3d) {
+        double probability = Randomness.nextDouble();
+        if (probability < 1d / 3d) {
             value += Randomness.nextGaussian() * Properties.MAX_DELTA;
-        } else if (P < 2d / 3d) {
+        } else if (probability < 2d / 3d) {
             value += Randomness.nextGaussian();
         } else {
             int precision = Randomness.nextInt(15);
             chopPrecision(precision);
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -107,6 +89,11 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
         value = value + delta;
     }
 
+    /**
+     * Reduces the precision of the value.
+     *
+     * @param precision the number of decimal places to keep
+     */
     private void chopPrecision(int precision) {
         if (value.isNaN() || value.isInfinite()) {
             return;
@@ -116,10 +103,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
         this.value = bd.doubleValue();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -127,10 +110,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
     public void increment(double delta) {
         value = value + delta;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -147,10 +126,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -158,10 +133,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
     public void increment() {
         increment(1.0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -171,10 +142,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
         value = min + ((max - min) / 2);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -182,10 +149,6 @@ public class DoublePrimitiveStatement extends NumericalPrimitiveStatement<Double
     public void decrement() {
         increment(-1.0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/FloatPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/FloatPrimitiveStatement.java
@@ -30,9 +30,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * <p>
- * FloatPrimitiveStatement class.
- * </p>
+ * Primitive statement for float values.
  *
  * @author Gordon Fraser
  */
@@ -41,31 +39,23 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
     private static final long serialVersionUID = 708022695544843828L;
 
     /**
-     * <p>
-     * Constructor for FloatPrimitiveStatement.
-     * </p>
+     * Constructs a new FloatPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Float} object.
+     * @param value the initial value.
      */
     public FloatPrimitiveStatement(TestCase tc, Float value) {
         super(tc, float.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for FloatPrimitiveStatement.
-     * </p>
+     * Constructs a new FloatPrimitiveStatement with default value 0.0F.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public FloatPrimitiveStatement(TestCase tc) {
         super(tc, float.class, 0.0F);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -75,19 +65,15 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         value = (float) 0.0;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
-
     /**
      * {@inheritDoc}
      */
     @Override
     public void delta() {
-        double P = Randomness.nextDouble();
-        if (P < 1d / 3d) {
+        double probability = Randomness.nextDouble();
+        if (probability < 1d / 3d) {
             value += (float) Randomness.nextGaussian() * Properties.MAX_DELTA;
-        } else if (P < 2d / 3d) {
+        } else if (probability < 2d / 3d) {
             value += (float) Randomness.nextGaussian();
         } else {
             int precision = Randomness.nextInt(7);
@@ -95,6 +81,11 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         }
     }
 
+    /**
+     * Reduces the precision of the value.
+     *
+     * @param precision the number of decimal places to keep
+     */
     private void chopPrecision(int precision) {
         if (value.isNaN() || value.isInfinite()) {
             return;
@@ -104,10 +95,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         this.value = bd.floatValue();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -116,10 +103,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         value = value + delta;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -127,10 +110,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
     public void increment(double delta) {
         value = value + (float) delta;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -147,10 +126,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -158,10 +133,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
     public void increment() {
         increment(1.0F);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -171,10 +142,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
         value = min + ((max - min) / 2);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -182,10 +149,6 @@ public class FloatPrimitiveStatement extends NumericalPrimitiveStatement<Float> 
     public void decrement() {
         increment(-1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/IntPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/IntPrimitiveStatement.java
@@ -27,9 +27,7 @@ import org.evosuite.testcase.TestCase;
 import org.evosuite.utils.Randomness;
 
 /**
- * <p>
- * IntPrimitiveStatement class.
- * </p>
+ * Primitive statement for integer values.
  *
  * @author fraser
  */
@@ -38,31 +36,23 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
     private static final long serialVersionUID = -8616399657291345433L;
 
     /**
-     * <p>
-     * Constructor for IntPrimitiveStatement.
-     * </p>
+     * Constructs a new IntPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Integer} object.
+     * @param value the initial value.
      */
     public IntPrimitiveStatement(TestCase tc, Integer value) {
         super(tc, int.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for IntPrimitiveStatement.
-     * </p>
+     * Constructs a new IntPrimitiveStatement with default value 0.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public IntPrimitiveStatement(TestCase tc) {
         super(tc, int.class, 0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -71,10 +61,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
     public void zero() {
         value = 0;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -85,10 +71,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
         value = value + delta;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -96,10 +78,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
     public void increment(long delta) {
         value = value + (int) delta;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -114,10 +92,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -125,10 +99,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
     public void increment() {
         increment(1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -138,10 +108,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
         value = min + ((max - min) / 2);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -149,10 +115,6 @@ public class IntPrimitiveStatement extends NumericalPrimitiveStatement<Integer> 
     public void decrement() {
         increment(-1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/LongPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/LongPrimitiveStatement.java
@@ -27,9 +27,7 @@ import org.evosuite.testcase.TestCase;
 import org.evosuite.utils.Randomness;
 
 /**
- * <p>
- * LongPrimitiveStatement class.
- * </p>
+ * Primitive statement for long values.
  *
  * @author fraser
  */
@@ -38,31 +36,23 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
     private static final long serialVersionUID = 6902273233816031053L;
 
     /**
-     * <p>
-     * Constructor for LongPrimitiveStatement.
-     * </p>
+     * Constructs a new LongPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Long} object.
+     * @param value the initial value.
      */
     public LongPrimitiveStatement(TestCase tc, Long value) {
         super(tc, long.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for LongPrimitiveStatement.
-     * </p>
+     * Constructs a new LongPrimitiveStatement with default value 0L.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public LongPrimitiveStatement(TestCase tc) {
         super(tc, long.class, (long) 0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -71,10 +61,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
     public void zero() {
         value = 0L;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -85,10 +71,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
         value = value + delta;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -96,10 +78,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
     public void increment(long delta) {
         value = value + delta;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -114,10 +92,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -125,10 +99,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
     public void increment() {
         increment(1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -138,10 +108,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
         value = min + ((max - min) / 2);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -149,10 +115,6 @@ public class LongPrimitiveStatement extends NumericalPrimitiveStatement<Long> {
     public void decrement() {
         increment(-1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/NumericalPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/NumericalPrimitiveStatement.java
@@ -29,45 +29,45 @@ import java.io.ObjectOutputStream;
 import java.lang.reflect.Type;
 
 /**
- * <p>Abstract NumericalPrimitiveStatement class.</p>
+ * Abstract base class for numerical primitive statements.
  *
  * @author Gordon Fraser
+ * @param <T> the type of the value
  */
 public abstract class NumericalPrimitiveStatement<T> extends PrimitiveStatement<T> {
 
     private static final long serialVersionUID = 476613542969677702L;
 
     /**
-     * <p>Constructor for NumericalPrimitiveStatement.</p>
+     * Constructs a new NumericalPrimitiveStatement.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
      * @param type  a {@link java.lang.reflect.Type} object.
-     * @param value a T object.
-     * @param <T>   a T object.
+     * @param value the initial value.
      */
     public NumericalPrimitiveStatement(TestCase tc, Type type, T value) {
         super(tc, type, value);
     }
 
     /**
-     * Increase value by smallest possible increment.
+     * Increases value by smallest possible increment.
      */
     public abstract void increment();
 
     /**
-     * Decrease value by smallest possible increment.
+     * Decreases value by smallest possible increment.
      */
     public abstract void decrement();
 
     /**
-     * Change value by delta.
+     * Changes value by delta.
      *
      * @param delta a long.
      */
     public abstract void increment(long delta);
 
     /**
-     * Change value by delta.
+     * Changes value by delta.
      *
      * @param delta a double.
      */
@@ -84,7 +84,7 @@ public abstract class NumericalPrimitiveStatement<T> extends PrimitiveStatement<
     public abstract void setMid(T min, T max);
 
     /**
-     * Is the value >= 0?.
+     * True if the value is greater than or equal to 0.
      *
      * @return a boolean.
      */

--- a/client/src/main/java/org/evosuite/testcase/statements/numeric/ShortPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/numeric/ShortPrimitiveStatement.java
@@ -27,9 +27,7 @@ import org.evosuite.testcase.TestCase;
 import org.evosuite.utils.Randomness;
 
 /**
- * <p>
- * ShortPrimitiveStatement class.
- * </p>
+ * Primitive statement for short values.
  *
  * @author fraser
  */
@@ -38,31 +36,23 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
     private static final long serialVersionUID = -1041008456902695964L;
 
     /**
-     * <p>
-     * Constructor for ShortPrimitiveStatement.
-     * </p>
+     * Constructs a new ShortPrimitiveStatement with the given value.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
-     * @param value a {@link java.lang.Short} object.
+     * @param value the initial value.
      */
     public ShortPrimitiveStatement(TestCase tc, Short value) {
         super(tc, short.class, value);
     }
 
     /**
-     * <p>
-     * Constructor for ShortPrimitiveStatement.
-     * </p>
+     * Constructs a new ShortPrimitiveStatement with default value 0.
      *
      * @param tc a {@link org.evosuite.testcase.TestCase} object.
      */
     public ShortPrimitiveStatement(TestCase tc) {
         super(tc, short.class, (short) 0);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
 
     /**
      * {@inheritDoc}
@@ -71,10 +61,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
     public void zero() {
         value = (short) 0;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
 
     /**
      * {@inheritDoc}
@@ -85,10 +71,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
         value = (short) (value + delta);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment(java.lang.Object)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -96,10 +78,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
     public void increment(long delta) {
         value = (short) (value + (short) delta);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}
@@ -115,10 +93,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#increment()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -126,10 +100,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
     public void increment() {
         increment((short) 1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#setMid(java.lang.Object, java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -139,10 +109,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
         value = (short) (min + ((max - min) / 2));
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#decrement()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -150,10 +116,6 @@ public class ShortPrimitiveStatement extends NumericalPrimitiveStatement<Short> 
     public void decrement() {
         increment(-1);
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.NumericalPrimitiveStatement#isPositive()
-     */
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Applied checkstyle fixes to the package `org.evosuite.testcase.statements.numeric` in the `client` module.

Changes include:
- Renaming local variable `P` to `probability` in `FloatPrimitiveStatement.java` and `DoublePrimitiveStatement.java` to comply with naming conventions.
- Improving Javadoc comments for classes and constructors, removing redundant and meaningless comments (e.g., "Constructor for..."), and ensuring compliance with Checkstyle rules (e.g., valid `@param` tags, full sentences).
- Removing redundant `/* (non-Javadoc) ... */` blocks while keeping `{@inheritDoc}`.
- Adding Javadoc to private helper methods like `chopPrecision`.
- Ensuring 0 Checkstyle violations in the package.

Verified by running `mvn -pl client checkstyle:check` and basic tests.

---
*PR created automatically by Jules for task [6983964326915142707](https://jules.google.com/task/6983964326915142707) started by @gofraser*