### PR TITLE
Fix Checkstyle violations in org.evosuite.testcase.fm

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/fm/EvoAbstractMethodInvocationListener.java
+++ b/client/src/main/java/org/evosuite/testcase/fm/EvoAbstractMethodInvocationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
  * contributors.
  *

--- a/client/src/main/java/org/evosuite/testcase/fm/EvoInvocationListener.java
+++ b/client/src/main/java/org/evosuite/testcase/fm/EvoInvocationListener.java
@@ -39,8 +39,7 @@ import java.util.stream.Collectors;
  * and how often they were called.
  * This is however not needed in the final generated JUnit tests.
  *
- * <p>
- * Created by Andrea Arcuri on 27/07/15.
+ * <p>Created by Andrea Arcuri on 27/07/15.
  */
 public class EvoInvocationListener implements InvocationListener, Serializable {
 
@@ -70,6 +69,11 @@ public class EvoInvocationListener implements InvocationListener, Serializable {
     }
 
 
+    /**
+     * Changes the class loader.
+     *
+     * @param loader the new class loader
+     */
     public void changeClassLoader(ClassLoader loader) {
         for (MethodDescriptor descriptor : map.values()) {
             if (descriptor != null) {
@@ -130,14 +134,14 @@ public class EvoInvocationListener implements InvocationListener, Serializable {
 
     @Deprecated
     private MethodDescriptor getMethodDescriptor_old(DescribedInvocation di) {
-    /*
-        Current Mockito API seems quite limited. Here, to know what
-        was called, it looks like the only way is to parse the results
-        of toString.
-        We can identify primitive types and String, but likely not the
-        exact type of input objects. This is a problem if methods are overloaded
-        and having same number of input parameters :(
-     */
+        /*
+            Current Mockito API seems quite limited. Here, to know what
+            was called, it looks like the only way is to parse the results
+            of toString.
+            We can identify primitive types and String, but likely not the
+            exact type of input objects. This is a problem if methods are overloaded
+            and having same number of input parameters :(
+         */
         String description = di.toString();
 
         int openingP = description.indexOf('(');

--- a/client/src/main/java/org/evosuite/testcase/fm/MethodDescriptor.java
+++ b/client/src/main/java/org/evosuite/testcase/fm/MethodDescriptor.java
@@ -145,6 +145,11 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
     }
 
 
+    /**
+     * Changes the class loader.
+     *
+     * @param loader the new class loader
+     */
     public void changeClassLoader(ClassLoader loader) {
         method.changeClassLoader(loader);
     }
@@ -158,10 +163,10 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
 
         int modifiers = method.getMethod().getModifiers();
 
-        if (method.getReturnType().equals(Void.TYPE) ||
-                method.getName().equals("equals") ||
-                method.getName().equals("hashCode") ||
-                Modifier.isPrivate(modifiers)) {
+        if (method.getReturnType().equals(Void.TYPE)
+                || method.getName().equals("equals")
+                || method.getName().equals("hashCode")
+                || Modifier.isPrivate(modifiers)) {
 
             return false;
         }
@@ -195,6 +200,11 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
         return true;
     }
 
+    /**
+     * Creates a copy of this descriptor.
+     *
+     * @return a copy of this descriptor
+     */
     public MethodDescriptor getCopy() {
         MethodDescriptor copy = new MethodDescriptor(method, methodName, className, inputParameterMatchers);
         copy.counter = this.counter;
@@ -205,6 +215,13 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
         return method.getNumParameters();
     }
 
+    /**
+     * Executes the matcher for the parameter at the given index.
+     *
+     * @param i the index of the parameter
+     * @return the result of the matcher execution
+     * @throws IllegalArgumentException if the index is invalid
+     */
     public Object executeMatcher(int i) throws IllegalArgumentException {
         if (i < 0 || i >= getNumberOfInputParameters()) {
             throw new IllegalArgumentException("Invalid index: " + i);
@@ -246,13 +263,24 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
                 return Mockito.nullable(type);
             }
         } catch (Exception e) {
-            logger.error("Failed to executed Mockito matcher n{} of type {} in {}.{}: {}", i, type, className, methodName, e.getMessage());
+            logger.error("Failed to executed Mockito matcher n{} of type {} in {}.{}: {}",
+                    i, type, className, methodName, e.getMessage());
             throw new EvosuiteError(e);
         }
     }
 
-    @Deprecated // better (more precise results) to use the other constructor
-    public MethodDescriptor(String className, String methodName, String inputParameterMatchers) throws IllegalArgumentException {
+    /**
+     * Constructor.
+     *
+     * @param className              the class name
+     * @param methodName             the method name
+     * @param inputParameterMatchers the matchers string
+     * @throws IllegalArgumentException if arguments are invalid
+     * @deprecated better (more precise results) to use the other constructor
+     */
+    @Deprecated
+    public MethodDescriptor(String className, String methodName,
+                            String inputParameterMatchers) throws IllegalArgumentException {
         Inputs.checkNull(methodName, inputParameterMatchers);
         this.className = className;
         this.methodName = methodName;
@@ -285,6 +313,11 @@ public class MethodDescriptor implements Comparable<MethodDescriptor>, Serializa
         return inputParameterMatchers;
     }
 
+    /**
+     * Gets the ID.
+     *
+     * @return the ID
+     */
     public String getID() {
         if (id == null) {
             id = className + "." + getMethodName() + "#" + getInputParameterMatchers();

--- a/client/src/main/java/org/evosuite/testcase/fm/SpecifiedValuesAnswer.java
+++ b/client/src/main/java/org/evosuite/testcase/fm/SpecifiedValuesAnswer.java
@@ -27,8 +27,7 @@ import org.mockito.stubbing.Answer;
  * specified each time an answer is queried.
  * If there are more queries than values, the last value will be returned.
  *
- * <p>
- * Created by Andrea Arcuri on 27/07/15.
+ * <p>Created by Andrea Arcuri on 27/07/15.
  */
 @Deprecated // there is easier way to do it in Mockito, ie "Stubbing consecutive calls (iterator-style stubbing)"
 public class SpecifiedValuesAnswer<T> implements Answer<T> {


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.testcase.fm` package in the `client` module.

Changes include:
- `SpecifiedValuesAnswer.java`: Fixed `<p>` tag placement in Javadoc.
- `EvoAbstractMethodInvocationListener.java`: Changed license header from `/**` to `/*` to fix Javadoc parsing error.
- `MethodDescriptor.java`:
    - Wrapped logical operators (`||`) to the start of new lines.
    - Added meaningful Javadoc for public methods (`changeClassLoader`, `getCopy`, `executeMatcher`, `getID`) and the deprecated constructor.
    - Fixed line length violations.
- `EvoInvocationListener.java`:
    - Fixed `<p>` tag placement in class Javadoc.
    - Added Javadoc for `changeClassLoader`.
    - Corrected indentation of block comments.

Ran `mvn -pl client checkstyle:check` to verify no violations remain in the package.
Ran `mvn -pl client test -Dtest=EvoInvocationListenerTest,MethodDescriptorTest,SpecifiedValuesAnswerTest` to ensure no regressions.

---
*PR created automatically by Jules for task [4466404103536151014](https://jules.google.com/task/4466404103536151014) started by @gofraser*