### PR TITLE
Fix Checkstyle issues in org.evosuite.testcase.variable

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/variable/ArrayIndex.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/ArrayIndex.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import com.googlecode.gentyref.GenericTypeReflector;
@@ -66,9 +67,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Constructor for ArrayIndex.
-     * </p>
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param array    a {@link ArrayReference} object.
@@ -92,9 +91,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Getter for the field <code>array</code>.
-     * </p>
      *
      * @return a {@link ArrayReference} object.
      */
@@ -103,9 +100,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Setter for the field <code>array</code>.
-     * </p>
      *
      * @param r a {@link ArrayReference} object.
      */
@@ -123,9 +118,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
-     * getArrayIndex
-     * </p>
+     * getArrayIndex.
      *
      * @return a int.
      */
@@ -135,9 +128,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
-     * setArrayIndex
-     * </p>
+     * setArrayIndex.
      *
      * @param index a int.
      */
@@ -158,7 +149,8 @@ public class ArrayIndex extends VariableReferenceImpl {
             }
         }
 
-        //notice that this case is only reached if no AssignmentStatement was used to assign to the array index (as in that case the for loop would have found something)
+        //notice that this case is only reached if no AssignmentStatement was used to assign to the array index
+        // (as in that case the for loop would have found something)
         //Therefore the array must have been assigned in some method and we can return the method call
 
         return array.getStPosition();
@@ -167,8 +159,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return name for source code representation
+     * <p>Return name for source code representation
      */
     @Override
     public String getName() {
@@ -241,8 +232,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return the actual object represented by this variable for a given scope
+     * <p>Return the actual object represented by this variable for a given scope
      */
     @Override
     public Object getObject(Scope scope) throws CodeUnderTestException {
@@ -270,8 +260,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return ((Number) object).intValue();
         } else if (object instanceof Character) {
             return (int) (Character) object;
-        } else
-             {
+        } else {
             return 0;
         }
     }
@@ -283,8 +272,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return (short) ((Number) object).intValue();
         } else if (object instanceof Character) {
             return (short) ((Character) object).charValue();
-        } else
-             {
+        } else {
             return 0;
         }
     }
@@ -296,8 +284,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return (byte) ((Number) object).intValue();
         } else if (object instanceof Character) {
             return (byte) ((Character) object).charValue();
-        } else
-             {
+        } else {
             return 0;
         }
     }
@@ -309,8 +296,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return ((Number) object).longValue();
         } else if (object instanceof Character) {
             return (long) (Character) object;
-        } else
-             {
+        } else {
             return 0L;
         }
     }
@@ -322,8 +308,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return ((Number) object).floatValue();
         } else if (object instanceof Character) {
             return (float) (Character) object;
-        } else
-             {
+        } else {
             return 0F;
         }
     }
@@ -335,8 +320,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return ((Number) object).doubleValue();
         } else if (object instanceof Character) {
             return (double) (Character) object;
-        } else
-             {
+        } else {
             return 0.0;
         }
     }
@@ -348,8 +332,7 @@ public class ArrayIndex extends VariableReferenceImpl {
             return (Character) object;
         } else if (object instanceof Number) {
             return (char) ((Number) object).intValue();
-        } else
-             {
+        } else {
             return '0';
         }
     }
