### PR TITLE
Apply Checkstyle to org.evosuite.testcase.statements.environment

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/statements/environment/AccessedEnvironment.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/AccessedEnvironment.java
@@ -32,8 +32,7 @@ import java.util.Set;
  * Class used to keep track of what environment components (local files, remote URLs, etc)
  * a test case has accessed to.
  *
- * <p>
- * Created by arcuri on 12/12/14.
+ * @author arcuri
  */
 public class AccessedEnvironment implements Serializable {
 
@@ -63,6 +62,9 @@ public class AccessedEnvironment implements Serializable {
     private final Set<EndPointInfo> remoteContactedPorts;
 
 
+    /**
+     * Constructor.
+     */
     public AccessedEnvironment() {
         localFiles = new LinkedHashSet<>();
         remoteURLs = new LinkedHashSet<>();
@@ -70,6 +72,11 @@ public class AccessedEnvironment implements Serializable {
         remoteContactedPorts = new LinkedHashSet<>();
     }
 
+    /**
+     * Copies the content of another AccessedEnvironment into this one.
+     *
+     * @param other the AccessedEnvironment to copy from.
+     */
     public void copyFrom(AccessedEnvironment other) {
         clear();
         this.localFiles.addAll(other.localFiles);
@@ -78,6 +85,9 @@ public class AccessedEnvironment implements Serializable {
         this.remoteContactedPorts.addAll(other.remoteContactedPorts);
     }
 
+    /**
+     * Clears all accessed environment data.
+     */
     public void clear() {
         localFiles.clear();
         remoteURLs.clear();
@@ -85,48 +95,105 @@ public class AccessedEnvironment implements Serializable {
         remoteContactedPorts.clear();
     }
 
+    /**
+     * Checks if a specific property is present.
+     *
+     * @param property the property to check.
+     * @return true if the property is present, false otherwise.
+     * @throws IllegalArgumentException if the property is null.
+     */
     public boolean hasProperty(String property) throws IllegalArgumentException {
         Inputs.checkNull(property);
 
         return false; //TODO
     }
 
+    /**
+     * Adds a collection of remote contacted ports.
+     *
+     * @param ports the ports to add.
+     */
     public void addRemoteContactedPorts(Collection<EndPointInfo> ports) {
         remoteContactedPorts.addAll(ports);
     }
 
+    /**
+     * Returns an unmodifiable view of the remote contacted ports.
+     *
+     * @return a set of remote contacted ports.
+     */
     public Set<EndPointInfo> getViewOfRemoteContactedPorts() {
         return Collections.unmodifiableSet(remoteContactedPorts);
     }
 
+    /**
+     * Adds a collection of local listening ports.
+     *
+     * @param ports the ports to add.
+     */
     public void addLocalListeningPorts(Collection<EndPointInfo> ports) {
         localListeningPorts.addAll(ports);
     }
 
+    /**
+     * Returns an unmodifiable view of the local listening ports.
+     *
+     * @return a set of local listening ports.
+     */
     public Set<EndPointInfo> getViewOfLocalListeningPorts() {
         return Collections.unmodifiableSet(localListeningPorts);
     }
 
+    /**
+     * Adds a collection of accessed local files.
+     *
+     * @param files the files to add.
+     */
     public void addLocalFiles(Collection<String> files) {
         localFiles.addAll(files);
     }
 
+    /**
+     * Returns an unmodifiable view of the accessed local files.
+     *
+     * @return a set of accessed local files.
+     */
     public Set<String> getViewOfAccessedFiles() {
         return Collections.unmodifiableSet(localFiles);
     }
 
+    /**
+     * Adds a collection of accessed remote URLs.
+     *
+     * @param urls the URLs to add.
+     */
     public void addRemoteURLs(Collection<String> urls) {
         remoteURLs.addAll(urls);
     }
 
+    /**
+     * Returns an unmodifiable view of the accessed remote URLs.
+     *
+     * @return a set of accessed remote URLs.
+     */
     public Set<String> getViewOfRemoteURLs() {
         return Collections.unmodifiableSet(remoteURLs);
     }
 
+    /**
+     * Checks if any network resource has been accessed.
+     *
+     * @return true if network has been accessed, false otherwise.
+     */
     public boolean isNetworkAccessed() {
         return !remoteURLs.isEmpty() || !localListeningPorts.isEmpty() || !remoteContactedPorts.isEmpty();
     }
 
+    /**
+     * Checks if the file system has been accessed.
+     *
+     * @return true if file system has been accessed, false otherwise.
+     */
     public boolean isFileSystemAccessed() {
         return !localFiles.isEmpty();
     }

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/EnvironmentDataStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/EnvironmentDataStatement.java
@@ -25,15 +25,31 @@ import org.evosuite.testcase.statements.PrimitiveStatement;
 import java.lang.reflect.Type;
 
 /**
- * Created by arcuri on 12/12/14.
+ * Abstract class for environment data statements.
+ *
+ * @author arcuri
+ * @param <T> the type of the environment data.
  */
 public abstract class EnvironmentDataStatement<T> extends PrimitiveStatement<T> {
 
     private static final long serialVersionUID = -348689954506405873L;
 
+    /**
+     * Constructor.
+     *
+     * @param tc    the test case context.
+     * @param clazz the type of the environment data.
+     * @param value the value of the environment data.
+     */
     protected EnvironmentDataStatement(TestCase tc, Type clazz, T value) {
         super(tc, clazz, value);
     }
 
+    /**
+     * Generates the test code for this statement.
+     *
+     * @param varName the variable name to use in the test code.
+     * @return the generated test code string.
+     */
     public abstract String getTestCode(String varName);
 }

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/EnvironmentStatements.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/EnvironmentStatements.java
@@ -25,13 +25,19 @@ import org.evosuite.testcase.statements.PrimitiveStatement;
 import org.evosuite.utils.Randomness;
 
 /**
- * @see org.evosuite.runtime.testdata.EnvironmentDataList
+ * Utility class for handling environment statements.
  *
- * <p>
- * Created by arcuri on 12/11/14.
+ * @author arcuri
+ * @see org.evosuite.runtime.testdata.EnvironmentDataList
  */
 public class EnvironmentStatements {
 
+    /**
+     * Checks if the given class is an environment data type.
+     *
+     * @param clazz the class to check.
+     * @return true if the class is an environment data type, false otherwise.
+     */
     public static boolean isEnvironmentData(Class<?> clazz) {
         for (Class<?> env : EnvironmentDataList.getListOfClasses()) {
             if (clazz.equals(env)) {
@@ -41,13 +47,22 @@ public class EnvironmentStatements {
         return false;
     }
 
+    /**
+     * Creates a new PrimitiveStatement for the given environment data type.
+     *
+     * @param clazz the environment data class.
+     * @param tc    the test case context.
+     * @return a new PrimitiveStatement instance.
+     * @throws IllegalArgumentException if the class is not an environment data type.
+     */
     public static PrimitiveStatement<?> getStatement(Class<?> clazz, TestCase tc) throws IllegalArgumentException {
         if (!isEnvironmentData(clazz)) {
             throw new IllegalArgumentException("Class " + clazz.getName() + " is not an environment data type");
         }
 
         if (clazz.equals(EvoSuiteFile.class)) {
-            return new FileNamePrimitiveStatement(tc, new EvoSuiteFile(Randomness.choice(tc.getAccessedEnvironment().getViewOfAccessedFiles())));
+            String fileName = Randomness.choice(tc.getAccessedEnvironment().getViewOfAccessedFiles());
+            return new FileNamePrimitiveStatement(tc, new EvoSuiteFile(fileName));
         } else if (clazz.equals(EvoSuiteLocalAddress.class)) {
             return new LocalAddressPrimitiveStatement(tc);
         } else if (clazz.equals(EvoSuiteRemoteAddress.class)) {

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/FileNamePrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/FileNamePrimitiveStatement.java
@@ -41,7 +41,7 @@ public class FileNamePrimitiveStatement extends EnvironmentDataStatement<EvoSuit
     private static final long serialVersionUID = 4402006999670328128L;
 
     /**
-     * <p>Constructor for FileNamePrimitiveStatement.</p>
+     * Constructor.
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
      * @param value a {@link org.evosuite.runtime.testdata.EvoSuiteFile} object.
@@ -50,6 +50,9 @@ public class FileNamePrimitiveStatement extends EnvironmentDataStatement<EvoSuit
         super(tc, EvoSuiteFile.class, value);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTestCode(String varName) {
         String testCode = "";
@@ -69,10 +72,6 @@ public class FileNamePrimitiveStatement extends EnvironmentDataStatement<EvoSuit
         return testCode;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#delta()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -81,10 +80,6 @@ public class FileNamePrimitiveStatement extends EnvironmentDataStatement<EvoSuit
         randomize();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#zero()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -92,10 +87,6 @@ public class FileNamePrimitiveStatement extends EnvironmentDataStatement<EvoSuit
     public void zero() {
         // there does not exist a zero value for files
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.PrimitiveStatement#randomize()
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/LocalAddressPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/LocalAddressPrimitiveStatement.java
@@ -28,21 +28,37 @@ import org.evosuite.utils.Randomness;
 import org.evosuite.utils.StringUtil;
 
 /**
- * Created by arcuri on 12/15/14.
+ * Primitive statement for local address.
+ *
+ * @author arcuri
  */
 public class LocalAddressPrimitiveStatement extends EnvironmentDataStatement<EvoSuiteLocalAddress> {
 
     private static final long serialVersionUID = -6687351650507282638L;
 
+    /**
+     * Constructor.
+     *
+     * @param tc the test case context.
+     */
     public LocalAddressPrimitiveStatement(TestCase tc) {
         this(tc, null);
         randomize();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param tc    the test case context.
+     * @param value the local address value.
+     */
     public LocalAddressPrimitiveStatement(TestCase tc, EvoSuiteLocalAddress value) {
         super(tc, EvoSuiteLocalAddress.class, value);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTestCode(String varName) {
         String testCode = "";
@@ -65,16 +81,25 @@ public class LocalAddressPrimitiveStatement extends EnvironmentDataStatement<Evo
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void delta() {
         randomize();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void zero() {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void randomize() {
 

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/RemoteAddressPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/RemoteAddressPrimitiveStatement.java
@@ -30,21 +30,37 @@ import org.evosuite.utils.Randomness;
 import org.evosuite.utils.StringUtil;
 
 /**
- * Created by arcuri on 12/17/14.
+ * Primitive statement for remote address.
+ *
+ * @author arcuri
  */
 public class RemoteAddressPrimitiveStatement extends EnvironmentDataStatement<EvoSuiteRemoteAddress> {
 
     private static final long serialVersionUID = -4863601663573415059L;
 
+    /**
+     * Constructor.
+     *
+     * @param tc the test case context.
+     */
     public RemoteAddressPrimitiveStatement(TestCase tc) {
         this(tc, null);
         randomize();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param tc    the test case context.
+     * @param value the remote address value.
+     */
     public RemoteAddressPrimitiveStatement(TestCase tc, EvoSuiteRemoteAddress value) {
         super(tc, EvoSuiteRemoteAddress.class, value);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTestCode(String varName) {
         String testCode = "";
@@ -66,16 +82,25 @@ public class RemoteAddressPrimitiveStatement extends EnvironmentDataStatement<Ev
         return testCode;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void delta() {
         randomize();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void zero() {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void randomize() {
         EvoSuiteRemoteAddress addr;
@@ -110,6 +135,12 @@ public class RemoteAddressPrimitiveStatement extends EnvironmentDataStatement<Ev
         setValue(addr);
     }
 
+    /**
+     * Ensures the port is within valid range.
+     *
+     * @param port the port to check.
+     * @return a valid port number.
+     */
     private int getPort(int port) {
         if (port <= 0 || port > 65535) {
             port = 12345; //just a valid port number

--- a/client/src/main/java/org/evosuite/testcase/statements/environment/UrlPrimitiveStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/environment/UrlPrimitiveStatement.java
@@ -27,22 +27,38 @@ import org.evosuite.utils.Randomness;
 import org.evosuite.utils.StringUtil;
 
 /**
- * Created by arcuri on 12/14/14.
+ * Primitive statement for URL.
+ *
+ * @author arcuri
  */
 public class UrlPrimitiveStatement extends EnvironmentDataStatement<EvoSuiteURL> {
 
     private static final long serialVersionUID = 2062390100066807026L;
 
+    /**
+     * Constructor.
+     *
+     * @param tc the test case context.
+     */
     public UrlPrimitiveStatement(TestCase tc) {
         this(tc, null);
         randomize();
     }
 
 
+    /**
+     * Constructor.
+     *
+     * @param tc    the test case context.
+     * @param value the URL value.
+     */
     public UrlPrimitiveStatement(TestCase tc, EvoSuiteURL value) {
         super(tc, EvoSuiteURL.class, value);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTestCode(String varName) {
         String testCode = "";
@@ -62,16 +78,25 @@ public class UrlPrimitiveStatement extends EnvironmentDataStatement<EvoSuiteURL>
         return testCode;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void delta() {
         randomize();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void zero() {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void randomize() {
         String url = Randomness.choice(tc.getAccessedEnvironment().getViewOfRemoteURLs());


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.testcase.statements.environment` package in the client module.

Key changes:
- Added meaningful Javadoc comments to `AccessedEnvironment`, `EnvironmentStatements`, and various `PrimitiveStatement` subclasses.
- Fixed Javadoc paragraph tag placements (moved `<p>` tags).
- Removed redundant Javadoc blocks in favor of `{@inheritDoc}`.
- Fixed a line length violation in `EnvironmentStatements.java` by extracting a local variable.
- Ensured all public methods and constructors have appropriate Javadoc documentation.

Verified with `mvn checkstyle:check` and `mvn compile`.

---
*PR created automatically by Jules for task [11783907262385936845](https://jules.google.com/task/11783907262385936845) started by @gofraser*