### PR TITLE
Fix checkstyle issues in RegExpVisitor.java

### DIFF
--- a/client/src/main/java/dk/brics/automaton/RegExpVisitor.java
+++ b/client/src/main/java/dk/brics/automaton/RegExpVisitor.java
@@ -1,14 +1,21 @@
 package dk.brics.automaton;
 
-/*
+/**
  * This class is not in the org.evosuite package,
  * as it has to access package level variables and classes in the
- * dk.brics.automaton package
+ * dk.brics.automaton package.
  *
+ * @param <K> The return type of the visitor.
  */
-
 public abstract class RegExpVisitor<K> {
 
+    /**
+     * Visits a regular expression.
+     *
+     * @param e The regular expression to visit.
+     * @return The result of the visit.
+     * @throws IllegalArgumentException if the regular expression kind is unsupported.
+     */
     public final K visitRegExp(RegExp e) {
         switch (e.kind) {
             case REGEXP_ANYCHAR: {
@@ -61,7 +68,7 @@ public abstract class RegExpVisitor<K> {
             }
             default:
                 throw new IllegalArgumentException(
-                        "Unsupported kind ogf regular expression " + e.kind);
+                        "Unsupported kind of regular expression " + e.kind);
         }
     }
 


### PR DESCRIPTION
Applied checkstyle fixes to `client/src/main/java/dk/brics/automaton/RegExpVisitor.java`.
Specifically:
1. Converted the existing block comment explaining the package placement to a class-level Javadoc with `@param <K>`.
2. Added meaningful Javadoc to `visitRegExp(RegExp e)`, documenting the parameter, return value, and the thrown exception.
3. Fixed a typo in the `IllegalArgumentException` message: "Unsupported kind ogf regular expression" -> "Unsupported kind of regular expression".

Verified with `mvn checkstyle:check` (0 violations) and `mvn compile` (success). Run `DefaultTestCaseTest` to ensure basic client functionality.

---
*PR created automatically by Jules for task [16613571397383884866](https://jules.google.com/task/16613571397383884866) started by @gofraser*