@@ -357,8 +340,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Set the actual object represented by this variable in a given scope
+     * <p>Set the actual object represented by this variable in a given scope
      */
     @Override
     public void setObject(Scope scope, Object value) throws CodeUnderTestException {
@@ -376,83 +358,44 @@ public class ArrayIndex extends VariableReferenceImpl {
             if (value == null && arrayObject.getClass().getComponentType().isPrimitive()) {
                 throw new CodeUnderTestException(new NullPointerException());
             }
-            if (arrayObject.getClass().getComponentType().equals(int.class)) {
-                Array.setInt(arrayObject, indices.get(indices.size() - 1),
-                        getIntValue(value));
-            } else  {
-                if (arrayObject.getClass().getComponentType().equals(boolean.class))
-                Array.setBoolean(arrayObject, indices.get(indices.size() - 1),
-                        (Boolean) value);
-            else if (arrayObject.getClass().getComponentType().equals(char.class)) {
-                Array.setChar(arrayObject, indices.get(indices.size() - 1),
-                        getCharValue(value));
-            } else  {
-                if (arrayObject.getClass().getComponentType().equals(double.class))
-                Array.setDouble(arrayObject, indices.get(indices.size() - 1),
-                        getDoubleValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(float.class))
-                Array.setFloat(arrayObject, indices.get(indices.size() - 1),
-                        getFloatValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(long.class))
-                Array.setLong(arrayObject, indices.get(indices.size() - 1),
-                        getLongValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(short.class))
-                Array.setShort(arrayObject, indices.get(indices.size() - 1),
-                        getShortValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(byte.class))
-                Array.setByte(arrayObject, indices.get(indices.size() - 1),
-                        getByteValue(value));
-                // We also need to check if we are assigning to a wrapper type, because autoboxing
-                // only seems to work from int -> Integer, but e.g. not from byte -> Integer
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Integer.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getIntValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Boolean.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1), value);
-            else if (arrayObject.getClass().getComponentType().equals(Character.class)) {
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getCharValue(value));
-            } else  {
-                if (arrayObject.getClass().getComponentType().equals(Double.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getDoubleValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Float.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getFloatValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Long.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getLongValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Short.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getShortValue(value));
-            else  {
-                if (arrayObject.getClass().getComponentType().equals(Byte.class))
-                Array.set(arrayObject, indices.get(indices.size() - 1),
-                        getByteValue(value));
-            else {
-                Array.set(arrayObject, indices.get(indices.size() - 1), value);
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
-            }
+
+            Class<?> componentType = arrayObject.getClass().getComponentType();
+            int lastIndex = indices.get(indices.size() - 1);
+
+            if (componentType.equals(int.class)) {
+                Array.setInt(arrayObject, lastIndex, getIntValue(value));
+            } else if (componentType.equals(boolean.class)) {
+                Array.setBoolean(arrayObject, lastIndex, (Boolean) value);
+            } else if (componentType.equals(char.class)) {
+                Array.setChar(arrayObject, lastIndex, getCharValue(value));
+            } else if (componentType.equals(double.class)) {
+                Array.setDouble(arrayObject, lastIndex, getDoubleValue(value));
+            } else if (componentType.equals(float.class)) {
+                Array.setFloat(arrayObject, lastIndex, getFloatValue(value));
+            } else if (componentType.equals(long.class)) {
+                Array.setLong(arrayObject, lastIndex, getLongValue(value));
+            } else if (componentType.equals(short.class)) {
+                Array.setShort(arrayObject, lastIndex, getShortValue(value));
+            } else if (componentType.equals(byte.class)) {
+                Array.setByte(arrayObject, lastIndex, getByteValue(value));
+            } else if (componentType.equals(Integer.class)) {
+                Array.set(arrayObject, lastIndex, getIntValue(value));
+            } else if (componentType.equals(Boolean.class)) {
+                Array.set(arrayObject, lastIndex, value);
+            } else if (componentType.equals(Character.class)) {
+                Array.set(arrayObject, lastIndex, getCharValue(value));
+            } else if (componentType.equals(Double.class)) {
+                Array.set(arrayObject, lastIndex, getDoubleValue(value));
+            } else if (componentType.equals(Float.class)) {
+                Array.set(arrayObject, lastIndex, getFloatValue(value));
+            } else if (componentType.equals(Long.class)) {
+                Array.set(arrayObject, lastIndex, getLongValue(value));
+            } else if (componentType.equals(Short.class)) {
+                Array.set(arrayObject, lastIndex, getShortValue(value));
+            } else if (componentType.equals(Byte.class)) {
+                Array.set(arrayObject, lastIndex, getByteValue(value));
+            } else {
+                Array.set(arrayObject, lastIndex, value);
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             throw new CodeUnderTestException(e);
@@ -462,8 +405,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference copy(TestCase newTestCase, int offset) {
@@ -478,10 +420,6 @@ public class ArrayIndex extends VariableReferenceImpl {
         return new ArrayIndex(newTestCase, (ArrayReference) array.clone(newTestCase), indices);
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#getAdditionalVariableReference()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -489,15 +427,10 @@ public class ArrayIndex extends VariableReferenceImpl {
     public VariableReference getAdditionalVariableReference() {
         if (array.getAdditionalVariableReference() == null) {
             return array;
-        } else
-             {
+        } else {
             return array.getAdditionalVariableReference();
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#setAdditionalVariableReference(org.evosuite.testcase.VariableReference)
-     */
 
     /**
      * {@inheritDoc}
@@ -507,10 +440,6 @@ public class ArrayIndex extends VariableReferenceImpl {
         assert (var instanceof ArrayReference);
         array = (ArrayReference) var;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#replaceAdditionalVariableReference(org.evosuite.testcase.VariableReference, org.evosuite.testcase.VariableReference)
-     */
 
     /**
      * {@inheritDoc}
@@ -526,15 +455,10 @@ public class ArrayIndex extends VariableReferenceImpl {
             // but for this we have FieldStatements, which would give us
             // ArrayReferences.
             // Such a replacement should only happen as part of a graceful delete
-        } else
-             {
+        } else {
             array.replaceAdditionalVariableReference(var1, var2);
         }
     }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
 
     /**
      * {@inheritDoc}
@@ -549,10 +473,6 @@ public class ArrayIndex extends VariableReferenceImpl {
         result = prime * result + ((indices == null) ? 0 : indices.hashCode());
         return result;
     }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -573,17 +493,16 @@ public class ArrayIndex extends VariableReferenceImpl {
             if (other.array != null) {
                 return false;
             }
-        } else  {
-            if (!array.equals(other.array))
-            return false;
+        } else {
+            if (!array.equals(other.array)) {
+                return false;
+            }
         }
         return indices.equals(other.indices);
     }
 
     /**
-     * <p>
-     * setArrayIndices
-     * </p>
+     * setArrayIndices.
      *
      * @param indices a {@link java.util.List} object.
      */
@@ -595,9 +514,7 @@ public class ArrayIndex extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
-     * getArrayIndices
-     * </p>
+     * getArrayIndices.
      *
      * @return a {@link java.util.List} object.
      */

--- a/client/src/main/java/org/evosuite/testcase/variable/ArrayLengthSymbolicUtil.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/ArrayLengthSymbolicUtil.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import org.evosuite.Properties;
@@ -44,11 +45,12 @@ public class ArrayLengthSymbolicUtil {
     /**
      * Creates the expression for an array length.
      *
-     * @param length the length.
+     * @param length                  the length.
      * @param arraySymbolicLengthName the symbolic length name.
-     * @return .
+     * @return the array symbolic length expression.
      */
-    public static IntegerValue buildArraySymbolicLengthExpression(int length, ArraySymbolicLengthName arraySymbolicLengthName) {
+    public static IntegerValue buildArraySymbolicLengthExpression(int length,
+                                                                ArraySymbolicLengthName arraySymbolicLengthName) {
         IntegerValue lengthExpression;
 
         // If arrays support is enabled, we create the symbolic value
@@ -69,7 +71,7 @@ public class ArrayLengthSymbolicUtil {
     /**
      * Checks if support for symbolic arrays is enabled.
      *
-     * @return .
+     * @return true if enabled.
      */
     public static boolean isSymbolicArraysSupportEnabled() {
         return Properties.IS_DSE_ARRAYS_SUPPORT_ENABLED;

--- a/client/src/main/java/org/evosuite/testcase/variable/ArrayReference.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/ArrayReference.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -31,16 +32,12 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Summary.
- * @author Gordon Fraser
- */
-
-/**
  * Represents a reference to an array in the test case.
  *
- * <p>
- * Note: The array length is currently stored in both ArrayReference and ArrayStatement (if created by one).
+ * <p>Note: The array length is currently stored in both ArrayReference and ArrayStatement (if created by one).
  * This duplication should be addressed in future refactorings to avoid inconsistencies.
+ *
+ * @author Gordon Fraser
  */
 public class ArrayReference extends VariableReferenceImpl {
 
@@ -49,9 +46,7 @@ public class ArrayReference extends VariableReferenceImpl {
     private int[] lengths;
 
     /**
-     * <p>
      * Constructor for ArrayReference.
-     * </p>
      *
      * @param tc    a {@link org.evosuite.testcase.TestCase} object.
      * @param clazz a {@link java.lang.Class} object.
@@ -62,9 +57,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Constructor for ArrayReference.
-     * </p>
      *
      * @param tc      a {@link org.evosuite.testcase.TestCase} object.
      * @param clazz   a {@link GenericClass} object.
@@ -77,22 +70,18 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Constructor for ArrayReference.
-     * </p>
      *
-     * @param tc           a {@link org.evosuite.testcase.TestCase} object.
-     * @param clazz        a {@link GenericClass} object.
-     * @param array_length a int.
+     * @param tc          a {@link org.evosuite.testcase.TestCase} object.
+     * @param clazz       a {@link GenericClass} object.
+     * @param arrayLength a int.
      */
-    public ArrayReference(TestCase tc, GenericClass<?> clazz, int array_length) {
-        this(tc, clazz, new int[]{array_length});
+    public ArrayReference(TestCase tc, GenericClass<?> clazz, int arrayLength) {
+        this(tc, clazz, new int[]{arrayLength});
     }
 
     /**
-     * <p>
-     * getArrayLength
-     * </p>
+     * getArrayLength.
      *
      * @return a int.
      */
@@ -101,9 +90,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
-     * setArrayLength
-     * </p>
+     * setArrayLength.
      *
      * @param l a int.
      */
@@ -113,9 +100,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Getter for the field <code>lengths</code>.
-     * </p>
      *
      * @return an array of int.
      */
@@ -124,9 +109,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Setter for the field <code>lengths</code>.
-     * </p>
      *
      * @param lengths an array of int.
      */
@@ -138,9 +121,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Setter for an element of the field <code>lengths</code>.
-     * </p>
      *
      * @param length an int
      * @param index  an int
@@ -152,8 +133,7 @@ public class ArrayReference extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference copy(TestCase newTestCase, int offset) {
@@ -163,7 +143,6 @@ public class ArrayReference extends VariableReferenceImpl {
             otherArray.setLengths(lengths);
             return otherArray;
         } else {
-
             // FIXME: This part should be redundant
 
             if (newRef.getComponentType() != null) {
@@ -181,9 +160,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
-     * getArrayDimensions
-     * </p>
+     * getArrayDimensions.
      *
      * @return a int.
      */
@@ -192,9 +169,7 @@ public class ArrayReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Setter for the field <code>lengths</code>.
-     * </p>
      *
      * @param lengths a {@link java.util.List} object.
      */
@@ -207,6 +182,11 @@ public class ArrayReference extends VariableReferenceImpl {
         }
     }
 
+    /**
+     * getMaximumIndex.
+     *
+     * @return a int.
+     */
     public int getMaximumIndex() {
         int max = 0;
 
@@ -223,10 +203,23 @@ public class ArrayReference extends VariableReferenceImpl {
         return max;
     }
 
+    /**
+     * isInitialized.
+     *
+     * @param index a int.
+     * @return a boolean.
+     */
     public boolean isInitialized(int index) {
         return isInitialized(index, testCase.size());
     }
 
+    /**
+     * isInitialized.
+     *
+     * @param index    a int.
+     * @param position a int.
+     * @return a boolean.
+     */
     public boolean isInitialized(int index, int position) {
         int pos = 0;
         for (Statement s : testCase) {

--- a/client/src/main/java/org/evosuite/testcase/variable/ArraySymbolicLengthName.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/ArraySymbolicLengthName.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 /**
@@ -26,14 +27,39 @@ package org.evosuite.testcase.variable;
  */
 public class ArraySymbolicLengthName {
 
+    /**
+     * Separator.
+     */
     public static final String ARRAY_LENGTH_NAME_SEPARATOR = "_";
+    /**
+     * Separator regex.
+     */
     public static final String ARRAY_LENGTH_NAME_SEPARATOR_REGEX = "\\_";
+    /**
+     * Suffix.
+     */
     public static final String ARRAY_LENGTH_SYMBOLIC_NAME_SUFFIX = "length";
-    public static final String ARRAY_LENGTH_SYMBOLIC_NAME_INVALID_FOR_NAME_EXCEPTION = "Array length symbolic name invalid for name: ";
+    /**
+     * Exception message.
+     */
+    public static final String ARRAY_LENGTH_SYMBOLIC_NAME_INVALID_FOR_NAME_EXCEPTION =
+            "Array length symbolic name invalid for name: ";
 
+    /**
+     * Sections amount.
+     */
     public static final int ARRAY_LENGTH_SYMBOLIC_NAME_SECTIONS_AMOUNT = 3;
+    /**
+     * Dimension position.
+     */
     public static final int ARRAY_LENGTH_SYMBOLIC_NAME_DIMENSION_POSITION = 2;
+    /**
+     * Array name position.
+     */
     public static final int ARRAY_LENGTH_SYMBOLIC_NAME_ARRAY_NAME_POSITION = 0;
+    /**
+     * Dimension tag position.
+     */
     public static final int ARRAY_LENGTH_SYMBOLIC_NAME_DIMENSION_TAG_POSITION = 1;
 
     private final int dimension;
@@ -41,6 +67,11 @@ public class ArraySymbolicLengthName {
     private final String arrayReferenceName;
     private final String symbolicName;
 
+    /**
+     * Constructor.
+     *
+     * @param symbolicName a {@link java.lang.String} object.
+     */
     public ArraySymbolicLengthName(String symbolicName) {
         if (!isArraySymbolicLengthVariableName(symbolicName)) {
             throw new IllegalArgumentException(ARRAY_LENGTH_SYMBOLIC_NAME_INVALID_FOR_NAME_EXCEPTION + symbolicName);
@@ -54,20 +85,41 @@ public class ArraySymbolicLengthName {
         this.symbolicName = symbolicName;
     }
 
+    /**
+     * Constructor.
+     *
+     * @param arrayReferenceName a {@link java.lang.String} object.
+     * @param dimension          a int.
+     */
     public ArraySymbolicLengthName(String arrayReferenceName, int dimension) {
         this.arrayReferenceName = arrayReferenceName;
         this.dimension = dimension;
         this.symbolicName = buildSymbolicLengthDimensionName(arrayReferenceName, dimension);
     }
 
+    /**
+     * Getter for the field <code>dimension</code>.
+     *
+     * @return a int.
+     */
     public int getDimension() {
         return dimension;
     }
 
+    /**
+     * Getter for the field <code>symbolicName</code>.
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getSymbolicName() {
         return symbolicName;
     }
 
+    /**
+     * Getter for the field <code>arrayReferenceName</code>.
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getArrayReferenceName() {
         return arrayReferenceName;
     }
@@ -76,8 +128,8 @@ public class ArraySymbolicLengthName {
      * Builds the name of an array length symbolic variable.
      *
      * @param arrayReferenceName the reference name.
-     * @param dimension the dimension.
-     * @return .
+     * @param dimension          the dimension.
+     * @return the symbolic name.
      */
     public static String buildSymbolicLengthDimensionName(String arrayReferenceName, int dimension) {
         return new StringBuilder()
@@ -93,12 +145,13 @@ public class ArraySymbolicLengthName {
      * Checks whether a symbolic variable name corresponds to an array's length.
      *
      * @param symbolicVariableName the symbolic variable name.
-     * @return .
+     * @return true if valid.
      */
     public static boolean isArraySymbolicLengthVariableName(String symbolicVariableName) {
         String[] nameSections = symbolicVariableName.split(ArraySymbolicLengthName.ARRAY_LENGTH_NAME_SEPARATOR_REGEX);
 
         return nameSections.length == ARRAY_LENGTH_SYMBOLIC_NAME_SECTIONS_AMOUNT
-                && nameSections[ARRAY_LENGTH_SYMBOLIC_NAME_DIMENSION_TAG_POSITION].equals(ARRAY_LENGTH_SYMBOLIC_NAME_SUFFIX);
+                && nameSections[ARRAY_LENGTH_SYMBOLIC_NAME_DIMENSION_TAG_POSITION]
+                .equals(ARRAY_LENGTH_SYMBOLIC_NAME_SUFFIX);
     }
 }

--- a/client/src/main/java/org/evosuite/testcase/variable/ConstantValue.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/ConstantValue.java
@@ -32,7 +32,7 @@ import java.lang.reflect.Type;
 
 
 /**
- * <p>ConstantValue class.</p>
+ * ConstantValue class.
  *
  * @author Gordon Fraser
  */
@@ -40,8 +40,10 @@ public class ConstantValue extends VariableReferenceImpl {
 
     private static final long serialVersionUID = -3760942087575495415L;
 
+    private Object value;
+
     /**
-     * <p>Constructor for ConstantValue.</p>
+     * Constructor for ConstantValue.
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param type     a {@link GenericClassImpl} object.
@@ -50,13 +52,20 @@ public class ConstantValue extends VariableReferenceImpl {
         super(testCase, type);
     }
 
+    /**
+     * Constructor for ConstantValue.
+     *
+     * @param testCase a {@link org.evosuite.testcase.TestCase} object.
+     * @param type     a {@link GenericClassImpl} object.
+     * @param value    a {@link java.lang.Object} object.
+     */
     public ConstantValue(TestCase testCase, GenericClass<?> type, Object value) {
         super(testCase, type);
         setValue(value);
     }
 
     /**
-     * <p>Constructor for ConstantValue.</p>
+     * Constructor for ConstantValue.
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param type     a {@link java.lang.reflect.Type} object.
@@ -68,8 +77,7 @@ public class ConstantValue extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference copy(TestCase newTestCase, int offset) {
@@ -78,6 +86,9 @@ public class ConstantValue extends VariableReferenceImpl {
         return ret;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public VariableReference clone(TestCase newTestCase) {
         Statement st = newTestCase.getStatement(getStPosition());
@@ -89,10 +100,8 @@ public class ConstantValue extends VariableReferenceImpl {
         throw new IllegalArgumentException("Constant value not defined in new test");
     }
 
-    private Object value;
-
     /**
-     * <p>Getter for the field <code>value</code>.</p>
+     * Getter for the field <code>value</code>.
      *
      * @return a {@link java.lang.Object} object.
      */
@@ -101,7 +110,7 @@ public class ConstantValue extends VariableReferenceImpl {
     }
 
     /**
-     * <p>Setter for the field <code>value</code>.</p>
+     * Setter for the field <code>value</code>.
      *
      * @param value a {@link java.lang.Object} object.
      */
@@ -112,8 +121,7 @@ public class ConstantValue extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * The position of the statement, defining this VariableReference, in the
+     * <p>The position of the statement, defining this VariableReference, in the
      * testcase.
      */
     @Override
@@ -131,8 +139,7 @@ public class ConstantValue extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return name for source code representation
+     * <p>Return name for source code representation
      */
     @Override
     public String getName() {
@@ -149,8 +156,7 @@ public class ConstantValue extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return the actual object represented by this variable for a given scope
+     * <p>Return the actual object represented by this variable for a given scope
      */
     @Override
     public Object getObject(Scope scope) {
@@ -173,15 +179,18 @@ public class ConstantValue extends VariableReferenceImpl {
         if (r instanceof ConstantValue) {
             ConstantValue v = (ConstantValue) r;
             if (this.value == null) {
-                return v.getValue() == null;
+                return v.value == null;
             } else {
-                return this.value.equals(v.getValue());
+                return this.value.equals(v.value);
             }
         }
 
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void changeClassLoader(ClassLoader loader) {
         super.changeClassLoader(loader);

--- a/client/src/main/java/org/evosuite/testcase/variable/FieldReference.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/FieldReference.java
@@ -34,9 +34,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- * <p>
  * FieldReference class.
- * </p>
  *
  * @author Gordon Fraser
  */
@@ -51,9 +49,7 @@ public class FieldReference extends VariableReferenceImpl {
     private VariableReference source;
 
     /**
-     * <p>
      * Constructor for FieldReference.
-     * </p>
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param field    a {@link java.lang.reflect.Field} object.
@@ -61,7 +57,9 @@ public class FieldReference extends VariableReferenceImpl {
      */
     public FieldReference(TestCase testCase, GenericField field, VariableReference source) {
         super(testCase, field.getFieldType());
-        assert (source != null || field.isStatic()) : "No source object was supplied, therefore we assumed the field to be static. However asking the field if it was static, returned false";
+        assert (source != null || field.isStatic()) : "No source object was supplied, "
+                + "therefore we assumed the field to be static. "
+                + "However asking the field if it was static, returned false";
         this.field = field;
         this.source = source;
     }
@@ -80,7 +78,9 @@ public class FieldReference extends VariableReferenceImpl {
                           VariableReference source) {
         super(testCase, fieldType);
         assert (field != null);
-        assert (source != null || field.isStatic()) : "No source object was supplied, therefore we assumed the field to be static. However asking the field if it was static, returned false";
+        assert (source != null || field.isStatic()) : "No source object was supplied, "
+                + "therefore we assumed the field to be static. "
+                + "However asking the field if it was static, returned false";
         this.field = field;
         this.source = source;
         assert (source == null || field.getField().getDeclaringClass().isAssignableFrom(source.getVariableClass()))
@@ -93,9 +93,7 @@ public class FieldReference extends VariableReferenceImpl {
     }
 
     /**
-     * <p>
      * Constructor for FieldReference.
-     * </p>
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param field    a {@link java.lang.reflect.Field} object.
@@ -142,8 +140,7 @@ public class FieldReference extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return the actual object represented by this variable for a given scope
+     * <p>Return the actual object represented by this variable for a given scope
      */
     @Override
     public Object getObject(Scope scope) throws CodeUnderTestException {
@@ -173,8 +170,7 @@ public class FieldReference extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Set the actual object represented by this variable in a given scope
+     * <p>Set the actual object represented by this variable in a given scope
      */
     @Override
     public void setObject(Scope scope, Object value) throws CodeUnderTestException {
@@ -189,14 +185,16 @@ public class FieldReference extends VariableReferenceImpl {
                      *    That means we can have a testcase
                      *  SomeObject var1 = null;
                      *  var1.someAttribute = test;
-                     *  and the testcase will execute in evosuite, executing it with junit will however lead to a nullpointer exception
+                     *  and the testcase will execute in evosuite, executing it with junit will however lead to a
+                     *  nullpointer exception
                      */
                     throw new CodeUnderTestException(new NullPointerException());
                 }
 
                 // TODO: It seems this is unavoidable based on the search operators
                 //       but maybe there is a better solution
-                if (!field.getField().getDeclaringClass().isAssignableFrom(sourceObject.getClass())) {
+                if (!field.getField().getDeclaringClass()
+                        .isAssignableFrom(sourceObject.getClass())) {
                     throw new CodeUnderTestException(new IllegalArgumentException(
                             "Cannot assignable: " + value + " of class "
                                     + value.getClass() + " to field " + field
@@ -210,7 +208,8 @@ public class FieldReference extends VariableReferenceImpl {
                     + value + " on object " + sourceObject + ": " + e, e);
             throw e;
         } catch (IllegalAccessException e) {
-            logger.error("Error while assigning field: " + field.getField().toString()
+            logger.error("Error while assigning field: "
+                    + field.getField().toString()
                     + " of type: " + field.getField().getType().getCanonicalName()
                     + " " + e, e);
             throw new EvosuiteError(e);
@@ -223,10 +222,6 @@ public class FieldReference extends VariableReferenceImpl {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#getAdditionalVariableReference()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -234,15 +229,10 @@ public class FieldReference extends VariableReferenceImpl {
     public VariableReference getAdditionalVariableReference() {
         if (source != null && source.getAdditionalVariableReference() != null) {
             return source.getAdditionalVariableReference();
-        } else
-             {
+        } else {
             return source;
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#setAdditionalVariableReference(org.evosuite.testcase.VariableReference)
-     */
 
     /**
      * {@inheritDoc}
@@ -257,10 +247,6 @@ public class FieldReference extends VariableReferenceImpl {
         }
         source = var;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#replaceAdditionalVariableReference(org.evosuite.testcase.VariableReference, org.evosuite.testcase.VariableReference)
-     */
 
     /**
      * {@inheritDoc}
@@ -277,8 +263,7 @@ public class FieldReference extends VariableReferenceImpl {
                     }
                 }
                 source = var2;
-            } else
-                 {
+            } else {
                 source.replaceAdditionalVariableReference(var1, var2);
             }
         }
@@ -303,22 +288,21 @@ public class FieldReference extends VariableReferenceImpl {
                 }
             }
             throw new AssertionError(
-                    "A VariableReference's position is only defined if the VariableReference is defined by a statement in the testCase.");
+                    "A VariableReference's position is only defined if the VariableReference is defined by a statement "
+                            + "in the testCase.");
         }
     }
 
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return name for source code representation
+     * <p>Return name for source code representation
      */
     @Override
     public String getName() {
         if (source != null) {
             return source.getName() + "." + field.getName();
-        } else
-             {
+        } else {
             return field.getOwnerClass().getSimpleName() + "." + field.getName();
         }
     }
@@ -332,14 +316,12 @@ public class FieldReference extends VariableReferenceImpl {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference copy(TestCase newTestCase, int offset) {
         Type fieldType = field.getFieldType();
         if (source != null) {
-            //            VariableReference otherSource = newTestCase.getStatement(source.getStPosition()).getReturnValue();
             VariableReference otherSource = source.copy(newTestCase, offset);
             return new FieldReference(newTestCase, field.copy(), fieldType, otherSource);
         } else {
@@ -366,10 +348,6 @@ public class FieldReference extends VariableReferenceImpl {
         return field.isAccessible();
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -381,10 +359,6 @@ public class FieldReference extends VariableReferenceImpl {
         result = prime * result + ((source == null) ? 0 : source.hashCode());
         return result;
     }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -405,13 +379,14 @@ public class FieldReference extends VariableReferenceImpl {
             if (other.field != null) {
                 return false;
             }
-        } else  {
-            if (!field.equals(other.field))
-            return false;
+        } else {
+            if (!field.equals(other.field)) {
+                return false;
+            }
         }
         if (source == null) {
             return other.source == null;
-        } else  {
+        } else {
             return source.equals(other.source);
         }
     }
@@ -425,8 +400,8 @@ public class FieldReference extends VariableReferenceImpl {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReferenceImpl#loadBytecode(org.objectweb.asm.commons.GeneratorAdapter, java.util.Map)
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void loadBytecode(GeneratorAdapter mg, Map<Integer, Integer> locals) {
@@ -442,8 +417,8 @@ public class FieldReference extends VariableReferenceImpl {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReferenceImpl#storeBytecode(org.objectweb.asm.commons.GeneratorAdapter, java.util.Map)
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void storeBytecode(GeneratorAdapter mg, Map<Integer, Integer> locals) {
@@ -459,10 +434,6 @@ public class FieldReference extends VariableReferenceImpl {
                     org.objectweb.asm.Type.getType(getVariableClass()));
         }
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#changeClassLoader(java.lang.ClassLoader)
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/variable/NullReference.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/NullReference.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import org.evosuite.testcase.TestCase;
@@ -33,7 +34,7 @@ public class NullReference extends VariableReferenceImpl {
     private static final long serialVersionUID = -6172885297590386463L;
 
     /**
-     * <p>Constructor for NullReference.</p>
+     * Constructor for NullReference.
      *
      * @param type     a {@link java.lang.reflect.Type} object.
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.

--- a/client/src/main/java/org/evosuite/testcase/variable/VariableReference.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/VariableReference.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import org.evosuite.testcase.TestCase;
@@ -33,8 +34,7 @@ import java.util.Map;
 /**
  * This class represents a variable in a test case.
  *
- * <p>
- * TODO: Store generic types in this variable - we know at creation what it is
+ * <p>TODO: Store generic types in this variable - we know at creation what it is
  * (from method calls).
  *
  * @author Gordon Fraser
@@ -103,36 +103,28 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     String getClassName();
 
     /**
-     * <p>
-     * getComponentName
-     * </p>
+     * getComponentName.
      *
      * @return a {@link java.lang.String} object.
      */
     String getComponentName();
 
     /**
-     * <p>
-     * getComponentType
-     * </p>
+     * getComponentType.
      *
      * @return a {@link java.lang.reflect.Type} object.
      */
     Type getComponentType();
 
     /**
-     * <p>
-     * getGenericClass
-     * </p>
+     * getGenericClass.
      *
      * @return a {@link GenericClassImpl} object.
      */
     GenericClass<?> getGenericClass();
 
     /**
-     * <p>
-     * getTestCase
-     * </p>
+     * getTestCase.
      *
      * @return a {@link org.evosuite.testcase.TestCase} object.
      */
@@ -195,7 +187,8 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     boolean isWrapperType();
 
     /**
-     * Return true if we can validly access this variable. This might not be the case for a field reference if the owner class is not accessible.
+     * Return true if we can validly access this variable. This might not be the case for a field reference
+     * if the owner class is not accessible.
      *
      * @return .
      */
@@ -266,15 +259,12 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
      *
      * @param scope The scope of the test case execution
      * @return a {@link java.lang.Object} object.
-     * @throws org.evosuite.testcase.execution.CodeUnderTestException if code from the class under test throws an exception. (E.g.
-     *                                                                the static init of a field)
+     * @throws CodeUnderTestException if code from the SUT throws an exception. (E.g. the static init of a field)
      */
     Object getObject(Scope scope) throws CodeUnderTestException;
 
     /**
-     * <p>
-     * getOriginalCode
-     * </p>
+     * getOriginalCode.
      *
      * @return the code this variable reference stems from or null if it was
      * generated.
@@ -286,8 +276,7 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
      *
      * @param scope The scope of the test case execution
      * @param value The value to be assigned
-     * @throws org.evosuite.testcase.execution.CodeUnderTestException if code from the class under test throws an exception. (E.g.
-     *                                                                the static init of a field)
+     * @throws CodeUnderTestException if code from the SUT throws an exception. (E.g. the static init of a field)
      */
     void setObject(Scope scope, Object value) throws CodeUnderTestException;
 
@@ -302,8 +291,7 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return string representation of the variable
+     * <p>Return string representation of the variable
      */
     @Override
     String toString();
@@ -316,27 +304,21 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     String getName();
 
     /**
-     * <p>
-     * getAdditionalVariableReference
-     * </p>
+     * getAdditionalVariableReference.
      *
      * @return a {@link VariableReference} object.
      */
     VariableReference getAdditionalVariableReference();
 
     /**
-     * <p>
-     * setAdditionalVariableReference
-     * </p>
+     * setAdditionalVariableReference.
      *
      * @param var a {@link VariableReference} object.
      */
     void setAdditionalVariableReference(VariableReference var);
 
     /**
-     * <p>
-     * replaceAdditionalVariableReference
-     * </p>
+     * replaceAdditionalVariableReference.
      *
      * @param var1 a {@link VariableReference} object.
      * @param var2 a {@link VariableReference} object.
@@ -345,9 +327,7 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
                                             VariableReference var2);
 
     /**
-     * <p>
-     * loadBytecode
-     * </p>
+     * loadBytecode.
      *
      * @param mg     a {@link org.objectweb.asm.commons.GeneratorAdapter} object.
      * @param locals a {@link java.util.Map} object.
@@ -355,9 +335,7 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     void loadBytecode(GeneratorAdapter mg, Map<Integer, Integer> locals);
 
     /**
-     * <p>
-     * storeBytecode
-     * </p>
+     * storeBytecode.
      *
      * @param mg     a {@link org.objectweb.asm.commons.GeneratorAdapter} object.
      * @param locals a {@link java.util.Map} object.
@@ -365,27 +343,21 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     void storeBytecode(GeneratorAdapter mg, Map<Integer, Integer> locals);
 
     /**
-     * <p>
-     * changeClassLoader
-     * </p>
+     * changeClassLoader.
      *
      * @param loader a {@link java.lang.ClassLoader} object.
      */
     void changeClassLoader(ClassLoader loader);
 
     /**
-     * <p>
-     * getDefaultValue
-     * </p>
+     * getDefaultValue.
      *
      * @return a {@link java.lang.Object} object.
      */
     Object getDefaultValue();
 
     /**
-     * <p>
-     * getDefaultValueString
-     * </p>
+     * getDefaultValueString.
      *
      * @return a {@link java.lang.String} object.
      */
@@ -404,9 +376,7 @@ public interface VariableReference extends Comparable<VariableReference>, Serial
     int compareTo(VariableReference other);
 
     /**
-     * <p>
-     * same
-     * </p>
+     * same.
      *
      * @param r a {@link VariableReference} object.
      * @return a boolean.

--- a/client/src/main/java/org/evosuite/testcase/variable/VariableReferenceImpl.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/VariableReferenceImpl.java
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.evosuite.testcase.variable;
 
 import org.evosuite.testcase.TestCase;
@@ -68,9 +69,7 @@ public class VariableReferenceImpl implements VariableReference {
     }
 
     /**
-     * <p>
      * Constructor for VariableReferenceImpl.
-     * </p>
      *
      * @param testCase a {@link org.evosuite.testcase.TestCase} object.
      * @param type     a {@link java.lang.reflect.Type} object.
@@ -82,12 +81,10 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * The position of the statement, defining this VariableReference, in the
+     * <p>The position of the statement, defining this VariableReference, in the
      * testcase.
      *
-     * <p>
-     * TODO: Notify change listener also when return value changes
+     * <p>TODO: Notify change listener also when return value changes
      */
     @Override
     public synchronized int getStPosition() {
@@ -109,7 +106,8 @@ public class VariableReferenceImpl implements VariableReference {
                 msg.append("failed to find type ").append(this.type.getTypeName()).append("\n");
 
                 throw new AssertionError(
-                        msg + "A VariableReference's position is only defined if the VariableReference is defined by a statement in the testCase");
+                        msg + "A VariableReference's position is only defined if "
+                                + "the VariableReference is defined by a statement in the testCase");
             }
         }
         return stPosition;
@@ -123,8 +121,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference clone() {
@@ -135,8 +132,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Create a copy of the current variable
+     * <p>Create a copy of the current variable
      */
     @Override
     public VariableReference clone(TestCase newTestCase) {
@@ -154,8 +150,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return simple class name
+     * <p>Return simple class name
      */
     @Override
     public String getSimpleClassName() {
@@ -171,8 +166,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return class name
+     * <p>Return class name
      */
     @Override
     public String getClassName() {
@@ -198,16 +192,15 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if variable is an enumeration
+     * <p>Return true if variable is an enumeration
      */
     @Override
     public boolean isEnum() {
         return type.isEnum();
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#isArray()
+    /**
+     * {@inheritDoc}
      */
     @Override
     public boolean isArray() {
@@ -227,8 +220,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if variable is a primitive type
+     * <p>Return true if variable is a primitive type
      */
     @Override
     public boolean isPrimitive() {
@@ -238,8 +230,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if variable is void
+     * <p>Return true if variable is void
      */
     @Override
     public boolean isVoid() {
@@ -249,8 +240,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if variable is a string
+     * <p>Return true if variable is a string
      */
     @Override
     public boolean isString() {
@@ -260,8 +250,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if type of variable is a primitive wrapper
+     * <p>Return true if type of variable is a primitive wrapper
      */
     @Override
     public boolean isWrapperType() {
@@ -276,8 +265,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if other type can be assigned to this variable
+     * <p>Return true if other type can be assigned to this variable
      */
     @Override
     public boolean isAssignableFrom(Type other) {
@@ -287,8 +275,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if this variable can by assigned to a variable of other type
+     * <p>Return true if this variable can by assigned to a variable of other type
      */
     @Override
     public boolean isAssignableTo(Type other) {
@@ -298,8 +285,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if other type can be assigned to this variable
+     * <p>Return true if other type can be assigned to this variable
      */
     @Override
     public boolean isAssignableFrom(VariableReference other) {
@@ -309,8 +295,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return true if this variable can by assigned to a variable of other type
+     * <p>Return true if this variable can by assigned to a variable of other type
      */
     @Override
     public boolean isAssignableTo(VariableReference other) {
@@ -320,8 +305,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return type of this variable
+     * <p>Return type of this variable
      */
     @Override
     public Type getType() {
@@ -331,8 +315,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Set type of this variable
+     * <p>Set type of this variable
      */
     @Override
     public void setType(Type type) {
@@ -342,8 +325,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return raw class of this variable
+     * <p>Return raw class of this variable
      */
     @Override
     public Class<?> getVariableClass() {
@@ -353,8 +335,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return raw class of this variable's component
+     * <p>Return raw class of this variable's component
      */
     @Override
     public Class<?> getComponentClass() {
@@ -364,8 +345,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return the actual object represented by this variable for a given scope
+     * <p>Return the actual object represented by this variable for a given scope
      */
     @Override
     public Object getObject(Scope scope) throws CodeUnderTestException {
@@ -383,8 +363,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Set the actual object represented by this variable in a given scope
+     * <p>Set the actual object represented by this variable in a given scope
      */
     @Override
     public void setObject(Scope scope, Object value) throws CodeUnderTestException {
@@ -409,8 +388,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return string representation of the variable
+     * <p>Return string representation of the variable
      */
     @Override
     public String toString() {
@@ -424,8 +402,7 @@ public class VariableReferenceImpl implements VariableReference {
     /**
      * {@inheritDoc}
      *
-     * <p>
-     * Return name for source code representation
+     * <p>Return name for source code representation
      */
     @Override
     public String getName() {
@@ -441,8 +418,7 @@ public class VariableReferenceImpl implements VariableReference {
         logger.debug("Loading variable in bytecode: " + getStPosition());
         if (getStPosition() < 0) {
             mg.visitInsn(Opcodes.ACONST_NULL);
-        } else
-             {
+        } else {
             mg.loadLocal(locals.get(getStPosition()),
                     org.objectweb.asm.Type.getType(type.getRawClass()));
         }
@@ -471,29 +447,22 @@ public class VariableReferenceImpl implements VariableReference {
     public Object getDefaultValue() {
         if (isVoid()) {
             return null;
-        } else  {
-            if (type.isString())
+        }
+        if (type.isString()) {
             return "";
-        else if (isPrimitive()) {
+        }
+        if (isPrimitive()) {
             if (type.getRawClass().equals(float.class)) {
                 return 0.0F;
-            } else  {
-                if (type.getRawClass().equals(long.class))
+            } else if (type.getRawClass().equals(long.class)) {
                 return 0L;
-            else  {
-                if (type.getRawClass().equals(boolean.class))
+            } else if (type.getRawClass().equals(boolean.class)) {
                 return false;
-            else
-                 {
+            } else {
                 return 0;
             }
-            }
-            }
-        } else
-             {
-            return null;
         }
-        }
+        return null;
     }
 
     /**
@@ -503,36 +472,23 @@ public class VariableReferenceImpl implements VariableReference {
     public String getDefaultValueString() {
         if (isVoid()) {
             return "";
-        } else  {
-            if (type.isString())
+        }
+        if (type.isString()) {
             return "\"\"";
-        else if (isPrimitive()) {
+        }
+        if (isPrimitive()) {
             if (type.getRawClass().equals(float.class)) {
                 return "0.0F";
-            } else  {
-                if (type.getRawClass().equals(long.class))
+            } else if (type.getRawClass().equals(long.class)) {
                 return "0L";
-            else  {
-                if (type.getRawClass().equals(boolean.class))
+            } else if (type.getRawClass().equals(boolean.class)) {
                 return "false";
-            else
-                 {
+            } else {
                 return "0";
             }
-            }
-            }
-        } else
-             {
-            return "null";
         }
-        }
+        return "null";
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Comparable#compareTo(java.lang.Object)
-     */
 
     /**
      * {@inheritDoc}
@@ -566,10 +522,6 @@ public class VariableReferenceImpl implements VariableReference {
         return type;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#getAdditionalVariableReference()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -578,10 +530,6 @@ public class VariableReferenceImpl implements VariableReference {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#setAdditionalVariableReference(org.evosuite.testcase.VariableReference)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -589,10 +537,6 @@ public class VariableReferenceImpl implements VariableReference {
     public void setAdditionalVariableReference(VariableReference var) {
         // Do nothing by default
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#replaceAdditionalVariableReference(org.evosuite.testcase.VariableReference, org.evosuite.testcase.VariableReference)
-     */
 
     /**
      * {@inheritDoc}
@@ -604,10 +548,6 @@ public class VariableReferenceImpl implements VariableReference {
 
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#getDistance()
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -616,10 +556,6 @@ public class VariableReferenceImpl implements VariableReference {
         return distance;
     }
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#setDistance(int)
-     */
-
     /**
      * {@inheritDoc}
      */
@@ -627,10 +563,6 @@ public class VariableReferenceImpl implements VariableReference {
     public void setDistance(int distance) {
         this.distance = distance;
     }
-
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.VariableReference#changeClassLoader(java.lang.ClassLoader)
-     */
 
     /**
      * {@inheritDoc}

--- a/client/src/main/java/org/evosuite/testcase/variable/name/AbstractVariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/AbstractVariableNameStrategy.java
@@ -1,10 +1,31 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.evosuite.testcase.variable.name;
+
+import org.evosuite.testcase.variable.VariableReference;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import org.evosuite.testcase.variable.VariableReference;
 
 /**
  * The basic implementation for a {@link VariableNameStrategy}.
@@ -39,7 +60,6 @@ public abstract class AbstractVariableNameStrategy implements VariableNameStrate
      * Create a name to uniquely identify a variable.
      *
      * @param variable The variable to be named.
-     *
      * @return The name choosen for the variable.
      */
     public abstract String createNameForVariable(VariableReference variable);

--- a/client/src/main/java/org/evosuite/testcase/variable/name/HeuristicsVariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/HeuristicsVariableNameStrategy.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.evosuite.testcase.variable.name;
 
 import org.apache.commons.lang3.StringUtils;
@@ -9,7 +29,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy{
+/**
+ * Heuristics-based variable naming strategy.
+ *
+ * @author Afonso Oliveira
+ */
+public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy {
 
     protected final Map<String, Integer> nextIndices = new ConcurrentHashMap<>();
     /**
@@ -19,6 +44,7 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
     protected Map<VariableReference, String> argumentNames = new HashMap<>();
 
     private TypeBasedVariableNameStrategy typeBasedVariableNameStrategy = new TypeBasedVariableNameStrategy();
+
     @Override
     public String createNameForVariable(VariableReference variable) {
         String typeBasedName = typeBasedVariableNameStrategy.getPlainNameForVariable(variable);
@@ -29,8 +55,9 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
      * Returns the variable name + the corresponding index if and only if there is more than one repetition of the name,
      * otherwise, it returns the name without an index at last.
      *
-     * Mainly used for Heuristic Renaming Strategy.
+     * <p>Mainly used for Heuristic Renaming Strategy.
      *
+     * @param variableName a {@link java.lang.String} object.
      * @return String
      */
     private String getVariableWithIndexExcludingFirstAppearance(String variableName) {
@@ -43,14 +70,17 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
         }
         return variableName;
     }
+
     /**
      * Retrieve a suggested name based on method, argument and type information.
      *
-     * The followed order for prioritizing is:
+     * <p>The followed order for prioritizing is:
      * 1. Use argument suggestion, if not possible
      * 2. Use method suggestion + reductions, if not possible
      * 3. Use type suggestion, traditional naming.
      *
+     * @param var          a {@link org.evosuite.testcase.variable.VariableReference} object.
+     * @param variableName a {@link java.lang.String} object.
      * @return String
      */
     private String getPrioritizedName(final VariableReference var, String variableName) {
@@ -61,7 +91,7 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
         } else if (methodCode != null) {
             variableName = analyzeMethodName(methodCode);
         }
-        if(variableName.equals(var.getSimpleClassName())){
+        if (variableName.equals(var.getSimpleClassName())) {
             variableName = "_" + variableName;
         }
         return variableName;
@@ -71,14 +101,15 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
      * Returns the suggested method name controlling camel case and excluding some particles
      * of the method names.
      *
+     * @param methodCode a {@link java.lang.String} object.
      * @return String
      */
     private String analyzeMethodName(String methodCode) {
         String name = "";
         ArrayList<String> methodName = HeuristicsUtil.separateByCamelCase(methodCode);
-        if(methodCode.length() > 0){
-            if(HeuristicsUtil.containsAvoidableParticle(methodName.get(0)) && methodName.size() > 1){
-                name = StringUtils.join(methodName.subList(1,methodName.size()), "");
+        if (methodCode.length() > 0) {
+            if (HeuristicsUtil.containsAvoidableParticle(methodName.get(0)) && methodName.size() > 1) {
+                name = StringUtils.join(methodName.subList(1, methodName.size()), "");
                 final char[] auxCharArray = name.toCharArray();
                 auxCharArray[0] = Character.toLowerCase(auxCharArray[0]);
                 return new String(auxCharArray);
@@ -87,7 +118,10 @@ public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy
         return methodCode;
     }
 
-    public void addVariableInformation(Map<String, Map<VariableReference, String>> information){
+    /**
+     * {@inheritDoc}
+     */
+    public void addVariableInformation(Map<String, Map<VariableReference, String>> information) {
         methodNames = information.get("MethodNames");
         argumentNames = information.get("ArgumentNames");
     }

--- a/client/src/main/java/org/evosuite/testcase/variable/name/TypeBasedVariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/TypeBasedVariableNameStrategy.java
@@ -1,10 +1,31 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.evosuite.testcase.variable.name;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.CharUtils;
 import org.evosuite.testcase.variable.ArrayReference;
 import org.evosuite.testcase.variable.VariableReference;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A name strategy that is based on variable type.
@@ -23,7 +44,13 @@ public class TypeBasedVariableNameStrategy extends AbstractVariableNameStrategy 
         return getIndexIncludingFirstAppearance(variableName);
     }
 
-    public String getPlainNameForVariable(VariableReference var){
+    /**
+     * getPlainNameForVariable.
+     *
+     * @param var a {@link org.evosuite.testcase.variable.VariableReference} object.
+     * @return a {@link java.lang.String} object.
+     */
+    public String getPlainNameForVariable(VariableReference var) {
         String className = var.getSimpleClassName();
         String variableName;
         if (var instanceof ArrayReference) {
@@ -55,8 +82,9 @@ public class TypeBasedVariableNameStrategy extends AbstractVariableNameStrategy 
      * Returns the variable name + the number of repetitions counting from 0.
      * i.e. If the variable appears only once in the test, it is named as variable0.
      *
-     * Mainly used for Type-Based Renaming Strategy (traditional naming in EvoSuite).
+     * <p>Mainly used for Type-Based Renaming Strategy (traditional naming in EvoSuite).
      *
+     * @param variableName a {@link java.lang.String} object.
      * @return String
      */
     private String getIndexIncludingFirstAppearance(String variableName) {
@@ -67,7 +95,11 @@ public class TypeBasedVariableNameStrategy extends AbstractVariableNameStrategy 
         nextIndices.put(variableName, index + 1);
         return variableName += index;
     }
-    public void addVariableInformation(Map<String, Map<VariableReference, String>> information){
+
+    /**
+     * {@inheritDoc}
+     */
+    public void addVariableInformation(Map<String, Map<VariableReference, String>> information) {
         //If needed any information about types
     }
 

--- a/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategy.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.evosuite.testcase.variable.name;
 
 import org.evosuite.testcase.variable.VariableReference;
@@ -10,7 +30,6 @@ import java.util.Optional;
  * The variable name strategy defines the logic behind how a name is generated.
  *
  * @author Afonso Oliveira
- *
  * @see TypeBasedVariableNameStrategy
  */
 public interface VariableNameStrategy {
@@ -19,7 +38,6 @@ public interface VariableNameStrategy {
      * Get the name that is used to identify a {@link VariableReference}.
      *
      * @param variable The variable for which the name should be generated.
-     *
      * @return The name to be used when referencing the variable.
      */
     String getNameForVariable(VariableReference variable);
@@ -28,7 +46,6 @@ public interface VariableNameStrategy {
      * Get the {@link VariableReference} from the variable name.
      *
      * @param variableName The name used to identify the variable.
-     *
      * @return The variable reference.
      */
     Optional<VariableReference> getVariableFromName(String variableName);
@@ -42,6 +59,8 @@ public interface VariableNameStrategy {
 
     /**
      * Allows to add information on dictionaries for variable naming.
+     *
+     * @param information a {@link java.util.Map} object.
      */
     void addVariableInformation(Map<String, Map<VariableReference, String>> information);
 

--- a/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategyFactory.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategyFactory.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.evosuite.testcase.variable.name;
 
 import org.evosuite.Properties;
@@ -5,8 +25,7 @@ import org.evosuite.Properties;
 /**
  * This class encapsulates the logic of creating a new naming strategy.
  *
- * <p>
- * With the use of method get we can create a new variable naming strategy
+ * <p>With the use of method get we can create a new variable naming strategy
  * using the default configuration or by providing the desired naming strategy.
  *
  * <pre>
@@ -16,12 +35,22 @@ import org.evosuite.Properties;
  * <pre>
  *     VariableNameStrategy namingStrategy = VariableNameStrategyFactory.get(Properties.VARIABLE_NAMING_STRATEGY);
  * </pre>
- * @author Afonso Oliveira
  *
+ * @author Afonso Oliveira
  * @see TypeBasedVariableNameStrategy
  */
 public class VariableNameStrategyFactory {
 
+    private VariableNameStrategyFactory() {
+        // Nothing to do here
+    }
+
+    /**
+     * Get the variable naming strategy.
+     *
+     * @param identifierNamingStrategy a {@link org.evosuite.Properties.VariableNamingStrategy} object.
+     * @return a {@link org.evosuite.testcase.variable.name.VariableNameStrategy} object.
+     */
     public static VariableNameStrategy get(Properties.VariableNamingStrategy identifierNamingStrategy) {
         if (Properties.VariableNamingStrategy.TYPE_BASED.equals(identifierNamingStrategy)) {
             return new TypeBasedVariableNameStrategy();
@@ -29,15 +58,15 @@ public class VariableNameStrategyFactory {
         if (Properties.VariableNamingStrategy.HEURISTICS_BASED.equals(identifierNamingStrategy)) {
             return new HeuristicsVariableNameStrategy();
         } else {
-            throw new IllegalArgumentException(String.format("Unknown variable naming strategy: %s", identifierNamingStrategy));
+            throw new IllegalArgumentException(String.format("Unknown variable naming strategy: %s",
+                    identifierNamingStrategy));
         }
     }
 
     /**
      * Get the currently selected variable naming strategy.
      *
-     * <p>
-     * The select strategy is defined in {@link Properties#VARIABLE_NAMING_STRATEGY}.
+     * <p>The select strategy is defined in {@link Properties#VARIABLE_NAMING_STRATEGY}.
      *
      * @return The selected strategy.
      */
@@ -45,15 +74,13 @@ public class VariableNameStrategyFactory {
         return get(Properties.VARIABLE_NAMING_STRATEGY);
     }
 
-    private VariableNameStrategyFactory() {
-        // Nothing to do here
-    }
-
-    public static boolean gatherInformation(){
-        if (Properties.VariableNamingStrategy.HEURISTICS_BASED.equals(Properties.VARIABLE_NAMING_STRATEGY)) {
-            return true;
-        }
-        return false;
+    /**
+     * gatherInformation.
+     *
+     * @return a boolean.
+     */
+    public static boolean gatherInformation() {
+        return Properties.VariableNamingStrategy.HEURISTICS_BASED.equals(Properties.VARIABLE_NAMING_STRATEGY);
     }
 
 }


### PR DESCRIPTION
Applied Checkstyle fixes to the `org.evosuite.testcase.variable` package.

Changes include:
- Fixed indentation and whitespace issues.
- Refactored nested if-else blocks in `ArrayIndex`, `VariableReferenceImpl`, and `FieldReference`.
- Added missing Javadoc and fixed Javadoc formatting.
- Renamed parameter `array_length` to `arrayLength` in `ArrayReference`.
- Removed redundant comments.
- Added license headers where missing.
- Grouped imports correctly.

Verified with Checkstyle and ran relevant tests.

---
*PR created automatically by Jules for task [1661642052157111650](https://jules.google.com/task/1661642052157111650) started by @gofraser*