### PR TITLE
Apply Checkstyle to org.evosuite.testcase.statements.reflection

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/statements/reflection/PrivateFieldStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/reflection/PrivateFieldStatement.java
@@ -46,8 +46,7 @@ import java.util.List;
  * Statement representing the setting of a private field, which is done through reflection in the
  * generated JUnit tests.
  *
- * <p>
- * Created by foo on 20/02/15.
+ * <p>Created by foo on 20/02/15.
  */
 public class PrivateFieldStatement extends MethodStatement {
 
@@ -66,20 +65,43 @@ public class PrivateFieldStatement extends MethodStatement {
     static {
         try {
             //Class<T> klass, T instance, String fieldName, Object value
-            setVariable = PrivateAccess.class.getMethod("setVariable", Class.class, Object.class, String.class, Object.class);
+            setVariable = PrivateAccess.class.getMethod("setVariable",
+                    Class.class, Object.class, String.class, Object.class);
         } catch (NoSuchMethodException e) {
             //should never happen
             throw new RuntimeException("EvoSuite bug", e);
         }
     }
 
-    public PrivateFieldStatement(TestCase tc, Class<?> klass, String fieldName, VariableReference callee, VariableReference param)
+    /**
+     * Constructor.
+     *
+     * @param tc
+     *         the test case
+     * @param klass
+     *         the class owning the field
+     * @param fieldName
+     *         the name of the field
+     * @param callee
+     *         the object instance (can be null for static fields)
+     * @param param
+     *         the value to set
+     * @throws NoSuchFieldException
+     *         if field not found
+     * @throws IllegalArgumentException
+     *         if arguments are invalid
+     * @throws ConstructionFailedException
+     *         if construction fails
+     */
+    public PrivateFieldStatement(TestCase tc, Class<?> klass, String fieldName,
+                                 VariableReference callee, VariableReference param)
             throws NoSuchFieldException, IllegalArgumentException, ConstructionFailedException {
         super(
                 tc,
                 new GenericMethod(setVariable, PrivateAccess.class),
                 null, //it is static
-                Arrays.asList(  // setVariable(Class<T> klass, T instance, String fieldName, Object value)
+                Arrays.asList(
+                        // setVariable(Class<T> klass, T instance, String fieldName, Object value)
                         new ConstantValue(tc, GenericClassFactory.get(Class.class), klass),  // Class<T> klass
                         //new ClassPrimitiveStatement(tc,klass).getReturnValue(),  // Class<T> klass
                         callee, // T instance
@@ -145,7 +167,9 @@ public class PrivateFieldStatement extends MethodStatement {
     }
 
     @Override
-    public Throwable execute(Scope scope, PrintStream out) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException {
+    public Throwable execute(Scope scope, PrintStream out)
+            throws InvocationTargetException, IllegalArgumentException,
+            IllegalAccessException, InstantiationException {
         if (!isStaticField) {
             try {
                 Object receiver = parameters.get(1).getObject(scope);

--- a/client/src/main/java/org/evosuite/testcase/statements/reflection/PrivateMethodStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/reflection/PrivateMethodStatement.java
@@ -41,8 +41,7 @@ import java.util.List;
 /**
  * Test case statement representing a reflection call to a private method of the SUT.
  *
- * <p>
- * Created by Andrea Arcuri on 22/02/15.
+ * <p>Created by Andrea Arcuri on 22/02/15.
  */
 public class PrivateMethodStatement extends MethodStatement {
 
@@ -52,7 +51,25 @@ public class PrivateMethodStatement extends MethodStatement {
 
     private boolean isStaticMethod = false;
 
-    public PrivateMethodStatement(TestCase tc, Class<?> klass, Method method, VariableReference callee, List<VariableReference> params, boolean isStatic) {
+    /**
+     * Constructor.
+     *
+     * @param tc
+     *         the test case
+     * @param klass
+     *         the class owning the method
+     * @param method
+     *         the method to call
+     * @param callee
+     *         the object instance (can be null for static methods)
+     * @param params
+     *         the parameters to pass
+     * @param isStatic
+     *         whether the method is static
+     */
+    public PrivateMethodStatement(TestCase tc, Class<?> klass, Method method,
+                                  VariableReference callee, List<VariableReference> params,
+                                  boolean isStatic) {
         super(
                 tc,
                 new GenericMethod(PrivateAccess.getCallMethod(params.size()), PrivateAccess.class),
@@ -67,7 +84,8 @@ public class PrivateMethodStatement extends MethodStatement {
     }
 
     private static List<VariableReference> getReflectionParams(TestCase tc, Class<?> klass, Method method,
-                                                               VariableReference callee, List<VariableReference> inputs) {
+                                                               VariableReference callee,
+                                                               List<VariableReference> inputs) {
 
         List<VariableReference> list = new ArrayList<>(3 + inputs.size() * 2);
         list.add(new ConstantValue(tc, GenericClassFactory.get(Class.class), klass));
@@ -103,7 +121,8 @@ public class PrivateMethodStatement extends MethodStatement {
         VariableReference newCallee = parameters.get(1).copy(newTestCase, offset);
         Class<?> klass = (Class<?>) ((ConstantValue) parameters.get(0)).getValue(); // TODO: Make this nice
 
-        pm = new PrivateMethodStatement(newTestCase, klass, reflectedMethod.getMethod(), newCallee, newParams, isStaticMethod);
+        pm = new PrivateMethodStatement(newTestCase, klass, reflectedMethod.getMethod(),
+                newCallee, newParams, isStaticMethod);
 
         assert pm.parameters.size() == this.parameters.size();
 

--- a/client/src/main/java/org/evosuite/testcase/statements/reflection/ReflectionFactory.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/reflection/ReflectionFactory.java
@@ -31,8 +31,7 @@ import java.util.List;
 /**
  * Class used to get private fields/methods to construct statements in the generated tests.
  *
- * <p>
- * Created by Andrea Arcuri on 22/02/15.
+ * <p>Created by Andrea Arcuri on 22/02/15.
  */
 public class ReflectionFactory {
 
@@ -41,6 +40,14 @@ public class ReflectionFactory {
     private final List<Method> methods;
 
 
+    /**
+     * Constructor.
+     *
+     * @param target
+     *         the target class
+     * @throws IllegalArgumentException
+     *         if target is null
+     */
     public ReflectionFactory(Class<?> target) throws IllegalArgumentException {
         this.target = target;
         if (target == null) {
@@ -79,14 +86,29 @@ public class ReflectionFactory {
         }
     }
 
+    /**
+     * Gets the number of usable fields.
+     *
+     * @return the number of usable fields
+     */
     public int getNumberOfUsableFields() {
         return fields.size();
     }
 
+    /**
+     * Checks if there are private fields or methods.
+     *
+     * @return true if there are private fields or methods
+     */
     public boolean hasPrivateFieldsOrMethods() {
         return !(fields.isEmpty() && methods.isEmpty());
     }
 
+    /**
+     * Determines if the next item should be a field.
+     *
+     * @return true if the next item should be a field
+     */
     public boolean nextUseField() {
         if (fields.isEmpty()) {
             return false;
@@ -104,6 +126,13 @@ public class ReflectionFactory {
         return Randomness.nextDouble() <= ratio;
     }
 
+    /**
+     * Gets the next field.
+     *
+     * @return the next field
+     * @throws IllegalStateException
+     *         if there are no private fields
+     */
     public Field nextField() throws IllegalStateException {
         if (fields.isEmpty()) {
             throw new IllegalStateException("No private field");
@@ -111,6 +140,13 @@ public class ReflectionFactory {
         return Randomness.choice(fields);
     }
 
+    /**
+     * Gets the next method.
+     *
+     * @return the next method
+     * @throws IllegalStateException
+     *         if there are no private methods
+     */
     public Method nextMethod() throws IllegalStateException {
         if (methods.isEmpty()) {
             throw new IllegalStateException("No private method");
@@ -118,6 +154,11 @@ public class ReflectionFactory {
         return Randomness.choice(methods);
     }
 
+    /**
+     * Gets the reflected class.
+     *
+     * @return the reflected class
+     */
     public Class<?> getReflectedClass() {
         return target;
     }


### PR DESCRIPTION
This PR applies Checkstyle fixes to the `org.evosuite.testcase.statements.reflection` package in the `client` module. The changes include adding meaningful Javadocs to public methods and constructors, fixing Javadoc paragraph formatting, breaking long lines to adhere to the 120-character limit, and fixing whitespace violations. No methods were renamed, and no functional changes were made.

---
*PR created automatically by Jules for task [8089239825874095868](https://jules.google.com/task/8089239825874095868) started by @gofraser*