### PR TITLE
Apply checkstyle to org.evosuite.testcase.execution package

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionObserver.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionObserver.java
@@ -48,12 +48,10 @@ public abstract class ExecutionObserver {
                     Void.class));
 
     /**
-     * <p>
-     * isWrapperType.
-     * </p>
+     * Checks if the given class is a wrapper type.
      *
-     * @param clazz a {@link java.lang.Class} object.
-     * @return a boolean.
+     * @param clazz a {@link java.lang.Class} object to check.
+     * @return true if the class is a wrapper type, false otherwise.
      */
     protected static boolean isWrapperType(Class<?> clazz) {
         return WRAPPER_TYPES.contains(clazz);
@@ -105,6 +103,9 @@ public abstract class ExecutionObserver {
 
     /**
      * Allow observers to update the execution result at the end the execution of a test.
+     *
+     * @param r the execution result.
+     * @param s the scope of execution.
      */
     public abstract void testExecutionFinished(ExecutionResult r, Scope s);
 

--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionResult.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionResult.java
@@ -381,6 +381,11 @@ public class ExecutionResult implements Cloneable {
         return hasSecurityException;
     }
 
+    /**
+     * Sets whether a security exception occurred.
+     *
+     * @param value true if a security exception occurred.
+     */
     public void setSecurityException(boolean value) {
         logger.debug("Changing hasSecurityException from " + hasSecurityException + " to " + value);
         hasSecurityException = value;
@@ -435,38 +440,83 @@ public class ExecutionResult implements Cloneable {
         return "Trace:" + trace;
     }
 
+    /**
+     * Gets the set of system properties read during test execution.
+     *
+     * @return a {@link java.util.Set} of read system properties.
+     */
     public Set<String> getReadProperties() {
         return readProperties;
     }
 
+    /**
+     * Sets the set of system properties read during test execution.
+     *
+     * @param readProperties a {@link java.util.Set} of read system properties.
+     */
     public void setReadProperties(Set<String> readProperties) {
         this.readProperties = readProperties;
     }
 
+    /**
+     * Checks if any system property was written during test execution.
+     *
+     * @return true if any system property was written, false otherwise.
+     */
     public boolean wasAnyPropertyWritten() {
         return wasAnyPropertyWritten;
     }
 
+    /**
+     * Sets whether any system property was written during test execution.
+     *
+     * @param wasAnyPropertyWritten true if any system property was written.
+     */
     public void setWasAnyPropertyWritten(boolean wasAnyPropertyWritten) {
         this.wasAnyPropertyWritten = wasAnyPropertyWritten;
     }
 
+    /**
+     * Sets the test case that produced this result.
+     *
+     * @param tc the {@link org.evosuite.testcase.TestCase}.
+     */
     public void setTest(TestCase tc) {
         this.test = tc;
     }
 
+    /**
+     * Sets the covered input goals.
+     *
+     * @param coveredGoals a map of statement index to set of covered input goals.
+     */
     public void setInputGoals(Map<Integer, Set<InputCoverageGoal>> coveredGoals) {
         inputGoals.putAll(coveredGoals);
     }
 
+    /**
+     * Sets the covered output goals.
+     *
+     * @param coveredGoals a map of statement index to set of covered output goals.
+     */
     public void setOutputGoals(Map<Integer, Set<OutputCoverageGoal>> coveredGoals) {
         outputGoals.putAll(coveredGoals);
     }
 
+    /**
+     * Gets the covered input goals.
+     *
+     * @return a map of statement index to set of covered input goals.
+     */
     public Map<Integer, Set<InputCoverageGoal>> getInputGoals() {
         return inputGoals;
     }
 
+    /**
+     * Gets the covered output goals.
+     *
+     * @return a map of statement index to set of covered output goals.
+     */
     public Map<Integer, Set<OutputCoverageGoal>> getOutputGoals() {
         return outputGoals;
     }
@@ -489,6 +539,11 @@ public class ExecutionResult implements Cloneable {
         return Collections.unmodifiableList(this.featureVectors);
     }
 
+    /**
+     * Gets the map of explicit exceptions.
+     *
+     * @return a {@link java.util.Map} of explicit exceptions.
+     */
     public Map<Integer, Boolean> getExplicitExceptions() {
         return explicitExceptions;
     }

--- a/client/src/main/java/org/evosuite/testcase/execution/MethodCall.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/MethodCall.java
@@ -17,16 +17,16 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * <p>MethodCall class.</p>
- *
- * @author Gordon Fraser
- */
 package org.evosuite.testcase.execution;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Represents a method call in an execution trace.
+ *
+ * @author Gordon Fraser
+ */
 public class MethodCall implements Cloneable {
     public String className;
     public String methodName;

--- a/client/src/main/java/org/evosuite/testcase/execution/TestCaseExecutor.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/TestCaseExecutor.java
@@ -238,6 +238,11 @@ public class TestCaseExecutor implements ThreadFactory {
         observers = new LinkedHashSet<>();
     }
 
+    /**
+     * Returns a copy of the current set of execution observers.
+     *
+     * @return a {@link java.util.Set} object containing the execution observers.
+     */
     public Set<ExecutionObserver> getExecutionObservers() {
         return new LinkedHashSet<>(observers);
     }
@@ -545,6 +550,11 @@ public class TestCaseExecutor implements ThreadFactory {
         return currentThread;
     }
 
+    /**
+     * Sets the execution observers.
+     *
+     * @param observers a {@link java.util.Set} of {@link org.evosuite.testcase.execution.ExecutionObserver} objects.
+     */
     public void setExecutionObservers(Set<ExecutionObserver> observers) {
         this.observers = observers;
     }


### PR DESCRIPTION
This PR applies Checkstyle fixes and improvements to the `org.evosuite.testcase.execution` package.

Changes:
1.  **MethodCall.java**: Moved the class Javadoc block from before the `package` declaration to its correct position before the `public class` definition.
2.  **TestCaseExecutor.java**: Added meaningful Javadocs to `getExecutionObservers` and `setExecutionObservers`.
3.  **ExecutionObserver.java**: Added meaningful Javadocs to `isWrapperType` and `testExecutionFinished`.
4.  **ExecutionResult.java**: Added meaningful Javadocs to several public methods including getters/setters for system properties, security exceptions, explicit exceptions, and coverage goals.

The changes ensure better code documentation and compliance with standard Javadoc practices, even where Checkstyle might not explicitly flag issues due to configuration thresholds (e.g. `minLineCount`). No methods were renamed.

---
*PR created automatically by Jules for task [14630505725175400707](https://jules.google.com/task/14630505725175400707) started by @gofraser*